### PR TITLE
Collision

### DIFF
--- a/Editor/Blocks/CalculateForces.cs
+++ b/Editor/Blocks/CalculateForces.cs
@@ -137,7 +137,7 @@ for (uint neighborIndex = 0; neighborIndex < nbMax; ++neighborIndex)
 
 #ifdef FLUVIO_SURFACE_TENSION_ENABLED
     // Surface tension term (external)
-    if (normal.w > FLUVIO_PI && normal.w < FLUVIO_PI * 2.0f)
+    if (normal.w > FLUVIO_PI && normal.w < FLUVIO_TAU)
     {{
         scalar = neighborMass
             * Poly6CalculateLaplacian(dist, solverData_KernelFactors.x, solverData_KernelSize.y)

--- a/Editor/Blocks/Collision.meta
+++ b/Editor/Blocks/Collision.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 64934ffb6508ffb4ba63dd77b1a8fa91
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Blocks/Collision/CollisionAABox.cs
+++ b/Editor/Blocks/Collision/CollisionAABox.cs
@@ -9,7 +9,7 @@ namespace Thinksquirrel.FluvioFX.Editor.Blocks
     class CollisionAABox : UnityEditor.VFX.Block.CollisionAABox
     {
         [VFXSetting]
-        public bool EnableDensity = true;
+        public bool EnableFluidForces = true;
 
         public override string name
         {
@@ -24,14 +24,16 @@ namespace Thinksquirrel.FluvioFX.Editor.Blocks
         public override IEnumerable<VFXNamedExpression> parameters =>
             FluvioFXCollisionUtility.GetParameters(this, base.parameters);
         protected override IEnumerable<VFXPropertyWithValue> inputProperties =>
-            FluvioFXCollisionUtility.GetInputProperties(base.inputProperties, EnableDensity);
+            FluvioFXCollisionUtility.GetInputProperties(base.inputProperties, EnableFluidForces);
         public override IEnumerable<VFXAttributeInfo> attributes =>
             FluvioFXCollisionUtility.GetAttributes(base.attributes);
 
         public override string source =>
             FluvioFXCollisionUtility.GetCollisionSource(
+                this,
+                EnableFluidForces,
                 base.source,
                 collisionResponseSource,
-                EnableDensity);
+                roughSurfaceSource);
     }
 }

--- a/Editor/Blocks/Collision/CollisionAABox.cs
+++ b/Editor/Blocks/Collision/CollisionAABox.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using System.Linq;
+using UnityEditor.VFX;
+using UnityEngine;
+
+namespace Thinksquirrel.FluvioFX.Editor.Blocks
+{
+    [VFXInfo(category = "FluvioFX/Collision")]
+    class CollisionAABox : UnityEditor.VFX.Block.CollisionAABox
+    {
+        [VFXSetting]
+        public bool EnableDensity = true;
+
+        public override string name
+        {
+            get
+            {
+                return "Fluid Collider (AABox)";
+            }
+        }
+
+        public override IEnumerable<VFXNamedExpression> parameters =>
+            FluvioFXCollisionUtility.GetParameters(this, base.parameters);
+        protected override IEnumerable<VFXPropertyWithValue> inputProperties =>
+            FluvioFXCollisionUtility.GetInputProperties(base.inputProperties, EnableDensity);
+        public override IEnumerable<VFXAttributeInfo> attributes =>
+            FluvioFXCollisionUtility.GetAttributes(base.attributes);
+
+        public override string source =>
+            FluvioFXCollisionUtility.GetCollisionSource(
+                base.source,
+                collisionResponseSource,
+                EnableDensity);
+    }
+}

--- a/Editor/Blocks/Collision/CollisionAABox.cs
+++ b/Editor/Blocks/Collision/CollisionAABox.cs
@@ -19,6 +19,8 @@ namespace Thinksquirrel.FluvioFX.Editor.Blocks
             }
         }
 
+        public override IEnumerable<string> includes =>
+            FluvioFXCollisionUtility.GetIncludes(base.includes);
         public override IEnumerable<VFXNamedExpression> parameters =>
             FluvioFXCollisionUtility.GetParameters(this, base.parameters);
         protected override IEnumerable<VFXPropertyWithValue> inputProperties =>

--- a/Editor/Blocks/Collision/CollisionAABox.cs
+++ b/Editor/Blocks/Collision/CollisionAABox.cs
@@ -6,11 +6,8 @@ using UnityEngine;
 namespace Thinksquirrel.FluvioFX.Editor.Blocks
 {
     [VFXInfo(category = "FluvioFX/Collision")]
-    class CollisionAABox : UnityEditor.VFX.Block.CollisionAABox
+    class CollisionAABox : UnityEditor.VFX.Block.CollisionAABox, ICollisionSettings
     {
-        [VFXSetting]
-        public bool EnableFluidForces = true;
-
         public override string name
         {
             get
@@ -19,19 +16,33 @@ namespace Thinksquirrel.FluvioFX.Editor.Blocks
             }
         }
 
+        [VFXSetting]
+        public bool boundaryPressure = true;
+        [VFXSetting]
+        public bool boundaryViscosity = true;
+        [VFXSetting]
+        public bool repulsionForce = false;
+
+        public bool BoundaryPressure => boundaryPressure;
+
+        public bool BoundaryViscosity => boundaryViscosity;
+
+        public bool RepulsionForce => repulsionForce;
+
+        public bool RoughSurface => roughSurface;
+
         public override IEnumerable<string> includes =>
             FluvioFXCollisionUtility.GetIncludes(base.includes);
         public override IEnumerable<VFXNamedExpression> parameters =>
             FluvioFXCollisionUtility.GetParameters(this, base.parameters);
         protected override IEnumerable<VFXPropertyWithValue> inputProperties =>
-            FluvioFXCollisionUtility.GetInputProperties(base.inputProperties, EnableFluidForces);
+            FluvioFXCollisionUtility.GetInputProperties(this, base.inputProperties);
         public override IEnumerable<VFXAttributeInfo> attributes =>
             FluvioFXCollisionUtility.GetAttributes(base.attributes);
 
         public override string source =>
             FluvioFXCollisionUtility.GetCollisionSource(
                 this,
-                EnableFluidForces,
                 base.source,
                 collisionResponseSource,
                 roughSurfaceSource);

--- a/Editor/Blocks/Collision/CollisionAABox.cs.meta
+++ b/Editor/Blocks/Collision/CollisionAABox.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 642b05113afda054881d1d3fba9c743e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Blocks/Collision/CollisionCylinder.cs
+++ b/Editor/Blocks/Collision/CollisionCylinder.cs
@@ -9,7 +9,7 @@ namespace Thinksquirrel.FluvioFX.Editor.Blocks
     class CollisionCylinder : UnityEditor.VFX.Block.CollisionCylinder
     {
         [VFXSetting]
-        public bool EnableDensity = true;
+        public bool EnableFluidForces = true;
 
         public override string name
         {
@@ -24,14 +24,16 @@ namespace Thinksquirrel.FluvioFX.Editor.Blocks
         public override IEnumerable<VFXNamedExpression> parameters =>
             FluvioFXCollisionUtility.GetParameters(this, base.parameters);
         protected override IEnumerable<VFXPropertyWithValue> inputProperties =>
-            FluvioFXCollisionUtility.GetInputProperties(base.inputProperties, EnableDensity);
+            FluvioFXCollisionUtility.GetInputProperties(base.inputProperties, EnableFluidForces);
         public override IEnumerable<VFXAttributeInfo> attributes =>
             FluvioFXCollisionUtility.GetAttributes(base.attributes);
 
         public override string source =>
             FluvioFXCollisionUtility.GetCollisionSource(
+                this,
+                EnableFluidForces,
                 base.source,
                 collisionResponseSource,
-                EnableDensity);
+                roughSurfaceSource);
     }
 }

--- a/Editor/Blocks/Collision/CollisionCylinder.cs
+++ b/Editor/Blocks/Collision/CollisionCylinder.cs
@@ -6,11 +6,8 @@ using UnityEngine;
 namespace Thinksquirrel.FluvioFX.Editor.Blocks
 {
     [VFXInfo(category = "FluvioFX/Collision")]
-    class CollisionCylinder : UnityEditor.VFX.Block.CollisionCylinder
+    class CollisionCylinder : UnityEditor.VFX.Block.CollisionCylinder, ICollisionSettings
     {
-        [VFXSetting]
-        public bool EnableFluidForces = true;
-
         public override string name
         {
             get
@@ -19,19 +16,33 @@ namespace Thinksquirrel.FluvioFX.Editor.Blocks
             }
         }
 
+        [VFXSetting]
+        public bool boundaryPressure = true;
+        [VFXSetting]
+        public bool boundaryViscosity = true;
+        [VFXSetting]
+        public bool repulsionForce = false;
+
+        public bool BoundaryPressure => boundaryPressure;
+
+        public bool BoundaryViscosity => boundaryViscosity;
+
+        public bool RepulsionForce => repulsionForce;
+
+        public bool RoughSurface => roughSurface;
+
         public override IEnumerable<string> includes =>
             FluvioFXCollisionUtility.GetIncludes(base.includes);
         public override IEnumerable<VFXNamedExpression> parameters =>
             FluvioFXCollisionUtility.GetParameters(this, base.parameters);
         protected override IEnumerable<VFXPropertyWithValue> inputProperties =>
-            FluvioFXCollisionUtility.GetInputProperties(base.inputProperties, EnableFluidForces);
+            FluvioFXCollisionUtility.GetInputProperties(this, base.inputProperties);
         public override IEnumerable<VFXAttributeInfo> attributes =>
             FluvioFXCollisionUtility.GetAttributes(base.attributes);
 
         public override string source =>
             FluvioFXCollisionUtility.GetCollisionSource(
                 this,
-                EnableFluidForces,
                 base.source,
                 collisionResponseSource,
                 roughSurfaceSource);

--- a/Editor/Blocks/Collision/CollisionCylinder.cs
+++ b/Editor/Blocks/Collision/CollisionCylinder.cs
@@ -19,6 +19,8 @@ namespace Thinksquirrel.FluvioFX.Editor.Blocks
             }
         }
 
+        public override IEnumerable<string> includes =>
+            FluvioFXCollisionUtility.GetIncludes(base.includes);
         public override IEnumerable<VFXNamedExpression> parameters =>
             FluvioFXCollisionUtility.GetParameters(this, base.parameters);
         protected override IEnumerable<VFXPropertyWithValue> inputProperties =>

--- a/Editor/Blocks/Collision/CollisionCylinder.cs
+++ b/Editor/Blocks/Collision/CollisionCylinder.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using System.Linq;
+using UnityEditor.VFX;
+using UnityEngine;
+
+namespace Thinksquirrel.FluvioFX.Editor.Blocks
+{
+    [VFXInfo(category = "FluvioFX/Collision")]
+    class CollisionCylinder : UnityEditor.VFX.Block.CollisionCylinder
+    {
+        [VFXSetting]
+        public bool EnableDensity = true;
+
+        public override string name
+        {
+            get
+            {
+                return "Fluid Collider (Cylinder)";
+            }
+        }
+
+        public override IEnumerable<VFXNamedExpression> parameters =>
+            FluvioFXCollisionUtility.GetParameters(this, base.parameters);
+        protected override IEnumerable<VFXPropertyWithValue> inputProperties =>
+            FluvioFXCollisionUtility.GetInputProperties(base.inputProperties, EnableDensity);
+        public override IEnumerable<VFXAttributeInfo> attributes =>
+            FluvioFXCollisionUtility.GetAttributes(base.attributes);
+
+        public override string source =>
+            FluvioFXCollisionUtility.GetCollisionSource(
+                base.source,
+                collisionResponseSource,
+                EnableDensity);
+    }
+}

--- a/Editor/Blocks/Collision/CollisionCylinder.cs.meta
+++ b/Editor/Blocks/Collision/CollisionCylinder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5a7b68048c5f30b4498eb68deed166be
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Blocks/Collision/CollisionDepth.cs
+++ b/Editor/Blocks/Collision/CollisionDepth.cs
@@ -9,7 +9,7 @@ namespace Thinksquirrel.FluvioFX.Editor.Blocks
     class CollisionDepth : UnityEditor.VFX.Block.CollisionDepth
     {
         [VFXSetting]
-        public bool EnableDensity = true;
+        public bool EnableFluidForces = true;
 
         public override string name
         {
@@ -24,14 +24,16 @@ namespace Thinksquirrel.FluvioFX.Editor.Blocks
         public override IEnumerable<VFXNamedExpression> parameters =>
             FluvioFXCollisionUtility.GetParameters(this, base.parameters);
         protected override IEnumerable<VFXPropertyWithValue> inputProperties =>
-            FluvioFXCollisionUtility.GetInputProperties(base.inputProperties, EnableDensity);
+            FluvioFXCollisionUtility.GetInputProperties(base.inputProperties, EnableFluidForces);
         public override IEnumerable<VFXAttributeInfo> attributes =>
             FluvioFXCollisionUtility.GetAttributes(base.attributes);
 
         public override string source =>
             FluvioFXCollisionUtility.GetCollisionSource(
+                this,
+                EnableFluidForces,
                 base.source,
                 collisionResponseSource,
-                EnableDensity);
+                roughSurfaceSource);
     }
 }

--- a/Editor/Blocks/Collision/CollisionDepth.cs
+++ b/Editor/Blocks/Collision/CollisionDepth.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using System.Linq;
+using UnityEditor.VFX;
+using UnityEngine;
+
+namespace Thinksquirrel.FluvioFX.Editor.Blocks
+{
+    [VFXInfo(category = "FluvioFX/Collision")]
+    class CollisionDepth : UnityEditor.VFX.Block.CollisionDepth
+    {
+        [VFXSetting]
+        public bool EnableDensity = true;
+
+        public override string name
+        {
+            get
+            {
+                return "Fluid Collider (Depth)";
+            }
+        }
+
+        public override IEnumerable<VFXNamedExpression> parameters =>
+            FluvioFXCollisionUtility.GetParameters(this, base.parameters);
+        protected override IEnumerable<VFXPropertyWithValue> inputProperties =>
+            FluvioFXCollisionUtility.GetInputProperties(base.inputProperties, EnableDensity);
+        public override IEnumerable<VFXAttributeInfo> attributes =>
+            FluvioFXCollisionUtility.GetAttributes(base.attributes);
+
+        public override string source =>
+            FluvioFXCollisionUtility.GetCollisionSource(
+                base.source,
+                collisionResponseSource,
+                EnableDensity);
+    }
+}

--- a/Editor/Blocks/Collision/CollisionDepth.cs
+++ b/Editor/Blocks/Collision/CollisionDepth.cs
@@ -19,6 +19,8 @@ namespace Thinksquirrel.FluvioFX.Editor.Blocks
             }
         }
 
+        public override IEnumerable<string> includes =>
+            FluvioFXCollisionUtility.GetIncludes(base.includes);
         public override IEnumerable<VFXNamedExpression> parameters =>
             FluvioFXCollisionUtility.GetParameters(this, base.parameters);
         protected override IEnumerable<VFXPropertyWithValue> inputProperties =>

--- a/Editor/Blocks/Collision/CollisionDepth.cs
+++ b/Editor/Blocks/Collision/CollisionDepth.cs
@@ -6,11 +6,8 @@ using UnityEngine;
 namespace Thinksquirrel.FluvioFX.Editor.Blocks
 {
     [VFXInfo(category = "FluvioFX/Collision")]
-    class CollisionDepth : UnityEditor.VFX.Block.CollisionDepth
+    class CollisionDepth : UnityEditor.VFX.Block.CollisionDepth, ICollisionSettings
     {
-        [VFXSetting]
-        public bool EnableFluidForces = true;
-
         public override string name
         {
             get
@@ -19,19 +16,33 @@ namespace Thinksquirrel.FluvioFX.Editor.Blocks
             }
         }
 
+        [VFXSetting]
+        public bool boundaryPressure = true;
+        [VFXSetting]
+        public bool boundaryViscosity = true;
+        [VFXSetting]
+        public bool repulsionForce = false;
+
+        public bool BoundaryPressure => boundaryPressure;
+
+        public bool BoundaryViscosity => boundaryViscosity;
+
+        public bool RepulsionForce => repulsionForce;
+
+        public bool RoughSurface => roughSurface;
+
         public override IEnumerable<string> includes =>
             FluvioFXCollisionUtility.GetIncludes(base.includes);
         public override IEnumerable<VFXNamedExpression> parameters =>
             FluvioFXCollisionUtility.GetParameters(this, base.parameters);
         protected override IEnumerable<VFXPropertyWithValue> inputProperties =>
-            FluvioFXCollisionUtility.GetInputProperties(base.inputProperties, EnableFluidForces);
+            FluvioFXCollisionUtility.GetInputProperties(this, base.inputProperties);
         public override IEnumerable<VFXAttributeInfo> attributes =>
             FluvioFXCollisionUtility.GetAttributes(base.attributes);
 
         public override string source =>
             FluvioFXCollisionUtility.GetCollisionSource(
                 this,
-                EnableFluidForces,
                 base.source,
                 collisionResponseSource,
                 roughSurfaceSource);

--- a/Editor/Blocks/Collision/CollisionDepth.cs.meta
+++ b/Editor/Blocks/Collision/CollisionDepth.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d5f1a9810f92f3d4bbfbec757a06327d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Blocks/Collision/CollisionPlane.cs
+++ b/Editor/Blocks/Collision/CollisionPlane.cs
@@ -6,11 +6,8 @@ using UnityEngine;
 namespace Thinksquirrel.FluvioFX.Editor.Blocks
 {
     [VFXInfo(category = "FluvioFX/Collision")]
-    class CollisionPlane : UnityEditor.VFX.Block.CollisionPlane
+    class CollisionPlane : UnityEditor.VFX.Block.CollisionPlane, ICollisionSettings
     {
-        [VFXSetting]
-        public bool EnableFluidForces = true;
-
         public override string name
         {
             get
@@ -19,19 +16,33 @@ namespace Thinksquirrel.FluvioFX.Editor.Blocks
             }
         }
 
+        [VFXSetting]
+        public bool boundaryPressure = true;
+        [VFXSetting]
+        public bool boundaryViscosity = true;
+        [VFXSetting]
+        public bool repulsionForce = false;
+
+        public bool BoundaryPressure => boundaryPressure;
+
+        public bool BoundaryViscosity => boundaryViscosity;
+
+        public bool RepulsionForce => repulsionForce;
+
+        public bool RoughSurface => roughSurface;
+
         public override IEnumerable<string> includes =>
             FluvioFXCollisionUtility.GetIncludes(base.includes);
         public override IEnumerable<VFXNamedExpression> parameters =>
             FluvioFXCollisionUtility.GetParameters(this, base.parameters);
         protected override IEnumerable<VFXPropertyWithValue> inputProperties =>
-            FluvioFXCollisionUtility.GetInputProperties(base.inputProperties, EnableFluidForces);
+            FluvioFXCollisionUtility.GetInputProperties(this, base.inputProperties);
         public override IEnumerable<VFXAttributeInfo> attributes =>
             FluvioFXCollisionUtility.GetAttributes(base.attributes);
 
         public override string source =>
             FluvioFXCollisionUtility.GetCollisionSource(
                 this,
-                EnableFluidForces,
                 base.source,
                 collisionResponseSource,
                 roughSurfaceSource);

--- a/Editor/Blocks/Collision/CollisionPlane.cs
+++ b/Editor/Blocks/Collision/CollisionPlane.cs
@@ -19,6 +19,8 @@ namespace Thinksquirrel.FluvioFX.Editor.Blocks
             }
         }
 
+        public override IEnumerable<string> includes =>
+            FluvioFXCollisionUtility.GetIncludes(base.includes);
         public override IEnumerable<VFXNamedExpression> parameters =>
             FluvioFXCollisionUtility.GetParameters(this, base.parameters);
         protected override IEnumerable<VFXPropertyWithValue> inputProperties =>

--- a/Editor/Blocks/Collision/CollisionPlane.cs
+++ b/Editor/Blocks/Collision/CollisionPlane.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using System.Linq;
+using UnityEditor.VFX;
+using UnityEngine;
+
+namespace Thinksquirrel.FluvioFX.Editor.Blocks
+{
+    [VFXInfo(category = "FluvioFX/Collision")]
+    class CollisionPlane : UnityEditor.VFX.Block.CollisionPlane
+    {
+        [VFXSetting]
+        public bool EnableDensity = true;
+
+        public override string name
+        {
+            get
+            {
+                return "Fluid Collider (Plane)";
+            }
+        }
+
+        public override IEnumerable<VFXNamedExpression> parameters =>
+            FluvioFXCollisionUtility.GetParameters(this, base.parameters);
+        protected override IEnumerable<VFXPropertyWithValue> inputProperties =>
+            FluvioFXCollisionUtility.GetInputProperties(base.inputProperties, EnableDensity);
+        public override IEnumerable<VFXAttributeInfo> attributes =>
+            FluvioFXCollisionUtility.GetAttributes(base.attributes);
+
+        public override string source =>
+            FluvioFXCollisionUtility.GetCollisionSource(
+                base.source,
+                collisionResponseSource,
+                EnableDensity);
+    }
+}

--- a/Editor/Blocks/Collision/CollisionPlane.cs
+++ b/Editor/Blocks/Collision/CollisionPlane.cs
@@ -9,7 +9,7 @@ namespace Thinksquirrel.FluvioFX.Editor.Blocks
     class CollisionPlane : UnityEditor.VFX.Block.CollisionPlane
     {
         [VFXSetting]
-        public bool EnableDensity = true;
+        public bool EnableFluidForces = true;
 
         public override string name
         {
@@ -24,14 +24,16 @@ namespace Thinksquirrel.FluvioFX.Editor.Blocks
         public override IEnumerable<VFXNamedExpression> parameters =>
             FluvioFXCollisionUtility.GetParameters(this, base.parameters);
         protected override IEnumerable<VFXPropertyWithValue> inputProperties =>
-            FluvioFXCollisionUtility.GetInputProperties(base.inputProperties, EnableDensity);
+            FluvioFXCollisionUtility.GetInputProperties(base.inputProperties, EnableFluidForces);
         public override IEnumerable<VFXAttributeInfo> attributes =>
             FluvioFXCollisionUtility.GetAttributes(base.attributes);
 
         public override string source =>
             FluvioFXCollisionUtility.GetCollisionSource(
+                this,
+                EnableFluidForces,
                 base.source,
                 collisionResponseSource,
-                EnableDensity);
+                roughSurfaceSource);
     }
 }

--- a/Editor/Blocks/Collision/CollisionPlane.cs.meta
+++ b/Editor/Blocks/Collision/CollisionPlane.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 29e68ddc6593f8d4ab764ff657555d7a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Blocks/Collision/CollisionSDF.cs
+++ b/Editor/Blocks/Collision/CollisionSDF.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using System.Linq;
+using UnityEditor.VFX;
+using UnityEngine;
+
+namespace Thinksquirrel.FluvioFX.Editor.Blocks
+{
+    [VFXInfo(category = "FluvioFX/Collision")]
+    class CollisionSDF : UnityEditor.VFX.Block.CollisionSDF
+    {
+        [VFXSetting]
+        public bool EnableDensity = true;
+
+        public override string name
+        {
+            get
+            {
+                return "Fluid Collider (Signed Distance Field)";
+            }
+        }
+
+        public override IEnumerable<VFXNamedExpression> parameters =>
+            FluvioFXCollisionUtility.GetParameters(this, base.parameters);
+        protected override IEnumerable<VFXPropertyWithValue> inputProperties =>
+            FluvioFXCollisionUtility.GetInputProperties(base.inputProperties, EnableDensity);
+        public override IEnumerable<VFXAttributeInfo> attributes =>
+            FluvioFXCollisionUtility.GetAttributes(base.attributes);
+
+        public override string source =>
+            FluvioFXCollisionUtility.GetCollisionSource(
+                base.source,
+                collisionResponseSource,
+                EnableDensity);
+    }
+}

--- a/Editor/Blocks/Collision/CollisionSDF.cs
+++ b/Editor/Blocks/Collision/CollisionSDF.cs
@@ -6,11 +6,8 @@ using UnityEngine;
 namespace Thinksquirrel.FluvioFX.Editor.Blocks
 {
     [VFXInfo(category = "FluvioFX/Collision")]
-    class CollisionSDF : UnityEditor.VFX.Block.CollisionSDF
+    class CollisionSDF : UnityEditor.VFX.Block.CollisionSDF, ICollisionSettings
     {
-        [VFXSetting]
-        public bool EnableFluidForces = true;
-
         public override string name
         {
             get
@@ -19,19 +16,33 @@ namespace Thinksquirrel.FluvioFX.Editor.Blocks
             }
         }
 
+        [VFXSetting]
+        public bool boundaryPressure = true;
+        [VFXSetting]
+        public bool boundaryViscosity = true;
+        [VFXSetting]
+        public bool repulsionForce = false;
+
+        public bool BoundaryPressure => boundaryPressure;
+
+        public bool BoundaryViscosity => boundaryViscosity;
+
+        public bool RepulsionForce => repulsionForce;
+
+        public bool RoughSurface => roughSurface;
+
         public override IEnumerable<string> includes =>
             FluvioFXCollisionUtility.GetIncludes(base.includes);
         public override IEnumerable<VFXNamedExpression> parameters =>
             FluvioFXCollisionUtility.GetParameters(this, base.parameters);
         protected override IEnumerable<VFXPropertyWithValue> inputProperties =>
-            FluvioFXCollisionUtility.GetInputProperties(base.inputProperties, EnableFluidForces);
+            FluvioFXCollisionUtility.GetInputProperties(this, base.inputProperties);
         public override IEnumerable<VFXAttributeInfo> attributes =>
             FluvioFXCollisionUtility.GetAttributes(base.attributes);
 
         public override string source =>
             FluvioFXCollisionUtility.GetCollisionSource(
                 this,
-                EnableFluidForces,
                 base.source,
                 collisionResponseSource,
                 roughSurfaceSource);

--- a/Editor/Blocks/Collision/CollisionSDF.cs
+++ b/Editor/Blocks/Collision/CollisionSDF.cs
@@ -9,7 +9,7 @@ namespace Thinksquirrel.FluvioFX.Editor.Blocks
     class CollisionSDF : UnityEditor.VFX.Block.CollisionSDF
     {
         [VFXSetting]
-        public bool EnableDensity = true;
+        public bool EnableFluidForces = true;
 
         public override string name
         {
@@ -24,14 +24,16 @@ namespace Thinksquirrel.FluvioFX.Editor.Blocks
         public override IEnumerable<VFXNamedExpression> parameters =>
             FluvioFXCollisionUtility.GetParameters(this, base.parameters);
         protected override IEnumerable<VFXPropertyWithValue> inputProperties =>
-            FluvioFXCollisionUtility.GetInputProperties(base.inputProperties, EnableDensity);
+            FluvioFXCollisionUtility.GetInputProperties(base.inputProperties, EnableFluidForces);
         public override IEnumerable<VFXAttributeInfo> attributes =>
             FluvioFXCollisionUtility.GetAttributes(base.attributes);
 
         public override string source =>
             FluvioFXCollisionUtility.GetCollisionSource(
+                this,
+                EnableFluidForces,
                 base.source,
                 collisionResponseSource,
-                EnableDensity);
+                roughSurfaceSource);
     }
 }

--- a/Editor/Blocks/Collision/CollisionSDF.cs
+++ b/Editor/Blocks/Collision/CollisionSDF.cs
@@ -19,6 +19,8 @@ namespace Thinksquirrel.FluvioFX.Editor.Blocks
             }
         }
 
+        public override IEnumerable<string> includes =>
+            FluvioFXCollisionUtility.GetIncludes(base.includes);
         public override IEnumerable<VFXNamedExpression> parameters =>
             FluvioFXCollisionUtility.GetParameters(this, base.parameters);
         protected override IEnumerable<VFXPropertyWithValue> inputProperties =>

--- a/Editor/Blocks/Collision/CollisionSDF.cs.meta
+++ b/Editor/Blocks/Collision/CollisionSDF.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ee40510b6d7460c409487929cb5b9bed
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Blocks/Collision/CollisionSphere.cs
+++ b/Editor/Blocks/Collision/CollisionSphere.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using System.Linq;
+using UnityEditor.VFX;
+using UnityEngine;
+
+namespace Thinksquirrel.FluvioFX.Editor.Blocks
+{
+    [VFXInfo(category = "FluvioFX/Collision")]
+    class CollisionSphere : UnityEditor.VFX.Block.CollisionSphere
+    {
+        [VFXSetting]
+        public bool EnableDensity = true;
+
+        public override string name
+        {
+            get
+            {
+                return "Fluid Collider (Sphere)";
+            }
+        }
+
+        public override IEnumerable<VFXNamedExpression> parameters =>
+            FluvioFXCollisionUtility.GetParameters(this, base.parameters);
+        protected override IEnumerable<VFXPropertyWithValue> inputProperties =>
+            FluvioFXCollisionUtility.GetInputProperties(base.inputProperties, EnableDensity);
+        public override IEnumerable<VFXAttributeInfo> attributes =>
+            FluvioFXCollisionUtility.GetAttributes(base.attributes);
+
+        public override string source =>
+            FluvioFXCollisionUtility.GetCollisionSource(
+                base.source,
+                collisionResponseSource,
+                EnableDensity);
+    }
+}

--- a/Editor/Blocks/Collision/CollisionSphere.cs
+++ b/Editor/Blocks/Collision/CollisionSphere.cs
@@ -6,11 +6,8 @@ using UnityEngine;
 namespace Thinksquirrel.FluvioFX.Editor.Blocks
 {
     [VFXInfo(category = "FluvioFX/Collision")]
-    class CollisionSphere : UnityEditor.VFX.Block.CollisionSphere
+    class CollisionSphere : UnityEditor.VFX.Block.CollisionSphere, ICollisionSettings
     {
-        [VFXSetting]
-        public bool EnableFluidForces = true;
-
         public override string name
         {
             get
@@ -19,19 +16,33 @@ namespace Thinksquirrel.FluvioFX.Editor.Blocks
             }
         }
 
+        [VFXSetting]
+        public bool boundaryPressure = true;
+        [VFXSetting]
+        public bool boundaryViscosity = true;
+        [VFXSetting]
+        public bool repulsionForce = false;
+
+        public bool BoundaryPressure => boundaryPressure;
+
+        public bool BoundaryViscosity => boundaryViscosity;
+
+        public bool RepulsionForce => repulsionForce;
+
+        public bool RoughSurface => roughSurface;
+
         public override IEnumerable<string> includes =>
             FluvioFXCollisionUtility.GetIncludes(base.includes);
         public override IEnumerable<VFXNamedExpression> parameters =>
             FluvioFXCollisionUtility.GetParameters(this, base.parameters);
         protected override IEnumerable<VFXPropertyWithValue> inputProperties =>
-            FluvioFXCollisionUtility.GetInputProperties(base.inputProperties, EnableFluidForces);
+            FluvioFXCollisionUtility.GetInputProperties(this, base.inputProperties);
         public override IEnumerable<VFXAttributeInfo> attributes =>
             FluvioFXCollisionUtility.GetAttributes(base.attributes);
 
         public override string source =>
             FluvioFXCollisionUtility.GetCollisionSource(
                 this,
-                EnableFluidForces,
                 base.source,
                 collisionResponseSource,
                 roughSurfaceSource);

--- a/Editor/Blocks/Collision/CollisionSphere.cs
+++ b/Editor/Blocks/Collision/CollisionSphere.cs
@@ -19,6 +19,8 @@ namespace Thinksquirrel.FluvioFX.Editor.Blocks
             }
         }
 
+        public override IEnumerable<string> includes =>
+            FluvioFXCollisionUtility.GetIncludes(base.includes);
         public override IEnumerable<VFXNamedExpression> parameters =>
             FluvioFXCollisionUtility.GetParameters(this, base.parameters);
         protected override IEnumerable<VFXPropertyWithValue> inputProperties =>

--- a/Editor/Blocks/Collision/CollisionSphere.cs
+++ b/Editor/Blocks/Collision/CollisionSphere.cs
@@ -9,7 +9,7 @@ namespace Thinksquirrel.FluvioFX.Editor.Blocks
     class CollisionSphere : UnityEditor.VFX.Block.CollisionSphere
     {
         [VFXSetting]
-        public bool EnableDensity = true;
+        public bool EnableFluidForces = true;
 
         public override string name
         {
@@ -24,14 +24,16 @@ namespace Thinksquirrel.FluvioFX.Editor.Blocks
         public override IEnumerable<VFXNamedExpression> parameters =>
             FluvioFXCollisionUtility.GetParameters(this, base.parameters);
         protected override IEnumerable<VFXPropertyWithValue> inputProperties =>
-            FluvioFXCollisionUtility.GetInputProperties(base.inputProperties, EnableDensity);
+            FluvioFXCollisionUtility.GetInputProperties(base.inputProperties, EnableFluidForces);
         public override IEnumerable<VFXAttributeInfo> attributes =>
             FluvioFXCollisionUtility.GetAttributes(base.attributes);
 
         public override string source =>
             FluvioFXCollisionUtility.GetCollisionSource(
+                this,
+                EnableFluidForces,
                 base.source,
                 collisionResponseSource,
-                EnableDensity);
+                roughSurfaceSource);
     }
 }

--- a/Editor/Blocks/Collision/CollisionSphere.cs.meta
+++ b/Editor/Blocks/Collision/CollisionSphere.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7840bc596f18138438e445656d445f6a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Blocks/Collision/ICollisionSettings.cs
+++ b/Editor/Blocks/Collision/ICollisionSettings.cs
@@ -1,0 +1,22 @@
+namespace Thinksquirrel.FluvioFX.Editor.Blocks
+{
+    internal interface ICollisionSettings
+    {
+        bool BoundaryPressure
+        {
+            get;
+        }
+        bool BoundaryViscosity
+        {
+            get;
+        }
+        bool RepulsionForce
+        {
+            get;
+        }
+        bool RoughSurface
+        {
+            get;
+        }
+    }
+}

--- a/Editor/Blocks/Collision/ICollisionSettings.cs.meta
+++ b/Editor/Blocks/Collision/ICollisionSettings.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4baccf3295c5c9348a36d037b6c24803
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Blocks/DensityPressure.cs
+++ b/Editor/Blocks/DensityPressure.cs
@@ -11,32 +11,33 @@ namespace Thinksquirrel.FluvioFX.Editor.Blocks
 {
     [VFXInfo(category = "FluvioFX/Solver")]
     class DensityPressure : FluvioFXBlock
+    {
+        public override string name
         {
-            public override string name
+            get
             {
-                get
-                {
-                    return "Calculate Density and Pressure";
-                }
+                return "Calculate Density and Pressure";
             }
+        }
 
-            public override IEnumerable<VFXAttributeInfo> attributes
+        public override IEnumerable<VFXAttributeInfo> attributes
+        {
+            get
             {
-                get
+                yield return new VFXAttributeInfo(VFXAttribute.Position, VFXAttributeMode.Read);
+                if (hasLifetime)
                 {
-                    yield return new VFXAttributeInfo(VFXAttribute.Position, VFXAttributeMode.Read);
-                    if (hasLifetime)
-                    {
-                        yield return new VFXAttributeInfo(VFXAttribute.Alive, VFXAttributeMode.Read);
-                    }
-                    yield return new VFXAttributeInfo(VFXAttribute.Mass, VFXAttributeMode.Read);
-                    // yield return new VFXAttributeInfo(FluvioFXAttribute.NeighborCount, VFXAttributeMode.Read);
-                    yield return new VFXAttributeInfo(FluvioFXAttribute.DensityPressure, VFXAttributeMode.Write);
+                    yield return new VFXAttributeInfo(VFXAttribute.Alive, VFXAttributeMode.Read);
                 }
+                yield return new VFXAttributeInfo(VFXAttribute.Mass, VFXAttributeMode.Read);
+                // yield return new VFXAttributeInfo(FluvioFXAttribute.NeighborCount, VFXAttributeMode.Read);
+                yield return new VFXAttributeInfo(FluvioFXAttribute.DensityPressure, VFXAttributeMode.Write);
             }
-            public override string source => $@"
+        }
+        public override string source => $@"
 float3 dist;
 float density = 0;
+float pressure;
 #ifdef FLUVIO_INDEX_GRID
 uint neighborIndex;
 for (uint j = 0; j < neighborCount; ++j)
@@ -63,8 +64,9 @@ for (uint neighborIndex = 0; neighborIndex < nbMax; ++neighborIndex)
     density += neighborMass * Poly6Calculate(dist, solverData_KernelFactors.x, solverData_KernelSize.y);
 }}
 
-// Write to density/pressure texture
+// Write to density/pressure
 density = max(density, solverData_Fluid_MinimumDensity);
-densityPressure = float4(density, density, solverData_Fluid_GasConstant * (density - solverData_Fluid_Density), 0);";
+pressure = solverData_Fluid_GasConstant * (density - solverData_Fluid_Density);
+densityPressure = float4(density, density, pressure, pressure);";
     }
 }

--- a/Editor/Blocks/DensityPressure.cs
+++ b/Editor/Blocks/DensityPressure.cs
@@ -67,6 +67,6 @@ for (uint neighborIndex = 0; neighborIndex < nbMax; ++neighborIndex)
 // Write to density/pressure
 density = max(density, solverData_Fluid_MinimumDensity);
 pressure = solverData_Fluid_GasConstant * (density - solverData_Fluid_Density);
-densityPressure = float4(density, density, pressure, pressure);";
+densityPressure.xy = float2(density, pressure);";
     }
 }

--- a/Editor/Blocks/FluvioFXBlock.cs
+++ b/Editor/Blocks/FluvioFXBlock.cs
@@ -87,7 +87,7 @@ namespace Thinksquirrel.FluvioFX.Editor.Blocks
 
             if (initializeBlock)
             {
-                return initializeBlock.parameters.Where((exp) => !exp.name.Contains("_Tex"));
+                return initializeBlock.parameters.Where((expression) => !expression.name.Contains("_Tex"));
             }
             else
             {

--- a/Editor/Blocks/FluvioFXBlock.cs
+++ b/Editor/Blocks/FluvioFXBlock.cs
@@ -48,13 +48,79 @@ namespace Thinksquirrel.FluvioFX.Editor.Blocks
                 {
                     yield return p;
                 }
+
+                if (findSolverData)
+                {
+                    foreach (var exp in GetSolverDataExpressions(this))
+                    {
+                        yield return exp;
+                    }
+                }
+            }
+        }
+
+        protected virtual bool solverDataProperty => false;
+        protected virtual bool findSolverData => true;
+
+        protected override IEnumerable<VFXPropertyWithValue> inputProperties
+        {
+            get
+            {
+                if (solverDataProperty)
+                {
+                    return PropertiesFromType(typeof(SolverDataProperties));
+                }
+
+                return Enumerable.Empty<VFXPropertyWithValue>();
             }
         }
 
         protected bool hasLifetime => GetData().IsCurrentAttributeWritten(VFXAttribute.Alive);
 
+        internal static IEnumerable<VFXNamedExpression> GetSolverDataExpressions(VFXBlock block)
+        {
+            var context = block.GetParent();
+            var data = context.GetData();
+            var initializeBlock = data.owners
+                .SelectMany((c) => c.activeChildrenWithImplicit, (_, b) => b)
+                .FirstOrDefault((b) => b.GetType() == typeof(InitializeSolver));
+
+            if (initializeBlock)
+            {
+                return initializeBlock.parameters.Where((exp) => !exp.name.Contains("_Tex"));
+            }
+            else
+            {
+                var solverData = SolverData.defaultValue;
+                return solverData.defaultExpressions.Select((expression) =>
+                {
+                    expression.name = $"solverData_{expression.name}";
+                    return expression;
+                });
+            }
+        }
+
+        internal new static IEnumerable<VFXPropertyWithValue> PropertiesFromType(Type type)
+        {
+            if (type == null)
+            {
+                return Enumerable.Empty<VFXPropertyWithValue>();
+            }
+
+            var instance = System.Activator.CreateInstance(type);
+            return type.GetFields()
+                .Where(f => !f.IsStatic)
+                .Select(f =>
+                {
+                    var p = new VFXPropertyWithValue();
+                    p.property = new VFXProperty(f);
+                    p.value = f.GetValue(instance);
+                    return p;
+                });
+        }
+
 #pragma warning disable 649
-        public class InputProperties
+        public class SolverDataProperties
         {
             public SolverData solverData;
         }

--- a/Editor/Blocks/InitializeSolver.cs
+++ b/Editor/Blocks/InitializeSolver.cs
@@ -31,6 +31,9 @@ namespace Thinksquirrel.FluvioFX.Editor.Blocks
             }
         }
 
+        protected override bool solverDataProperty => true;
+        protected override bool findSolverData => false;
+
         public override string source => @"
 // Clear forces
 force = 0;

--- a/Editor/Blocks/InitializeSolver.cs
+++ b/Editor/Blocks/InitializeSolver.cs
@@ -35,8 +35,14 @@ namespace Thinksquirrel.FluvioFX.Editor.Blocks
         protected override bool findSolverData => false;
 
         public override string source => @"
+// Set old position
+oldPosition = position;
+
 // Clear forces
 force = 0;
+
+// Set mass
+mass = solverData_Fluid_ParticleMass;
 
 #ifdef FLUVIO_INDEX_GRID
 // Clear grid index
@@ -44,13 +50,6 @@ gridIndex = 0;
 
 // Clear neighbor count
 neighborCount = 0;
-
-// Set mass
-mass = solverData_Fluid_ParticleMass;
-
-// Set old position
-oldPosition = position;
-
 #endif";
     }
 }

--- a/Editor/Blocks/IntegrateParticles.cs
+++ b/Editor/Blocks/IntegrateParticles.cs
@@ -25,13 +25,13 @@ namespace Thinksquirrel.FluvioFX.Editor.Blocks
         }
 
         protected override IEnumerable<VFXPropertyWithValue> inputProperties =>
-            Integrator.Get(IntegrationMode).GetInputProperties();
+            Integrator.Get(IntegrationMode).GetInputProperties(base.inputProperties);
 
         public override IEnumerable<VFXNamedExpression> parameters
         {
             get
             {
-                foreach (var p in GetExpressionsFromSlots(this).Concat(Integrator.Get(IntegrationMode).GetParameters()))
+                foreach (var p in base.parameters.Concat(Integrator.Get(IntegrationMode).GetParameters()))
                 {
                     yield return p;
                 }

--- a/Editor/Blocks/NeighborSearch.cs
+++ b/Editor/Blocks/NeighborSearch.cs
@@ -74,7 +74,7 @@ for (uint candidate = 0; candidate < nbMax; ++candidate)
                         VFXAttribute.Position,
                         "candidatePosition",
                         "candidate")}
-                    dist = candidatePosition - position;
+                    dist = position - candidatePosition;
                     d = dot(dist, dist);
 
                     if (d < solverData_KernelSize.y)

--- a/Editor/Blocks/SurfaceNormal.cs
+++ b/Editor/Blocks/SurfaceNormal.cs
@@ -11,31 +11,31 @@ namespace Thinksquirrel.FluvioFX.Editor.Blocks
 {
     [VFXInfo(category = "FluvioFX/Solver")]
     class SurfaceNormal : FluvioFXBlock
+    {
+        public override string name
         {
-            public override string name
+            get
             {
-                get
-                {
-                    return "Calculate Surface Normal";
-                }
+                return "Calculate Surface Normal";
             }
+        }
 
-            public override IEnumerable<VFXAttributeInfo> attributes
+        public override IEnumerable<VFXAttributeInfo> attributes
+        {
+            get
             {
-                get
+                yield return new VFXAttributeInfo(VFXAttribute.Position, VFXAttributeMode.Read);
+                if (hasLifetime)
                 {
-                    yield return new VFXAttributeInfo(VFXAttribute.Position, VFXAttributeMode.Read);
-                    if (hasLifetime)
-                    {
-                        yield return new VFXAttributeInfo(VFXAttribute.Alive, VFXAttributeMode.Read);
-                    }
-                    yield return new VFXAttributeInfo(VFXAttribute.Mass, VFXAttributeMode.Read);
-
-                    // yield return new VFXAttributeInfo(FluvioFXAttribute.NeighborCount, VFXAttributeMode.Read);
-                    yield return new VFXAttributeInfo(FluvioFXAttribute.DensityPressure, VFXAttributeMode.Read);
-                    yield return new VFXAttributeInfo(FluvioFXAttribute.Normal, VFXAttributeMode.Write);
+                    yield return new VFXAttributeInfo(VFXAttribute.Alive, VFXAttributeMode.Read);
                 }
+                yield return new VFXAttributeInfo(VFXAttribute.Mass, VFXAttributeMode.Read);
+
+                // yield return new VFXAttributeInfo(FluvioFXAttribute.NeighborCount, VFXAttributeMode.Read);
+                yield return new VFXAttributeInfo(FluvioFXAttribute.DensityPressure, VFXAttributeMode.Read);
+                yield return new VFXAttributeInfo(FluvioFXAttribute.Normal, VFXAttributeMode.Write);
             }
+        }
 
             public override string source => $@"
 float3 dist;
@@ -64,10 +64,10 @@ for (uint neighborIndex = 0; neighborIndex < nbMax; ++neighborIndex)
     if (distLenSq >= solverData_KernelSize.y) continue;
 #endif
 
-    n += (neighborMass / neighborDensityPressure.y) * Poly6CalculateGradient(dist, solverData_KernelFactors.x, solverData_KernelSize.y);
+    n += (neighborMass / neighborDensityPressure.x) * Poly6CalculateGradient(dist, solverData_KernelFactors.x, solverData_KernelSize.y);
 }}
 
-// Write to normal texture
+// Write to normal
 float normalLen = length(n);
 normal = float4(n / normalLen, normalLen);";
     }

--- a/Editor/Integrators/Integrator.cs
+++ b/Editor/Integrators/Integrator.cs
@@ -29,7 +29,6 @@ namespace Thinksquirrel.FluvioFX.Editor.Integrators
             }
         }
 
-        protected virtual bool preIntegrate => false;
         protected virtual IEnumerable<Type> inputPropertyTypes => null;
         protected virtual IEnumerable<VFXNamedExpression> parameters => null;
         protected virtual IEnumerable<VFXAttributeInfo> attributes => null;
@@ -96,8 +95,6 @@ namespace Thinksquirrel.FluvioFX.Editor.Integrators
         public string GetSource()
         {
             return $@"
-{(preIntegrate ? "position += velocity * dt;" : "")}
-
 float invMass = 1.0f / mass;
 float3 acceleration = force * invMass;
 float3 v = dt * acceleration;

--- a/Editor/Integrators/Integrator.cs
+++ b/Editor/Integrators/Integrator.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using Thinksquirrel.FluvioFX.Editor.Blocks;
 using UnityEditor.VFX;
 using UnityEngine;
 using UnityEngine.Experimental.VFX;
@@ -36,35 +37,9 @@ namespace Thinksquirrel.FluvioFX.Editor.Integrators
         {
             get;
         }
-        protected static IEnumerable<VFXPropertyWithValue> PropertiesFromType(Type type)
-        {
-            if (type == null)
-            {
-                return Enumerable.Empty<VFXPropertyWithValue>();
-            }
 
-            var instance = System.Activator.CreateInstance(type);
-            return type.GetFields()
-                .Where(f => !f.IsStatic)
-                .Select(f =>
-                {
-                    var p = new VFXPropertyWithValue();
-                    p.property = new VFXProperty(f);
-                    p.value = f.GetValue(instance);
-                    return p;
-                });
-        }
-
-#pragma warning disable 649
-        private class InputProperties
+        public IEnumerable<VFXPropertyWithValue> GetInputProperties(IEnumerable<VFXPropertyWithValue> baseProperties)
         {
-            public SolverData solverData;
-        }
-#pragma warning restore 649
-
-        public IEnumerable<VFXPropertyWithValue> GetInputProperties()
-        {
-            var baseProperties = PropertiesFromType(typeof(InputProperties));
             foreach (var inputProperty in baseProperties)
             {
                 yield return inputProperty;
@@ -76,7 +51,7 @@ namespace Thinksquirrel.FluvioFX.Editor.Integrators
                 {
                     if (type != null)
                     {
-                        var typeProperties = PropertiesFromType(type);
+                        var typeProperties = FluvioFXBlock.PropertiesFromType(type);
                         foreach (var inputProperty in typeProperties)
                         {
                             yield return inputProperty;
@@ -128,7 +103,7 @@ float3 acceleration = force * invMass;
 float3 v = dt * acceleration;
 
 // Discard excessive velocities
-if (any(isnan(v) || isinf(v)) || dot(v, v) > (FLUVIO_MAX_SQR_VELOCITY_CHANGE * solverData_KernelSize.w * solverData_KernelSize.w))
+if (any(isnan(v) || isinf(v)) || dot(v, v) > FLUVIO_MAX_SQR_VELOCITY_CHANGE)
 {{
     v = 0;
 }}

--- a/Editor/Integrators/Verlet.cs
+++ b/Editor/Integrators/Verlet.cs
@@ -11,8 +11,6 @@ namespace Thinksquirrel.FluvioFX.Editor.Integrators
 {
     internal class Verlet : Integrator
     {
-        protected override bool preIntegrate => true;
-
         protected override IEnumerable<VFXAttributeInfo> attributes
         {
             get
@@ -23,8 +21,7 @@ namespace Thinksquirrel.FluvioFX.Editor.Integrators
 
         protected override string source => $@"
 float3 x = position;
-position = (x * 2) - oldPosition + (v * dt);
-velocity += v;
-";
+position = (x * 2) - oldPosition + ((v + velocity) * dt);
+velocity += v;";
     }
 }

--- a/Editor/Operators/FluidToSolverData.cs
+++ b/Editor/Operators/FluidToSolverData.cs
@@ -36,10 +36,9 @@ namespace Thinksquirrel.FluvioFX.Editor.Operators
         {
             // UpdateSolverTexture(true);
 
-            // KernelSize: x - h, y - h^2, z - h^3, w - simulation scale
+            // KernelSize: x - h, y - h^2, z - h^3, w - unused
             // KernelFactors: x - poly6, y - spiky, z - viscosity, w - unused
             VFXExpression h = inputExpression[0];
-            VFXExpression simulationScale = VFXValue.Constant(1.0f);
             var poly6 = new Poly6Kernel(h);
             var spiky = new SpikyKernel(h);
             var viscosity = new ViscosityKernel(h);
@@ -52,7 +51,7 @@ namespace Thinksquirrel.FluvioFX.Editor.Operators
                 h,
                 h * h,
                 h * h * h,
-                simulationScale
+                VFXValue.Constant(0.0f)
             }));
             outputExpression.Add(new VFXExpressionCombine(new []
             {
@@ -61,8 +60,7 @@ namespace Thinksquirrel.FluvioFX.Editor.Operators
             outputExpression.Add(new VFXTexture2DValue(Tex ? Tex : null));
             outputExpression.Add(new VFXExpressionCombine(new []
             {
-                VFXValue.Constant((float) (Tex? Tex.width : 0)),
-                    VFXValue.Constant((float) (Tex ? Tex.height : 0))
+                VFXValue.Constant((float) (Tex? Tex.width : 0)), VFXValue.Constant((float) (Tex ? Tex.height : 0))
             }));
 
             return outputExpression.ToArray();

--- a/Editor/Templates/Fluid Particle System.vfx
+++ b/Editor/Templates/Fluid Particle System.vfx
@@ -1,172 +1,5 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!114 &114023846229194376
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 73a13919d81fb7444849bae8b5c812a2, type: 3}
-  m_Name: VFXBasicSpawner
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 114350483966674976}
-  m_Children:
-  - {fileID: 114873264888500148}
-  m_UIPosition: {x: 716, y: -667}
-  m_UICollapsed: 0
-  m_UISuperCollapsed: 0
-  m_InputSlots: []
-  m_OutputSlots: []
-  m_Label: 
-  m_Data: {fileID: 0}
-  m_InputFlowSlot:
-  - link: []
-  - link: []
-  m_OutputFlowSlot:
-  - link:
-    - context: {fileID: 114946465509916290}
-      slotIndex: 0
---- !u!114 &114063133802684794
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a0b9e6b9139e58d4c957ec54595da7d3, type: 3}
-  m_Name: VFXQuadOutput
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 114350483966674976}
-  m_Children:
-  - {fileID: 114580989189733782}
-  - {fileID: 8926484042661618061}
-  m_UIPosition: {x: 716, y: 2031}
-  m_UICollapsed: 0
-  m_UISuperCollapsed: 0
-  m_InputSlots:
-  - {fileID: 114158099937248418}
-  m_OutputSlots: []
-  m_Label: 
-  m_Data: {fileID: 114428730288789306}
-  m_InputFlowSlot:
-  - link:
-    - context: {fileID: 114780028408030698}
-      slotIndex: 0
-  m_OutputFlowSlot:
-  - link: []
-  blendMode: 1
-  cullMode: 0
-  zWriteMode: 0
-  zTestMode: 0
-  uvMode: 0
-  useSoftParticle: 0
-  sortPriority: 0
-  sort: 0
-  indirectDraw: 0
-  castShadows: 0
-  preRefraction: 0
-  useGeometryShader: 0
---- !u!114 &114131763552434164
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a971fa2e110a0ac42ac1d8dae408704b, type: 3}
-  m_Name: SetAttribute
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 114946465509916290}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 2}
-  m_UICollapsed: 0
-  m_UISuperCollapsed: 0
-  m_InputSlots:
-  - {fileID: 8926484042661615843}
-  m_OutputSlots: []
-  m_Disabled: 0
-  attribute: lifetime
-  Composition: 0
-  Source: 0
-  Random: 0
-  channels: 6
---- !u!114 &114158099937248418
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 70a331b1d86cc8d4aa106ccbe0da5852, type: 3}
-  m_Name: VFXSlotTexture2D
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 0}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 114158099937248418}
-  m_MasterData:
-    m_Owner: {fileID: 114063133802684794}
-    m_Value:
-      m_Type:
-        m_SerializableType: UnityEngine.Texture2D, UnityEngine.CoreModule, Version=0.0.0.0,
-          Culture=neutral, PublicKeyToken=null
-      m_SerializableObject: '{"obj":{"fileID":2800000,"guid":"276d9e395ae18fe40a9b4988549f2349","type":3}}'
-    m_Space: 2147483647
-  m_Property:
-    name: mainTexture
-    m_serializedType:
-      m_SerializableType: UnityEngine.Texture2D, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &114307113894698210
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1b605c022ee79394a8a776c0869b3f9a, type: 3}
-  m_Name: VFXSlot
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 0}
-  m_Children:
-  - {fileID: 114986932069951040}
-  - {fileID: 114963171269329408}
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 0
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 114307113894698210}
-  m_MasterData:
-    m_Owner: {fileID: 114946465509916290}
-    m_Value:
-      m_Type:
-        m_SerializableType: UnityEditor.VFX.AABox, Unity.VisualEffectGraph.Editor,
-          Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-      m_SerializableObject: '{"center":{"x":0.0,"y":-0.25,"z":0.0},"size":{"x":3.0,"y":6.5,"z":3.0}}'
-    m_Space: 0
-  m_Property:
-    name: bounds
-    m_serializedType:
-      m_SerializableType: UnityEditor.VFX.AABox, Unity.VisualEffectGraph.Editor, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
 --- !u!114 &114340500867371532
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -179,15 +12,96 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d01270efd3285ea4a9d6c555cb0a8027, type: 3}
   m_Name: VFXUI
   m_EditorClassIdentifier: 
-  groupInfos: []
+  groupInfos:
+  - title: '[FluvioFX] Fluid simulation'
+    position:
+      serializedVersion: 2
+      x: 830.8771
+      y: -445.97025
+      width: 1264
+      height: 1704
+    contents:
+    - model: {fileID: 8926484042661618129}
+      id: 0
+      isStickyNote: 0
+    - model: {fileID: 8926484042661618162}
+      id: 0
+      isStickyNote: 0
+    - model: {fileID: 8926484042661618165}
+      id: 0
+      isStickyNote: 0
+    - model: {fileID: 8926484042661618168}
+      id: 0
+      isStickyNote: 0
+    - model: {fileID: 8926484042661618171}
+      id: 0
+      isStickyNote: 0
+    - model: {fileID: 8926484042661618174}
+      id: 0
+      isStickyNote: 0
+    - model: {fileID: 8926484042661618222}
+      id: 0
+      isStickyNote: 0
+    - model: {fileID: 0}
+      id: 0
+      isStickyNote: 1
+    - model: {fileID: 0}
+      id: 1
+      isStickyNote: 1
+    - model: {fileID: 0}
+      id: 2
+      isStickyNote: 1
+    - model: {fileID: 0}
+      id: 3
+      isStickyNote: 1
+    - model: {fileID: 0}
+      id: 4
+      isStickyNote: 1
+    - model: {fileID: 0}
+      id: 5
+      isStickyNote: 1
+    - model: {fileID: 0}
+      id: 6
+      isStickyNote: 1
+    - model: {fileID: 0}
+      id: 7
+      isStickyNote: 1
+  - title: '[FluvioFX] Update and integrate'
+    position:
+      serializedVersion: 2
+      x: 1325.8771
+      y: 1284.0298
+      width: 768
+      height: 277
+    contents:
+    - model: {fileID: 8926484042661618177}
+      id: 0
+      isStickyNote: 0
+    - model: {fileID: 0}
+      id: 8
+      isStickyNote: 1
+  - title: '[FluvioFX] Colliders'
+    position:
+      serializedVersion: 2
+      x: 863.8771
+      y: 418.02975
+      width: 426
+      height: 443
+    contents:
+    - model: {fileID: 8926484042661618180}
+      id: 0
+      isStickyNote: 0
+    - model: {fileID: 0}
+      id: 9
+      isStickyNote: 1
   stickyNoteInfos:
   - title: Initialize Solver
     position:
       serializedVersion: 2
-      x: 1132
-      y: 432
+      x: 1760.8771
+      y: 17.029755
       width: 309
-      height: 145
+      height: 143
     contents: "This block initializes FluvioFX particle attributes and must be in
       the first\r Update context."
     theme: Classic
@@ -195,10 +109,10 @@ MonoBehaviour:
   - title: Space Partitioning
     position:
       serializedVersion: 2
-      x: 1130
-      y: 619
-      width: 312
-      height: 147
+      x: 1758.8771
+      y: 173.02975
+      width: 311
+      height: 100
     contents: "First, the simulation area is divided into adjacent spaces. Particles\r
       are then categorized into these spaces in order to more efficiently perform
       a neighbor\r search step afterwards."
@@ -207,10 +121,10 @@ MonoBehaviour:
   - title: Neighbor search
     position:
       serializedVersion: 2
-      x: 1131
-      y: 791
+      x: 1758.8771
+      y: 295.02975
       width: 311
-      height: 147
+      height: 100
     contents: "FluvioFX requires neighboring particle information in order to simulate\r
       the forces between them. By examining adjacent spaces from partitioned particles,\r
       a search is performed. The results are then stored for later use."
@@ -219,10 +133,10 @@ MonoBehaviour:
   - title: Density and pressure
     position:
       serializedVersion: 2
-      x: 1131
-      y: 965
+      x: 1757.8771
+      y: 420.02975
       width: 312
-      height: 146
+      height: 100
     contents: Both particle density and pressure are determined here on a per-particle
       basis, based on an initial density and a physical gas constant.
     theme: Classic
@@ -230,10 +144,10 @@ MonoBehaviour:
   - title: Surface normal
     position:
       serializedVersion: 2
-      x: 1131
-      y: 1153
+      x: 1752.8771
+      y: 853.0298
       width: 314
-      height: 143
+      height: 100
     contents: "The normal vectors of the fluid surface are calculated based on density\r
       information. This is used in order to simulate a surface tension force, and\r
       can also be used to help render the fluid surface."
@@ -242,32 +156,22 @@ MonoBehaviour:
   - title: Calculate forces
     position:
       serializedVersion: 2
-      x: 1130
-      y: 1328
+      x: 1751.8771
+      y: 977.0298
       width: 314
-      height: 236
+      height: 223
     contents: "Here, internal fluid forces (pressure and viscosity), along with external\r
       fluid forces (surface tension, turbulence, and buoyancy) are calculated based\r
-      on the information above.\n\nSurface tension, turbulence, gravity, and buoyancy
-      forces can all be disabled for performance gains if not needed."
-    theme: Classic
-    textSize: Small
-  - title: Update and integrate
-    position:
-      serializedVersion: 2
-      x: 1128
-      y: 1602
-      width: 316
-      height: 179
-    contents: "Insert any standard VFX blocks here. The \"Integrate Particles\" block\r
-      must be the *last* block in the context."
+      on the information above.\n\nSurface tension, turbulence, gravity, buoyancy
+      force, and collision density forces can all be disabled for performance gains
+      if not needed."
     theme: Classic
     textSize: Small
   - title: Fluid properties
     position:
       serializedVersion: 2
-      x: 111
-      y: 474
+      x: 855.8771
+      y: -381.97025
       width: 451
       height: 414
     contents: "Physical fluid properties can all be changed or exposed from here.
@@ -280,22 +184,44 @@ MonoBehaviour:
   - title: Why multiple contexts and blocks?
     position:
       serializedVersion: 2
-      x: 104
-      y: 1242
-      width: 455
-      height: 230
+      x: 1313.8771
+      y: -381.97025
+      width: 423
+      height: 244
     contents: "FluvioFX requires synchronization steps to ensure correct simulation.\r
       Currently, this can only be achieved by creating individual contexts and blocks."
+    theme: Classic
+    textSize: Medium
+  - title: 
+    position:
+      serializedVersion: 2
+      x: 1751.8771
+      y: 1362.0298
+      width: 317
+      height: 136
+    contents: "Insert any standard VFX blocks here. The Integrate Particles block\r
+      must be the *last* block in this context."
+    theme: Classic
+    textSize: Medium
+  - title: 
+    position:
+      serializedVersion: 2
+      x: 908.8771
+      y: 482.02975
+      width: 329
+      height: 141
+    contents: Insert any Fluid Collider blocks here. These blocks can be found under
+      FluvioFX > Collision.
     theme: Classic
     textSize: Medium
   systemInfos: []
   categories: []
   uiBounds:
     serializedVersion: 2
-    x: 112
-    y: -667
-    width: 1341
-    height: 3083
+    x: 860
+    y: -1384
+    width: 1634
+    height: 3543
 --- !u!114 &114350483966674976
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -310,17 +236,18 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Parent: {fileID: 0}
   m_Children:
-  - {fileID: 114023846229194376}
-  - {fileID: 114946465509916290}
-  - {fileID: 114780028408030698}
-  - {fileID: 114063133802684794}
-  - {fileID: 8926484042661615670}
-  - {fileID: 8926484042661615672}
-  - {fileID: 8926484042661615674}
-  - {fileID: 8926484042661615676}
-  - {fileID: 8926484042661615678}
-  - {fileID: 8926484042661615844}
-  - {fileID: 8926484042661618010}
+  - {fileID: 8926484042661618129}
+  - {fileID: 8926484042661618162}
+  - {fileID: 8926484042661618165}
+  - {fileID: 8926484042661618168}
+  - {fileID: 8926484042661618171}
+  - {fileID: 8926484042661618174}
+  - {fileID: 8926484042661618177}
+  - {fileID: 8926484042661618180}
+  - {fileID: 8926484042661618182}
+  - {fileID: 8926484042661618185}
+  - {fileID: 8926484042661618216}
+  - {fileID: 8926484042661618222}
   m_UIPosition: {x: 0, y: 0}
   m_UICollapsed: 1
   m_UISuperCollapsed: 0
@@ -328,472 +255,6 @@ MonoBehaviour:
   m_ParameterInfo: []
   m_GraphVersion: 1
   m_saved: 1
---- !u!114 &114380859405582094
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: VFXSlotFloat
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 114963171269329408}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 114307113894698210}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: z
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &114428730288789306
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d78581a96eae8bf4398c282eb0b098bd, type: 3}
-  m_Name: VFXDataParticle
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 114350483966674976}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_Owners:
-  - {fileID: 114946465509916290}
-  - {fileID: 8926484042661615670}
-  - {fileID: 8926484042661615672}
-  - {fileID: 8926484042661615674}
-  - {fileID: 8926484042661615844}
-  - {fileID: 8926484042661615676}
-  - {fileID: 8926484042661615678}
-  - {fileID: 114780028408030698}
-  - {fileID: 114063133802684794}
-  m_Capacity: 2000
-  m_Space: 0
---- !u!114 &114512514798047786
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: VFXSlotFloat
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 114963171269329408}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 114307113894698210}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: x
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &114538391275492396
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: VFXSlotFloat
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 114986932069951040}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 114307113894698210}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: z
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &114571176826476282
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: VFXSlotFloat
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 0}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 114571176826476282}
-  m_MasterData:
-    m_Owner: {fileID: 114873264888500148}
-    m_Value:
-      m_Type:
-        m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-          PublicKeyToken=b77a5c561934e089
-      m_SerializableObject: 2000
-    m_Space: 2147483647
-  m_Property:
-    name: Rate
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 0
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Spawn Rate (in number per seconds)
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &114580989189733782
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d16c6aeaef944094b9a1633041804207, type: 3}
-  m_Name: Orient
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 114063133802684794}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 2}
-  m_UICollapsed: 0
-  m_UISuperCollapsed: 0
-  m_InputSlots: []
-  m_OutputSlots: []
-  m_Disabled: 0
-  mode: 0
---- !u!114 &114739294351936256
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: VFXSlotFloat
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 114986932069951040}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 114307113894698210}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: x
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &114780028408030698
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2dc095764ededfa4bb32fa602511ea4b, type: 3}
-  m_Name: VFXBasicUpdate
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 114350483966674976}
-  m_Children:
-  - {fileID: 8926484042661615687}
-  m_UIPosition: {x: 716, y: 1588}
-  m_UICollapsed: 0
-  m_UISuperCollapsed: 0
-  m_InputSlots: []
-  m_OutputSlots: []
-  m_Label: 
-  m_Data: {fileID: 114428730288789306}
-  m_InputFlowSlot:
-  - link:
-    - context: {fileID: 8926484042661615678}
-      slotIndex: 0
-  m_OutputFlowSlot:
-  - link:
-    - context: {fileID: 114063133802684794}
-      slotIndex: 0
-  integration: 1
-  angularIntegration: 0
-  ageParticles: 1
-  reapParticles: 1
---- !u!114 &114873264888500148
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f05c6884b705ce14d82ae720f0ec209f, type: 3}
-  m_Name: VFXSpawnerConstantRate
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 114023846229194376}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 2}
-  m_UICollapsed: 0
-  m_UISuperCollapsed: 0
-  m_InputSlots:
-  - {fileID: 114571176826476282}
-  m_OutputSlots: []
-  m_Disabled: 0
---- !u!114 &114920711487922656
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: VFXSlotFloat
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 114963171269329408}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 114307113894698210}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: y
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &114935892456706286
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: VFXSlotFloat
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 114986932069951040}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 114307113894698210}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: y
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &114946465509916290
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9dfea48843f53fc438eabc12a3a30abc, type: 3}
-  m_Name: VFXBasicInitialize
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 114350483966674976}
-  m_Children:
-  - {fileID: 114131763552434164}
-  - {fileID: 8926484042661615881}
-  - {fileID: 8926484042661618068}
-  m_UIPosition: {x: 716, y: -453}
-  m_UICollapsed: 0
-  m_UISuperCollapsed: 0
-  m_InputSlots:
-  - {fileID: 114307113894698210}
-  m_OutputSlots: []
-  m_Label: 
-  m_Data: {fileID: 114428730288789306}
-  m_InputFlowSlot:
-  - link:
-    - context: {fileID: 114023846229194376}
-      slotIndex: 0
-  m_OutputFlowSlot:
-  - link:
-    - context: {fileID: 8926484042661615670}
-      slotIndex: 0
---- !u!114 &114963171269329408
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ac39bd03fca81b849929b9c966f1836a, type: 3}
-  m_Name: VFXSlotFloat3
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 114307113894698210}
-  m_Children:
-  - {fileID: 114512514798047786}
-  - {fileID: 114920711487922656}
-  - {fileID: 114380859405582094}
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 0
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 114307113894698210}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: size
-    m_serializedType:
-      m_SerializableType: UnityEngine.Vector3, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-    attributes:
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: The size of the box along each axis.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &114986932069951040
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ac39bd03fca81b849929b9c966f1836a, type: 3}
-  m_Name: VFXSlotFloat3
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 114307113894698210}
-  m_Children:
-  - {fileID: 114739294351936256}
-  - {fileID: 114935892456706286}
-  - {fileID: 114538391275492396}
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 114307113894698210}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: center
-    m_serializedType:
-      m_SerializableType: UnityEngine.Vector3, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-    attributes:
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: The centre of the box.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
 --- !u!2058629511 &8926484042661614527
 VisualEffectResource:
   m_ObjectHideFlags: 0
@@ -804,6 +265,588 @@ VisualEffectResource:
   m_Graph: {fileID: 114350483966674976}
   m_ShaderSources:
   - compute: 1
+    name: '[System 1]A Update'
+    source: "#pragma kernel CSMain\n#include \"HLSLSupport.cginc\"\n#define NB_THREADS_PER_GROUP
+      64\n#define VFX_USE_LIFETIME_CURRENT 1\n#define VFX_USE_POSITION_CURRENT 1\n#define
+      VFX_USE_FORCE_CURRENT 1\n#define VFX_USE_MASS_CURRENT 1\n#define VFX_USE_OLDPOSITION_CURRENT
+      1\n#define VFX_USE_ALIVE_CURRENT 1\n#define VFX_USE_AGE_CURRENT 1\n#define VFX_HAS_INDIRECT_DRAW
+      1\n#define VFX_WORLD_SPACE 1\n\n\nCBUFFER_START(parameters)\n    float3 solverData_Gravity_a;\n
+      \   uint PADDING_0;\nCBUFFER_END\nTexture2D solverData_Tex_a;\nSamplerState
+      samplersolverData_Tex_a;\n\n\n#include \"Packages/com.unity.visualeffectgraph/Shaders/Common/VFXCommonCompute.cginc\"\n#include
+      \"Packages/com.unity.visualeffectgraph/Shaders/VFXCommon.cginc\"\n#include \"Packages/com.thinksquirrel.fluviofx/Shaders/FluvioCompute.cginc\"\n\n\n\nRWByteAddressBuffer
+      attributeBuffer;\n\n#if VFX_USE_ALIVE_CURRENT\nRWStructuredBuffer<uint> deadListOut;\n#endif\n\n#if
+      VFX_HAS_INDIRECT_DRAW\nRWStructuredBuffer<uint> indirectBuffer;\n#endif\n\nCBUFFER_START(updateParams)\n
+      \   uint nbMax;\n\tuint dispatchWidth;\n\tuint systemSeed;\nCBUFFER_END\n\nvoid
+      InitializeSolver(uint index, float3 position, inout float3 force, inout float
+      mass, inout float3 oldPosition, float solverData_Fluid_SmoothingDistance, float
+      solverData_Fluid_ParticleMass, float solverData_Fluid_Density, float solverData_Fluid_MinimumDensity,
+      float solverData_Fluid_GasConstant, float solverData_Fluid_Viscosity, float
+      solverData_Fluid_TurbulenceProbability, float solverData_Fluid_SurfaceTension,
+      float solverData_Fluid_BuoyancyCoefficient, float3 solverData_Gravity, float4
+      solverData_KernelSize, float4 solverData_KernelFactors, VFXSampler2D solverData_Tex,
+      float2 solverData_TexSize)\n{\n    \n    // Clear forces\n    force = 0;\n    \n
+      \   #ifdef FLUVIO_INDEX_GRID\n    // Clear grid index\n    gridIndex = 0;\n
+      \   \n    // Clear neighbor count\n    neighborCount = 0;\n    \n    // Set
+      mass\n    mass = solverData_Fluid_ParticleMass;\n    \n    // Set old position\n
+      \   oldPosition = position;\n    \n    #endif\n}\nvoid Reap(float age, float
+      lifetime, inout bool alive)\n{\n    if(age > lifetime) { alive = false; }\n}\n\n\n\n[numthreads(NB_THREADS_PER_GROUP,1,1)]\nvoid
+      CSMain(uint3 groupId          : SV_GroupID,\n            uint3 groupThreadId
+      \   : SV_GroupThreadID)\n{\n\tuint id = groupThreadId.x + groupId.x * NB_THREADS_PER_GROUP
+      + groupId.y * dispatchWidth * NB_THREADS_PER_GROUP;\n\tuint index = id;\n\tif
+      (id < nbMax)\n\t{\n#if VFX_USE_ALIVE_CURRENT\n\t\tbool alive = (attributeBuffer.Load((index
+      * 0x1 + 0xF000) << 2));\n\t\t\n\n\t\tif (alive)\n\t\t{\n\t\t\tfloat lifetime
+      = asfloat(attributeBuffer.Load((index * 0x1 + 0x0) << 2));\n\t\t\tfloat3 position
+      = asfloat(attributeBuffer.Load3((index * 0x4 + 0x800) << 2));\n\t\t\tfloat3
+      force = asfloat(attributeBuffer.Load3((index * 0x4 + 0x4800) << 2));\n\t\t\tfloat
+      mass = asfloat(attributeBuffer.Load((index * 0x1 + 0x6800) << 2));\n\t\t\tfloat3
+      oldPosition = asfloat(attributeBuffer.Load3((index * 0x4 + 0x7000) << 2));\n\t\t\tfloat
+      age = asfloat(attributeBuffer.Load((index * 0x1 + 0xF800) << 2));\n\t\t\t\n\n\t\t\t\n#if
+      VFX_USE_OLDPOSITION_CURRENT\n\t\t\toldPosition = position;\n#endif\n\t\t\t\n\t\t\t{\n\t\t\t
+      \   InitializeSolver(index, position,  /*inout */force,  /*inout */mass,  /*inout
+      */oldPosition, (float)0.38125, (float)7.625, (float)998.29, (float)9.9829, (float)0.01,
+      (float)0.3, (float)0.2, (float)0.728, (float)0, solverData_Gravity_a, float4(0.38125,0.1453516,0.05541528,0),
+      float4(9206.448,1554.828,43.08061,0), GetVFXSampler(solverData_Tex_a, samplersolverData_Tex_a),
+      float2(0,0));\n\t\t\t}\n\t\t\tReap(age, lifetime,  /*inout */alive);\n\t\t\t\n\n\t\t\tif
+      (alive)\n\t\t\t{\n\t\t\t\tattributeBuffer.Store3((index * 0x4 + 0x4800) << 2,asuint(force));\n\t\t\t\tattributeBuffer.Store((index
+      * 0x1 + 0x6800) << 2,asuint(mass));\n\t\t\t\tattributeBuffer.Store3((index *
+      0x4 + 0x7000) << 2,asuint(oldPosition));\n\t\t\t\t\n\n#if VFX_HAS_INDIRECT_DRAW\n
+      \               uint indirectIndex = indirectBuffer.IncrementCounter();\n\t\t\t\tindirectBuffer[indirectIndex]
+      = index;\n#endif\n\t\t\t}\n\t\t\telse\n\t\t\t{\n\t\t\t\tattributeBuffer.Store((index
+      * 0x1 + 0xF000) << 2,uint(alive));\n\t\t\t\t\n\n\t\t\t\tuint deadIndex = deadListOut.IncrementCounter();\n\t\t\t\tdeadListOut[deadIndex]
+      = index;\n\t\t\t}\n\t\t}\n#else\n\t\tfloat lifetime = asfloat(attributeBuffer.Load((index
+      * 0x1 + 0x0) << 2));\n\t\tfloat3 position = asfloat(attributeBuffer.Load3((index
+      * 0x4 + 0x800) << 2));\n\t\tfloat3 force = asfloat(attributeBuffer.Load3((index
+      * 0x4 + 0x4800) << 2));\n\t\tfloat mass = asfloat(attributeBuffer.Load((index
+      * 0x1 + 0x6800) << 2));\n\t\tfloat3 oldPosition = asfloat(attributeBuffer.Load3((index
+      * 0x4 + 0x7000) << 2));\n\t\tbool alive = (attributeBuffer.Load((index * 0x1
+      + 0xF000) << 2));\n\t\tfloat age = asfloat(attributeBuffer.Load((index * 0x1
+      + 0xF800) << 2));\n\t\t\n\n\t\t\n#if VFX_USE_OLDPOSITION_CURRENT\n\t\toldPosition
+      = position;\n#endif\n\t\t\n\t\t{\n\t\t    InitializeSolver(index, position,
+      \ /*inout */force,  /*inout */mass,  /*inout */oldPosition, (float)0.38125,
+      (float)7.625, (float)998.29, (float)9.9829, (float)0.01, (float)0.3, (float)0.2,
+      (float)0.728, (float)0, solverData_Gravity_a, float4(0.38125,0.1453516,0.05541528,0),
+      float4(9206.448,1554.828,43.08061,0), GetVFXSampler(solverData_Tex_a, samplersolverData_Tex_a),
+      float2(0,0));\n\t\t}\n\t\tReap(age, lifetime,  /*inout */alive);\n\t\t\n\n\t\tattributeBuffer.Store3((index
+      * 0x4 + 0x4800) << 2,asuint(force));\n\t\tattributeBuffer.Store((index * 0x1
+      + 0x6800) << 2,asuint(mass));\n\t\tattributeBuffer.Store3((index * 0x4 + 0x7000)
+      << 2,asuint(oldPosition));\n\t\tattributeBuffer.Store((index * 0x1 + 0xF000)
+      << 2,uint(alive));\n\t\t\n\n#if VFX_HAS_INDIRECT_DRAW\n        uint indirectIndex
+      = indirectBuffer.IncrementCounter();\n\t\tindirectBuffer[indirectIndex] = index;\n#endif\n#endif\n\t}\n}\n"
+  - compute: 1
+    name: '[System 1]B Update'
+    source: "#pragma kernel CSMain\n#include \"HLSLSupport.cginc\"\n#define NB_THREADS_PER_GROUP
+      64\n#define VFX_USE_LIFETIME_CURRENT 1\n#define VFX_USE_POSITION_CURRENT 1\n#define
+      VFX_USE_OLDPOSITION_CURRENT 1\n#define VFX_USE_ALIVE_CURRENT 1\n#define VFX_USE_AGE_CURRENT
+      1\n#define VFX_HAS_INDIRECT_DRAW 1\n#define VFX_WORLD_SPACE 1\n\n\nCBUFFER_START(parameters)\n
+      \   float3 solverData_Gravity_a;\n    uint PADDING_0;\nCBUFFER_END\n\n\n#include
+      \"Packages/com.unity.visualeffectgraph/Shaders/Common/VFXCommonCompute.cginc\"\n#include
+      \"Packages/com.unity.visualeffectgraph/Shaders/VFXCommon.cginc\"\n#include \"Packages/com.thinksquirrel.fluviofx/Shaders/FluvioCompute.cginc\"\n\n\n\nRWByteAddressBuffer
+      attributeBuffer;\n\n#if VFX_USE_ALIVE_CURRENT\nRWStructuredBuffer<uint> deadListOut;\n#endif\n\n#if
+      VFX_HAS_INDIRECT_DRAW\nRWStructuredBuffer<uint> indirectBuffer;\n#endif\n\nCBUFFER_START(updateParams)\n
+      \   uint nbMax;\n\tuint dispatchWidth;\n\tuint systemSeed;\nCBUFFER_END\n\nvoid
+      SpacePartitioning(uint index, float3 position, bool alive, float solverData_Fluid_SmoothingDistance,
+      float solverData_Fluid_ParticleMass, float solverData_Fluid_Density, float solverData_Fluid_MinimumDensity,
+      float solverData_Fluid_GasConstant, float solverData_Fluid_Viscosity, float
+      solverData_Fluid_TurbulenceProbability, float solverData_Fluid_SurfaceTension,
+      float solverData_Fluid_BuoyancyCoefficient, float3 solverData_Gravity, float4
+      solverData_KernelSize, float4 solverData_KernelFactors)\n{\n    \n    #ifdef
+      FLUVIO_INDEX_GRID\n    // indices are +1 for GPU grids (0 = not alive)\n    gridIndex
+      = GetGridIndexFromPosition(position, solverData_KernelSize.x) + 1;\n    #endif\n
+      \   \n}\nvoid Reap(float age, float lifetime, inout bool alive)\n{\n    if(age
+      > lifetime) { alive = false; }\n}\n\n\n\n[numthreads(NB_THREADS_PER_GROUP,1,1)]\nvoid
+      CSMain(uint3 groupId          : SV_GroupID,\n            uint3 groupThreadId
+      \   : SV_GroupThreadID)\n{\n\tuint id = groupThreadId.x + groupId.x * NB_THREADS_PER_GROUP
+      + groupId.y * dispatchWidth * NB_THREADS_PER_GROUP;\n\tuint index = id;\n\tif
+      (id < nbMax)\n\t{\n#if VFX_USE_ALIVE_CURRENT\n\t\tbool alive = (attributeBuffer.Load((index
+      * 0x1 + 0xF000) << 2));\n\t\t\n\n\t\tif (alive)\n\t\t{\n\t\t\tfloat lifetime
+      = asfloat(attributeBuffer.Load((index * 0x1 + 0x0) << 2));\n\t\t\tfloat3 position
+      = asfloat(attributeBuffer.Load3((index * 0x4 + 0x800) << 2));\n\t\t\tfloat3
+      oldPosition = asfloat(attributeBuffer.Load3((index * 0x4 + 0x7000) << 2));\n\t\t\tfloat
+      age = asfloat(attributeBuffer.Load((index * 0x1 + 0xF800) << 2));\n\t\t\t\n\n\t\t\t\n#if
+      VFX_USE_OLDPOSITION_CURRENT\n\t\t\toldPosition = position;\n#endif\n\t\t\t\n\t\t\t{\n\t\t\t
+      \   SpacePartitioning(index, position, alive, (float)0.38125, (float)7.625,
+      (float)998.29, (float)9.9829, (float)0.01, (float)0.3, (float)0.2, (float)0.728,
+      (float)0, solverData_Gravity_a, float4(0.38125,0.1453516,0.05541528,0), float4(9206.448,1554.828,43.08061,0));\n\t\t\t}\n\t\t\tReap(age,
+      lifetime,  /*inout */alive);\n\t\t\t\n\n\t\t\tif (alive)\n\t\t\t{\n\t\t\t\tattributeBuffer.Store3((index
+      * 0x4 + 0x7000) << 2,asuint(oldPosition));\n\t\t\t\t\n\n#if VFX_HAS_INDIRECT_DRAW\n
+      \               uint indirectIndex = indirectBuffer.IncrementCounter();\n\t\t\t\tindirectBuffer[indirectIndex]
+      = index;\n#endif\n\t\t\t}\n\t\t\telse\n\t\t\t{\n\t\t\t\tattributeBuffer.Store((index
+      * 0x1 + 0xF000) << 2,uint(alive));\n\t\t\t\t\n\n\t\t\t\tuint deadIndex = deadListOut.IncrementCounter();\n\t\t\t\tdeadListOut[deadIndex]
+      = index;\n\t\t\t}\n\t\t}\n#else\n\t\tfloat lifetime = asfloat(attributeBuffer.Load((index
+      * 0x1 + 0x0) << 2));\n\t\tfloat3 position = asfloat(attributeBuffer.Load3((index
+      * 0x4 + 0x800) << 2));\n\t\tfloat3 oldPosition = asfloat(attributeBuffer.Load3((index
+      * 0x4 + 0x7000) << 2));\n\t\tbool alive = (attributeBuffer.Load((index * 0x1
+      + 0xF000) << 2));\n\t\tfloat age = asfloat(attributeBuffer.Load((index * 0x1
+      + 0xF800) << 2));\n\t\t\n\n\t\t\n#if VFX_USE_OLDPOSITION_CURRENT\n\t\toldPosition
+      = position;\n#endif\n\t\t\n\t\t{\n\t\t    SpacePartitioning(index, position,
+      alive, (float)0.38125, (float)7.625, (float)998.29, (float)9.9829, (float)0.01,
+      (float)0.3, (float)0.2, (float)0.728, (float)0, solverData_Gravity_a, float4(0.38125,0.1453516,0.05541528,0),
+      float4(9206.448,1554.828,43.08061,0));\n\t\t}\n\t\tReap(age, lifetime,  /*inout
+      */alive);\n\t\t\n\n\t\tattributeBuffer.Store3((index * 0x4 + 0x7000) << 2,asuint(oldPosition));\n\t\tattributeBuffer.Store((index
+      * 0x1 + 0xF000) << 2,uint(alive));\n\t\t\n\n#if VFX_HAS_INDIRECT_DRAW\n        uint
+      indirectIndex = indirectBuffer.IncrementCounter();\n\t\tindirectBuffer[indirectIndex]
+      = index;\n#endif\n#endif\n\t}\n}\n"
+  - compute: 1
+    name: '[System 1]C Update'
+    source: "#pragma kernel CSMain\n#include \"HLSLSupport.cginc\"\n#define NB_THREADS_PER_GROUP
+      64\n#define VFX_USE_LIFETIME_CURRENT 1\n#define VFX_USE_POSITION_CURRENT 1\n#define
+      VFX_USE_OLDPOSITION_CURRENT 1\n#define VFX_USE_ALIVE_CURRENT 1\n#define VFX_USE_AGE_CURRENT
+      1\n#define VFX_HAS_INDIRECT_DRAW 1\n#define VFX_WORLD_SPACE 1\n\n\nCBUFFER_START(parameters)\n
+      \   float3 solverData_Gravity_a;\n    uint PADDING_0;\nCBUFFER_END\n\n\n#include
+      \"Packages/com.unity.visualeffectgraph/Shaders/Common/VFXCommonCompute.cginc\"\n#include
+      \"Packages/com.unity.visualeffectgraph/Shaders/VFXCommon.cginc\"\n#include \"Packages/com.thinksquirrel.fluviofx/Shaders/FluvioCompute.cginc\"\n\n\n\nRWByteAddressBuffer
+      attributeBuffer;\n\n#if VFX_USE_ALIVE_CURRENT\nRWStructuredBuffer<uint> deadListOut;\n#endif\n\n#if
+      VFX_HAS_INDIRECT_DRAW\nRWStructuredBuffer<uint> indirectBuffer;\n#endif\n\nCBUFFER_START(updateParams)\n
+      \   uint nbMax;\n\tuint dispatchWidth;\n\tuint systemSeed;\nCBUFFER_END\n\nvoid
+      NeighborSearch(uint index, float3 position, bool alive, float solverData_Fluid_SmoothingDistance,
+      float solverData_Fluid_ParticleMass, float solverData_Fluid_Density, float solverData_Fluid_MinimumDensity,
+      float solverData_Fluid_GasConstant, float solverData_Fluid_Viscosity, float
+      solverData_Fluid_TurbulenceProbability, float solverData_Fluid_SurfaceTension,
+      float solverData_Fluid_BuoyancyCoefficient, float3 solverData_Gravity, float4
+      solverData_KernelSize, float4 solverData_KernelFactors)\n{\n    \n    #ifdef
+      FLUVIO_INDEX_GRID\n    // TODO: Grid structure/neighbor search is not optimized,
+      due to VFX limitations.\n    // At the moment, we are unable to easily pass
+      custom buffers to the system,\n    // and not all platforms support texture
+      atomics, which would be required\n    // for a true spatial partition\n    \n
+      \   uint3 indexVector = GetGridIndexVector(position, solverData_KernelSize.x);\n
+      \   int3 indexVectorOff;\n    uint3 indexVectorOffset;\n    uint currentGridIndex;\n
+      \   uint nCount = 0;\n    float3 candidatePosition, dist;\n    float d;\n    \n
+      \   for (uint candidate = 0; candidate < nbMax; ++candidate)\n    {\n        if
+      (index == candidate) continue;\n    \n        \n        if (candidateGridIndex
+      == 0) continue;\n    \n        for (indexVectorOff.x = -1; indexVectorOff.x
+      <= 1; indexVectorOff.x++)\n        {\n            for (indexVectorOff.y = -1;
+      indexVectorOff.y <= 1; indexVectorOff.y++)\n            {\n                for
+      (indexVectorOff.z = -1; indexVectorOff.z <= 1; indexVectorOff.z++)\n                {\n
+      \                   indexVectorOffset = (uint3)(indexVector + indexVectorOff);\n
+      \                   currentGridIndex = GetGridIndex(indexVectorOffset);\n    \n
+      \                   // indices are +1 for GPU grids (0 = not alive)\n                    if
+      (candidateGridIndex - 1 == currentGridIndex)\n                    {\n                        float3
+      candidatePosition = asfloat(attributeBuffer.Load3((candidate * 0x4 + 0x800)
+      << 2));\n                        dist = candidatePosition - position;\n                        d
+      = dot(dist, dist);\n    \n                        if (d < solverData_KernelSize.y)\n
+      \                       {\n                            SetNeighborIndex(solverData_Tex,
+      solverData_TexSize, index, nCount++, candidate);\n    \n                            if
+      (nCount >= FLUVIO_MAX_NEIGHBORS)\n                            {\n                                neighborCount
+      = FLUVIO_MAX_NEIGHBORS;\n                                return;\n                            }\n
+      \                       }\n                    }\n                }\n            }\n
+      \       }\n    }\n    \n    neighborCount = nCount;\n    #endif\n    \n}\nvoid
+      Reap(float age, float lifetime, inout bool alive)\n{\n    if(age > lifetime)
+      { alive = false; }\n}\n\n\n\n[numthreads(NB_THREADS_PER_GROUP,1,1)]\nvoid CSMain(uint3
+      groupId          : SV_GroupID,\n            uint3 groupThreadId    : SV_GroupThreadID)\n{\n\tuint
+      id = groupThreadId.x + groupId.x * NB_THREADS_PER_GROUP + groupId.y * dispatchWidth
+      * NB_THREADS_PER_GROUP;\n\tuint index = id;\n\tif (id < nbMax)\n\t{\n#if VFX_USE_ALIVE_CURRENT\n\t\tbool
+      alive = (attributeBuffer.Load((index * 0x1 + 0xF000) << 2));\n\t\t\n\n\t\tif
+      (alive)\n\t\t{\n\t\t\tfloat lifetime = asfloat(attributeBuffer.Load((index *
+      0x1 + 0x0) << 2));\n\t\t\tfloat3 position = asfloat(attributeBuffer.Load3((index
+      * 0x4 + 0x800) << 2));\n\t\t\tfloat3 oldPosition = asfloat(attributeBuffer.Load3((index
+      * 0x4 + 0x7000) << 2));\n\t\t\tfloat age = asfloat(attributeBuffer.Load((index
+      * 0x1 + 0xF800) << 2));\n\t\t\t\n\n\t\t\t\n#if VFX_USE_OLDPOSITION_CURRENT\n\t\t\toldPosition
+      = position;\n#endif\n\t\t\t\n\t\t\t{\n\t\t\t    NeighborSearch(index, position,
+      alive, (float)0.38125, (float)7.625, (float)998.29, (float)9.9829, (float)0.01,
+      (float)0.3, (float)0.2, (float)0.728, (float)0, solverData_Gravity_a, float4(0.38125,0.1453516,0.05541528,0),
+      float4(9206.448,1554.828,43.08061,0));\n\t\t\t}\n\t\t\tReap(age, lifetime,  /*inout
+      */alive);\n\t\t\t\n\n\t\t\tif (alive)\n\t\t\t{\n\t\t\t\tattributeBuffer.Store3((index
+      * 0x4 + 0x7000) << 2,asuint(oldPosition));\n\t\t\t\t\n\n#if VFX_HAS_INDIRECT_DRAW\n
+      \               uint indirectIndex = indirectBuffer.IncrementCounter();\n\t\t\t\tindirectBuffer[indirectIndex]
+      = index;\n#endif\n\t\t\t}\n\t\t\telse\n\t\t\t{\n\t\t\t\tattributeBuffer.Store((index
+      * 0x1 + 0xF000) << 2,uint(alive));\n\t\t\t\t\n\n\t\t\t\tuint deadIndex = deadListOut.IncrementCounter();\n\t\t\t\tdeadListOut[deadIndex]
+      = index;\n\t\t\t}\n\t\t}\n#else\n\t\tfloat lifetime = asfloat(attributeBuffer.Load((index
+      * 0x1 + 0x0) << 2));\n\t\tfloat3 position = asfloat(attributeBuffer.Load3((index
+      * 0x4 + 0x800) << 2));\n\t\tfloat3 oldPosition = asfloat(attributeBuffer.Load3((index
+      * 0x4 + 0x7000) << 2));\n\t\tbool alive = (attributeBuffer.Load((index * 0x1
+      + 0xF000) << 2));\n\t\tfloat age = asfloat(attributeBuffer.Load((index * 0x1
+      + 0xF800) << 2));\n\t\t\n\n\t\t\n#if VFX_USE_OLDPOSITION_CURRENT\n\t\toldPosition
+      = position;\n#endif\n\t\t\n\t\t{\n\t\t    NeighborSearch(index, position, alive,
+      (float)0.38125, (float)7.625, (float)998.29, (float)9.9829, (float)0.01, (float)0.3,
+      (float)0.2, (float)0.728, (float)0, solverData_Gravity_a, float4(0.38125,0.1453516,0.05541528,0),
+      float4(9206.448,1554.828,43.08061,0));\n\t\t}\n\t\tReap(age, lifetime,  /*inout
+      */alive);\n\t\t\n\n\t\tattributeBuffer.Store3((index * 0x4 + 0x7000) << 2,asuint(oldPosition));\n\t\tattributeBuffer.Store((index
+      * 0x1 + 0xF000) << 2,uint(alive));\n\t\t\n\n#if VFX_HAS_INDIRECT_DRAW\n        uint
+      indirectIndex = indirectBuffer.IncrementCounter();\n\t\tindirectBuffer[indirectIndex]
+      = index;\n#endif\n#endif\n\t}\n}\n"
+  - compute: 1
+    name: '[System 1]D Update'
+    source: "#pragma kernel CSMain\n#include \"HLSLSupport.cginc\"\n#define NB_THREADS_PER_GROUP
+      64\n#define VFX_USE_LIFETIME_CURRENT 1\n#define VFX_USE_POSITION_CURRENT 1\n#define
+      VFX_USE_MASS_CURRENT 1\n#define VFX_USE_OLDPOSITION_CURRENT 1\n#define VFX_USE_DENSITYPRESSURE_CURRENT
+      1\n#define VFX_USE_ALIVE_CURRENT 1\n#define VFX_USE_AGE_CURRENT 1\n#define VFX_HAS_INDIRECT_DRAW
+      1\n#define VFX_WORLD_SPACE 1\n\n\nCBUFFER_START(parameters)\n    float3 solverData_Gravity_a;\n
+      \   uint PADDING_0;\nCBUFFER_END\n\n\n#include \"Packages/com.unity.visualeffectgraph/Shaders/Common/VFXCommonCompute.cginc\"\n#include
+      \"Packages/com.unity.visualeffectgraph/Shaders/VFXCommon.cginc\"\n#include \"Packages/com.thinksquirrel.fluviofx/Shaders/FluvioCompute.cginc\"\n\n\n\nRWByteAddressBuffer
+      attributeBuffer;\n\n#if VFX_USE_ALIVE_CURRENT\nRWStructuredBuffer<uint> deadListOut;\n#endif\n\n#if
+      VFX_HAS_INDIRECT_DRAW\nRWStructuredBuffer<uint> indirectBuffer;\n#endif\n\nCBUFFER_START(updateParams)\n
+      \   uint nbMax;\n\tuint dispatchWidth;\n\tuint systemSeed;\nCBUFFER_END\n\nvoid
+      DensityPressure(uint index, float3 position, bool alive, float mass, inout float4
+      densityPressure, float solverData_Fluid_SmoothingDistance, float solverData_Fluid_ParticleMass,
+      float solverData_Fluid_Density, float solverData_Fluid_MinimumDensity, float
+      solverData_Fluid_GasConstant, float solverData_Fluid_Viscosity, float solverData_Fluid_TurbulenceProbability,
+      float solverData_Fluid_SurfaceTension, float solverData_Fluid_BuoyancyCoefficient,
+      float3 solverData_Gravity, float4 solverData_KernelSize, float4 solverData_KernelFactors)\n{\n
+      \   \n    float3 dist;\n    float density = 0;\n    float pressure;\n    #ifdef
+      FLUVIO_INDEX_GRID\n    uint neighborIndex;\n    for (uint j = 0; j < neighborCount;
+      ++j)\n    {\n        neighborIndex = GetNeighborIndex(solverData_Tex, solverData_TexSize,
+      index, j);\n    #else\n    float distLenSq;\n    for (uint neighborIndex = 0;
+      neighborIndex < nbMax; ++neighborIndex)\n    {\n        if (index == neighborIndex)
+      continue;\n        bool neighborAlive = (attributeBuffer.Load((neighborIndex
+      * 0x1 + 0xF000) << 2));\n        if (!neighborAlive) continue;\n    #endif\n
+      \   \n        float3 neighborPosition = asfloat(attributeBuffer.Load3((neighborIndex
+      * 0x4 + 0x800) << 2));\n        float neighborMass = asfloat(attributeBuffer.Load((neighborIndex
+      * 0x1 + 0x6800) << 2));\n    \n        dist = position - neighborPosition;\n
+      \   #ifndef FLUVIO_INDEX_GRID\n        distLenSq = dot(dist, dist);\n        if
+      (distLenSq >= solverData_KernelSize.y) continue;\n    #endif\n    \n        density
+      += neighborMass * Poly6Calculate(dist, solverData_KernelFactors.x, solverData_KernelSize.y);\n
+      \   }\n    \n    // Write to density/pressure\n    density = max(density, solverData_Fluid_MinimumDensity);\n
+      \   pressure = solverData_Fluid_GasConstant * (density - solverData_Fluid_Density);\n
+      \   densityPressure = float4(density, density, pressure, pressure);\n}\nvoid
+      Reap(float age, float lifetime, inout bool alive)\n{\n    if(age > lifetime)
+      { alive = false; }\n}\n\n\n\n[numthreads(NB_THREADS_PER_GROUP,1,1)]\nvoid CSMain(uint3
+      groupId          : SV_GroupID,\n            uint3 groupThreadId    : SV_GroupThreadID)\n{\n\tuint
+      id = groupThreadId.x + groupId.x * NB_THREADS_PER_GROUP + groupId.y * dispatchWidth
+      * NB_THREADS_PER_GROUP;\n\tuint index = id;\n\tif (id < nbMax)\n\t{\n#if VFX_USE_ALIVE_CURRENT\n\t\tbool
+      alive = (attributeBuffer.Load((index * 0x1 + 0xF000) << 2));\n\t\t\n\n\t\tif
+      (alive)\n\t\t{\n\t\t\tfloat lifetime = asfloat(attributeBuffer.Load((index *
+      0x1 + 0x0) << 2));\n\t\t\tfloat3 position = asfloat(attributeBuffer.Load3((index
+      * 0x4 + 0x800) << 2));\n\t\t\tfloat mass = asfloat(attributeBuffer.Load((index
+      * 0x1 + 0x6800) << 2));\n\t\t\tfloat3 oldPosition = asfloat(attributeBuffer.Load3((index
+      * 0x4 + 0x7000) << 2));\n\t\t\tfloat4 densityPressure = asfloat(attributeBuffer.Load4((index
+      * 0x4 + 0x9000) << 2));\n\t\t\tfloat age = asfloat(attributeBuffer.Load((index
+      * 0x1 + 0xF800) << 2));\n\t\t\t\n\n\t\t\t\n#if VFX_USE_OLDPOSITION_CURRENT\n\t\t\toldPosition
+      = position;\n#endif\n\t\t\t\n\t\t\t{\n\t\t\t    DensityPressure(index, position,
+      alive, mass,  /*inout */densityPressure, (float)0.38125, (float)7.625, (float)998.29,
+      (float)9.9829, (float)0.01, (float)0.3, (float)0.2, (float)0.728, (float)0,
+      solverData_Gravity_a, float4(0.38125,0.1453516,0.05541528,0), float4(9206.448,1554.828,43.08061,0));\n\t\t\t}\n\t\t\tReap(age,
+      lifetime,  /*inout */alive);\n\t\t\t\n\n\t\t\tif (alive)\n\t\t\t{\n\t\t\t\tattributeBuffer.Store3((index
+      * 0x4 + 0x7000) << 2,asuint(oldPosition));\n\t\t\t\tattributeBuffer.Store4((index
+      * 0x4 + 0x9000) << 2,asuint(densityPressure));\n\t\t\t\t\n\n#if VFX_HAS_INDIRECT_DRAW\n
+      \               uint indirectIndex = indirectBuffer.IncrementCounter();\n\t\t\t\tindirectBuffer[indirectIndex]
+      = index;\n#endif\n\t\t\t}\n\t\t\telse\n\t\t\t{\n\t\t\t\tattributeBuffer.Store((index
+      * 0x1 + 0xF000) << 2,uint(alive));\n\t\t\t\t\n\n\t\t\t\tuint deadIndex = deadListOut.IncrementCounter();\n\t\t\t\tdeadListOut[deadIndex]
+      = index;\n\t\t\t}\n\t\t}\n#else\n\t\tfloat lifetime = asfloat(attributeBuffer.Load((index
+      * 0x1 + 0x0) << 2));\n\t\tfloat3 position = asfloat(attributeBuffer.Load3((index
+      * 0x4 + 0x800) << 2));\n\t\tfloat mass = asfloat(attributeBuffer.Load((index
+      * 0x1 + 0x6800) << 2));\n\t\tfloat3 oldPosition = asfloat(attributeBuffer.Load3((index
+      * 0x4 + 0x7000) << 2));\n\t\tfloat4 densityPressure = asfloat(attributeBuffer.Load4((index
+      * 0x4 + 0x9000) << 2));\n\t\tbool alive = (attributeBuffer.Load((index * 0x1
+      + 0xF000) << 2));\n\t\tfloat age = asfloat(attributeBuffer.Load((index * 0x1
+      + 0xF800) << 2));\n\t\t\n\n\t\t\n#if VFX_USE_OLDPOSITION_CURRENT\n\t\toldPosition
+      = position;\n#endif\n\t\t\n\t\t{\n\t\t    DensityPressure(index, position, alive,
+      mass,  /*inout */densityPressure, (float)0.38125, (float)7.625, (float)998.29,
+      (float)9.9829, (float)0.01, (float)0.3, (float)0.2, (float)0.728, (float)0,
+      solverData_Gravity_a, float4(0.38125,0.1453516,0.05541528,0), float4(9206.448,1554.828,43.08061,0));\n\t\t}\n\t\tReap(age,
+      lifetime,  /*inout */alive);\n\t\t\n\n\t\tattributeBuffer.Store3((index * 0x4
+      + 0x7000) << 2,asuint(oldPosition));\n\t\tattributeBuffer.Store4((index * 0x4
+      + 0x9000) << 2,asuint(densityPressure));\n\t\tattributeBuffer.Store((index *
+      0x1 + 0xF000) << 2,uint(alive));\n\t\t\n\n#if VFX_HAS_INDIRECT_DRAW\n        uint
+      indirectIndex = indirectBuffer.IncrementCounter();\n\t\tindirectBuffer[indirectIndex]
+      = index;\n#endif\n#endif\n\t}\n}\n"
+  - compute: 1
+    name: '[System 1]F Update'
+    source: "#pragma kernel CSMain\n#include \"HLSLSupport.cginc\"\n#define NB_THREADS_PER_GROUP
+      64\n#define VFX_USE_LIFETIME_CURRENT 1\n#define VFX_USE_POSITION_CURRENT 1\n#define
+      VFX_USE_MASS_CURRENT 1\n#define VFX_USE_OLDPOSITION_CURRENT 1\n#define VFX_USE_DENSITYPRESSURE_CURRENT
+      1\n#define VFX_USE_NORMAL_CURRENT 1\n#define VFX_USE_ALIVE_CURRENT 1\n#define
+      VFX_USE_AGE_CURRENT 1\n#define VFX_HAS_INDIRECT_DRAW 1\n#define VFX_WORLD_SPACE
+      1\n\n\nCBUFFER_START(parameters)\n    float3 solverData_Gravity_a;\n    uint
+      PADDING_0;\nCBUFFER_END\n\n\n#include \"Packages/com.unity.visualeffectgraph/Shaders/Common/VFXCommonCompute.cginc\"\n#include
+      \"Packages/com.unity.visualeffectgraph/Shaders/VFXCommon.cginc\"\n#include \"Packages/com.thinksquirrel.fluviofx/Shaders/FluvioCompute.cginc\"\n\n\n\nRWByteAddressBuffer
+      attributeBuffer;\n\n#if VFX_USE_ALIVE_CURRENT\nRWStructuredBuffer<uint> deadListOut;\n#endif\n\n#if
+      VFX_HAS_INDIRECT_DRAW\nRWStructuredBuffer<uint> indirectBuffer;\n#endif\n\nCBUFFER_START(updateParams)\n
+      \   uint nbMax;\n\tuint dispatchWidth;\n\tuint systemSeed;\nCBUFFER_END\n\nvoid
+      SurfaceNormal(uint index, float3 position, bool alive, float mass, float4 densityPressure,
+      inout float4 normal, float solverData_Fluid_SmoothingDistance, float solverData_Fluid_ParticleMass,
+      float solverData_Fluid_Density, float solverData_Fluid_MinimumDensity, float
+      solverData_Fluid_GasConstant, float solverData_Fluid_Viscosity, float solverData_Fluid_TurbulenceProbability,
+      float solverData_Fluid_SurfaceTension, float solverData_Fluid_BuoyancyCoefficient,
+      float3 solverData_Gravity, float4 solverData_KernelSize, float4 solverData_KernelFactors)\n{\n
+      \   \n    float3 dist;\n    float3 n = 0;\n    #ifdef FLUVIO_INDEX_GRID\n    uint
+      neighborIndex;\n    for (uint j = 0; j < neighborCount; ++j)\n    {\n        neighborIndex
+      = GetNeighborIndex(solverData_Tex, solverData_TexSize, index, j);\n    #else\n
+      \   float distLenSq;\n    for (uint neighborIndex = 0; neighborIndex < nbMax;
+      ++neighborIndex)\n    {\n        if (index == neighborIndex) continue;\n        bool
+      neighborAlive = (attributeBuffer.Load((neighborIndex * 0x1 + 0xF000) << 2));\n
+      \       if (!neighborAlive) continue;\n    #endif\n    \n        float3 neighborPosition
+      = asfloat(attributeBuffer.Load3((neighborIndex * 0x4 + 0x800) << 2));\n        float
+      neighborMass = asfloat(attributeBuffer.Load((neighborIndex * 0x1 + 0x6800) <<
+      2));\n        float4 neighborDensityPressure = asfloat(attributeBuffer.Load4((neighborIndex
+      * 0x4 + 0x9000) << 2));\n    \n        dist = position - neighborPosition;\n
+      \   #ifndef FLUVIO_INDEX_GRID\n        distLenSq = dot(dist, dist);\n        if
+      (distLenSq >= solverData_KernelSize.y) continue;\n    #endif\n    \n        n
+      += (neighborMass / neighborDensityPressure.y) * Poly6CalculateGradient(dist,
+      solverData_KernelFactors.x, solverData_KernelSize.y);\n    }\n    \n    // Write
+      to normal texture\n    float normalLen = length(n);\n    normal = float4(n /
+      normalLen, normalLen);\n}\nvoid Reap(float age, float lifetime, inout bool alive)\n{\n
+      \   if(age > lifetime) { alive = false; }\n}\n\n\n\n[numthreads(NB_THREADS_PER_GROUP,1,1)]\nvoid
+      CSMain(uint3 groupId          : SV_GroupID,\n            uint3 groupThreadId
+      \   : SV_GroupThreadID)\n{\n\tuint id = groupThreadId.x + groupId.x * NB_THREADS_PER_GROUP
+      + groupId.y * dispatchWidth * NB_THREADS_PER_GROUP;\n\tuint index = id;\n\tif
+      (id < nbMax)\n\t{\n#if VFX_USE_ALIVE_CURRENT\n\t\tbool alive = (attributeBuffer.Load((index
+      * 0x1 + 0xF000) << 2));\n\t\t\n\n\t\tif (alive)\n\t\t{\n\t\t\tfloat lifetime
+      = asfloat(attributeBuffer.Load((index * 0x1 + 0x0) << 2));\n\t\t\tfloat3 position
+      = asfloat(attributeBuffer.Load3((index * 0x4 + 0x800) << 2));\n\t\t\tfloat mass
+      = asfloat(attributeBuffer.Load((index * 0x1 + 0x6800) << 2));\n\t\t\tfloat3
+      oldPosition = asfloat(attributeBuffer.Load3((index * 0x4 + 0x7000) << 2));\n\t\t\tfloat4
+      densityPressure = asfloat(attributeBuffer.Load4((index * 0x4 + 0x9000) << 2));\n\t\t\tfloat4
+      normal = asfloat(attributeBuffer.Load4((index * 0x4 + 0xB000) << 2));\n\t\t\tfloat
+      age = asfloat(attributeBuffer.Load((index * 0x1 + 0xF800) << 2));\n\t\t\t\n\n\t\t\t\n#if
+      VFX_USE_OLDPOSITION_CURRENT\n\t\t\toldPosition = position;\n#endif\n\t\t\t\n\t\t\t{\n\t\t\t
+      \   SurfaceNormal(index, position, alive, mass, densityPressure,  /*inout */normal,
+      (float)0.38125, (float)7.625, (float)998.29, (float)9.9829, (float)0.01, (float)0.3,
+      (float)0.2, (float)0.728, (float)0, solverData_Gravity_a, float4(0.38125,0.1453516,0.05541528,0),
+      float4(9206.448,1554.828,43.08061,0));\n\t\t\t}\n\t\t\tReap(age, lifetime,  /*inout
+      */alive);\n\t\t\t\n\n\t\t\tif (alive)\n\t\t\t{\n\t\t\t\tattributeBuffer.Store3((index
+      * 0x4 + 0x7000) << 2,asuint(oldPosition));\n\t\t\t\tattributeBuffer.Store4((index
+      * 0x4 + 0xB000) << 2,asuint(normal));\n\t\t\t\t\n\n#if VFX_HAS_INDIRECT_DRAW\n
+      \               uint indirectIndex = indirectBuffer.IncrementCounter();\n\t\t\t\tindirectBuffer[indirectIndex]
+      = index;\n#endif\n\t\t\t}\n\t\t\telse\n\t\t\t{\n\t\t\t\tattributeBuffer.Store((index
+      * 0x1 + 0xF000) << 2,uint(alive));\n\t\t\t\t\n\n\t\t\t\tuint deadIndex = deadListOut.IncrementCounter();\n\t\t\t\tdeadListOut[deadIndex]
+      = index;\n\t\t\t}\n\t\t}\n#else\n\t\tfloat lifetime = asfloat(attributeBuffer.Load((index
+      * 0x1 + 0x0) << 2));\n\t\tfloat3 position = asfloat(attributeBuffer.Load3((index
+      * 0x4 + 0x800) << 2));\n\t\tfloat mass = asfloat(attributeBuffer.Load((index
+      * 0x1 + 0x6800) << 2));\n\t\tfloat3 oldPosition = asfloat(attributeBuffer.Load3((index
+      * 0x4 + 0x7000) << 2));\n\t\tfloat4 densityPressure = asfloat(attributeBuffer.Load4((index
+      * 0x4 + 0x9000) << 2));\n\t\tfloat4 normal = asfloat(attributeBuffer.Load4((index
+      * 0x4 + 0xB000) << 2));\n\t\tbool alive = (attributeBuffer.Load((index * 0x1
+      + 0xF000) << 2));\n\t\tfloat age = asfloat(attributeBuffer.Load((index * 0x1
+      + 0xF800) << 2));\n\t\t\n\n\t\t\n#if VFX_USE_OLDPOSITION_CURRENT\n\t\toldPosition
+      = position;\n#endif\n\t\t\n\t\t{\n\t\t    SurfaceNormal(index, position, alive,
+      mass, densityPressure,  /*inout */normal, (float)0.38125, (float)7.625, (float)998.29,
+      (float)9.9829, (float)0.01, (float)0.3, (float)0.2, (float)0.728, (float)0,
+      solverData_Gravity_a, float4(0.38125,0.1453516,0.05541528,0), float4(9206.448,1554.828,43.08061,0));\n\t\t}\n\t\tReap(age,
+      lifetime,  /*inout */alive);\n\t\t\n\n\t\tattributeBuffer.Store3((index * 0x4
+      + 0x7000) << 2,asuint(oldPosition));\n\t\tattributeBuffer.Store4((index * 0x4
+      + 0xB000) << 2,asuint(normal));\n\t\tattributeBuffer.Store((index * 0x1 + 0xF000)
+      << 2,uint(alive));\n\t\t\n\n#if VFX_HAS_INDIRECT_DRAW\n        uint indirectIndex
+      = indirectBuffer.IncrementCounter();\n\t\tindirectBuffer[indirectIndex] = index;\n#endif\n#endif\n\t}\n}\n"
+  - compute: 1
+    name: '[System 1]G Update'
+    source: "#pragma kernel CSMain\n#include \"HLSLSupport.cginc\"\n#define NB_THREADS_PER_GROUP
+      64\n#define VFX_USE_LIFETIME_CURRENT 1\n#define VFX_USE_POSITION_CURRENT 1\n#define
+      VFX_USE_VELOCITY_CURRENT 1\n#define VFX_USE_FORCE_CURRENT 1\n#define VFX_USE_MASS_CURRENT
+      1\n#define VFX_USE_OLDPOSITION_CURRENT 1\n#define VFX_USE_DENSITYPRESSURE_CURRENT
+      1\n#define VFX_USE_NORMAL_CURRENT 1\n#define VFX_USE_VORTICITYTURBULENCE_CURRENT
+      1\n#define VFX_USE_ALIVE_CURRENT 1\n#define VFX_USE_AGE_CURRENT 1\n#define VFX_HAS_INDIRECT_DRAW
+      1\n#define VFX_WORLD_SPACE 1\n\n\nCBUFFER_START(parameters)\n    float3 solverData_Gravity_a;\n
+      \   uint PADDING_0;\nCBUFFER_END\n\n\n#include \"Packages/com.unity.visualeffectgraph/Shaders/Common/VFXCommonCompute.cginc\"\n#include
+      \"Packages/com.unity.visualeffectgraph/Shaders/VFXCommon.cginc\"\n#include \"Packages/com.thinksquirrel.fluviofx/Shaders/FluvioCompute.cginc\"\n\n\n\nRWByteAddressBuffer
+      attributeBuffer;\n\n#if VFX_USE_ALIVE_CURRENT\nRWStructuredBuffer<uint> deadListOut;\n#endif\n\n#if
+      VFX_HAS_INDIRECT_DRAW\nRWStructuredBuffer<uint> indirectBuffer;\n#endif\n\nCBUFFER_START(updateParams)\n
+      \   uint nbMax;\n\tuint dispatchWidth;\n\tuint systemSeed;\nCBUFFER_END\n\nvoid
+      CalculateForces_C4E51299(uint index, float3 position, bool alive, float3 velocity,
+      float mass, float4 densityPressure, float4 normal, inout float4 vorticityTurbulence,
+      inout float3 force, float solverData_Fluid_SmoothingDistance, float solverData_Fluid_ParticleMass,
+      float solverData_Fluid_Density, float solverData_Fluid_MinimumDensity, float
+      solverData_Fluid_GasConstant, float solverData_Fluid_Viscosity, float solverData_Fluid_TurbulenceProbability,
+      float solverData_Fluid_SurfaceTension, float solverData_Fluid_BuoyancyCoefficient,
+      float3 solverData_Gravity, float4 solverData_KernelSize, float4 solverData_KernelFactors)
+      /*SurfaceTension:True Turbulence:True Gravity:True BuoyancyForce:True Collision:True
+      */\n{\n    \n    #define FLUVIO_SURFACE_TENSION_ENABLED 1\n    #define FLUVIO_TURBULENCE_ENABLED
+      1\n    #define FLUVIO_GRAVITY_ENABLED 1\n    #define FLUVIO_BUOYANCY_FORCE_ENABLED
+      1\n    #define FLUVIO_COLLISION_ENABLED 1\n    float3 dist, f, invNeighborDensity;\n
+      \   float scalar;\n    \n    #ifdef FLUVIO_INDEX_GRID\n    uint neighborIndex;\n
+      \   for (uint j = 0; j < neighborCount; ++j)\n    {\n        neighborIndex =
+      GetNeighborIndex(solverData_Tex, solverData_TexSize, index, j);\n    #else\n
+      \   float distLenSq;\n    for (uint neighborIndex = 0; neighborIndex < nbMax;
+      ++neighborIndex)\n    {\n        if (index == neighborIndex) continue;\n        bool
+      neighborAlive = (attributeBuffer.Load((neighborIndex * 0x1 + 0xF000) << 2));\n
+      \       if (!neighborAlive) continue;\n    #endif\n    \n        float3 neighborPosition
+      = asfloat(attributeBuffer.Load3((neighborIndex * 0x4 + 0x800) << 2));\n        float
+      neighborMass = asfloat(attributeBuffer.Load((neighborIndex * 0x1 + 0x6800) <<
+      2));\n        float3 neighborVelocity = asfloat(attributeBuffer.Load3((neighborIndex
+      * 0x4 + 0x2800) << 2));\n        float4 neighborDensityPressure = asfloat(attributeBuffer.Load4((neighborIndex
+      * 0x4 + 0x9000) << 2));\n    \n        dist = position - neighborPosition;\n
+      \   #ifndef FLUVIO_INDEX_GRID\n        distLenSq = dot(dist, dist);\n        if
+      (distLenSq >= solverData_KernelSize.y) continue;\n    #endif\n    \n    #ifdef
+      FLUVIO_COLLISION_ENABLED\n        invNeighborDensity = 1.0f / neighborDensityPressure.x;\n
+      \   #else\n        invNeighborDensity = 1.0f / neighborDensityPressure.y;\n
+      \   #endif\n    \n        // Pressure term\n    #ifdef FLUVIO_COLLISION_ENABLED\n
+      \       scalar = neighborMass\n            * (densityPressure.z + neighborDensityPressure.z)
+      / (neighborDensityPressure.x * 2.0f);\n    #else\n        scalar = neighborMass\n
+      \           * (densityPressure.w + neighborDensityPressure.w) / (neighborDensityPressure.y
+      * 2.0f);\n    #endif\n    \n        f = SpikyCalculateGradient(dist, solverData_KernelFactors.y,
+      solverData_KernelSize.x);\n        f *= scalar;\n    \n        force -= f;\n
+      \   \n        // Viscosity term\n        scalar = neighborMass\n            *
+      ViscosityCalculateLaplacian(\n                dist,\n                solverData_KernelFactors.z,\n
+      \               solverData_KernelSize.z,\n                solverData_KernelSize.x)\n
+      \           * invNeighborDensity;\n    \n        f = neighborVelocity - velocity;\n
+      \       f *= scalar * solverData_Fluid_Viscosity;\n    \n        force += f;\n
+      \   \n    #ifdef FLUVIO_SURFACE_TENSION_ENABLED\n        // Surface tension
+      term (external)\n        if (normal.w > FLUVIO_PI && normal.w < FLUVIO_PI *
+      2.0f)\n        {\n            scalar = neighborMass\n                * Poly6CalculateLaplacian(dist,
+      solverData_KernelFactors.x, solverData_KernelSize.y)\n                * solverData_Fluid_SurfaceTension\n
+      \               * 1.0f / neighborDensityPressure.y;\n    \n            f = normal.xyz
+      * scalar;\n    \n            force -= f;\n        }\n    #endif\n    \n    #ifdef
+      FLUVIO_TURBULENCE_ENABLED\n    // Turbulence term (external)\n    float4 neighborVorticityTurbulence
+      = asfloat(attributeBuffer.Load4((neighborIndex * 0x4 + 0xD000) << 2));\n    if
+      (vorticityTurbulence.w >= solverData_Fluid_TurbulenceProbability && neighborVorticityTurbulence.w
+      < solverData_Fluid_TurbulenceProbability)\n    {\n        scalar = neighborMass\n
+      \           * ViscosityCalculateLaplacian(\n                dist,\n                solverData_KernelFactors.z,\n
+      \               solverData_KernelSize.z,\n                solverData_KernelSize.x)\n
+      \           * invNeighborDensity;\n    \n        vorticityTurbulence = scalar
+      * (neighborVorticityTurbulence - vorticityTurbulence);\n        f = clamp_len(FLUVIO_TURBULENCE_CONSTANT
+      * cross(dist, vorticityTurbulence.xyz), FLUVIO_MAX_SQR_VELOCITY_CHANGE * mass);\n
+      \   \n        force += f;\n    }\n    #endif\n    }\n    \n    #ifdef FLUVIO_GRAVITY_ENABLED\n
+      \   // Gravity term (external)\n    force += solverData_Gravity;\n    #endif\n
+      \   \n    #ifdef FLUVIO_BUOYANCY_FORCE_ENABLED\n    // Buoyancy term (external)\n
+      \   #ifdef FLUVIO_COLLISION_ENABLED\n    force += solverData_Gravity * solverData_Fluid_BuoyancyCoefficient
+      * (densityPressure.x - solverData_Fluid_Density);\n    #else\n    force += solverData_Gravity
+      * solverData_Fluid_BuoyancyCoefficient * (densityPressure.y - solverData_Fluid_Density);\n
+      \   #endif\n    #endif\n}\nvoid Reap(float age, float lifetime, inout bool alive)\n{\n
+      \   if(age > lifetime) { alive = false; }\n}\n\n\n\n[numthreads(NB_THREADS_PER_GROUP,1,1)]\nvoid
+      CSMain(uint3 groupId          : SV_GroupID,\n            uint3 groupThreadId
+      \   : SV_GroupThreadID)\n{\n\tuint id = groupThreadId.x + groupId.x * NB_THREADS_PER_GROUP
+      + groupId.y * dispatchWidth * NB_THREADS_PER_GROUP;\n\tuint index = id;\n\tif
+      (id < nbMax)\n\t{\n#if VFX_USE_ALIVE_CURRENT\n\t\tbool alive = (attributeBuffer.Load((index
+      * 0x1 + 0xF000) << 2));\n\t\t\n\n\t\tif (alive)\n\t\t{\n\t\t\tfloat lifetime
+      = asfloat(attributeBuffer.Load((index * 0x1 + 0x0) << 2));\n\t\t\tfloat3 position
+      = asfloat(attributeBuffer.Load3((index * 0x4 + 0x800) << 2));\n\t\t\tfloat3
+      velocity = asfloat(attributeBuffer.Load3((index * 0x4 + 0x2800) << 2));\n\t\t\tfloat3
+      force = asfloat(attributeBuffer.Load3((index * 0x4 + 0x4800) << 2));\n\t\t\tfloat
+      mass = asfloat(attributeBuffer.Load((index * 0x1 + 0x6800) << 2));\n\t\t\tfloat3
+      oldPosition = asfloat(attributeBuffer.Load3((index * 0x4 + 0x7000) << 2));\n\t\t\tfloat4
+      densityPressure = asfloat(attributeBuffer.Load4((index * 0x4 + 0x9000) << 2));\n\t\t\tfloat4
+      normal = asfloat(attributeBuffer.Load4((index * 0x4 + 0xB000) << 2));\n\t\t\tfloat4
+      vorticityTurbulence = asfloat(attributeBuffer.Load4((index * 0x4 + 0xD000) <<
+      2));\n\t\t\tfloat age = asfloat(attributeBuffer.Load((index * 0x1 + 0xF800)
+      << 2));\n\t\t\t\n\n\t\t\t\n#if VFX_USE_OLDPOSITION_CURRENT\n\t\t\toldPosition
+      = position;\n#endif\n\t\t\t\n\t\t\t{\n\t\t\t    CalculateForces_C4E51299(index,
+      position, alive, velocity, mass, densityPressure, normal,  /*inout */vorticityTurbulence,
+      \ /*inout */force, (float)0.38125, (float)7.625, (float)998.29, (float)9.9829,
+      (float)0.01, (float)0.3, (float)0.2, (float)0.728, (float)0, solverData_Gravity_a,
+      float4(0.38125,0.1453516,0.05541528,0), float4(9206.448,1554.828,43.08061,0));\n\t\t\t}\n\t\t\tReap(age,
+      lifetime,  /*inout */alive);\n\t\t\t\n\n\t\t\tif (alive)\n\t\t\t{\n\t\t\t\tattributeBuffer.Store3((index
+      * 0x4 + 0x4800) << 2,asuint(force));\n\t\t\t\tattributeBuffer.Store3((index
+      * 0x4 + 0x7000) << 2,asuint(oldPosition));\n\t\t\t\tattributeBuffer.Store4((index
+      * 0x4 + 0xD000) << 2,asuint(vorticityTurbulence));\n\t\t\t\t\n\n#if VFX_HAS_INDIRECT_DRAW\n
+      \               uint indirectIndex = indirectBuffer.IncrementCounter();\n\t\t\t\tindirectBuffer[indirectIndex]
+      = index;\n#endif\n\t\t\t}\n\t\t\telse\n\t\t\t{\n\t\t\t\tattributeBuffer.Store((index
+      * 0x1 + 0xF000) << 2,uint(alive));\n\t\t\t\t\n\n\t\t\t\tuint deadIndex = deadListOut.IncrementCounter();\n\t\t\t\tdeadListOut[deadIndex]
+      = index;\n\t\t\t}\n\t\t}\n#else\n\t\tfloat lifetime = asfloat(attributeBuffer.Load((index
+      * 0x1 + 0x0) << 2));\n\t\tfloat3 position = asfloat(attributeBuffer.Load3((index
+      * 0x4 + 0x800) << 2));\n\t\tfloat3 velocity = asfloat(attributeBuffer.Load3((index
+      * 0x4 + 0x2800) << 2));\n\t\tfloat3 force = asfloat(attributeBuffer.Load3((index
+      * 0x4 + 0x4800) << 2));\n\t\tfloat mass = asfloat(attributeBuffer.Load((index
+      * 0x1 + 0x6800) << 2));\n\t\tfloat3 oldPosition = asfloat(attributeBuffer.Load3((index
+      * 0x4 + 0x7000) << 2));\n\t\tfloat4 densityPressure = asfloat(attributeBuffer.Load4((index
+      * 0x4 + 0x9000) << 2));\n\t\tfloat4 normal = asfloat(attributeBuffer.Load4((index
+      * 0x4 + 0xB000) << 2));\n\t\tfloat4 vorticityTurbulence = asfloat(attributeBuffer.Load4((index
+      * 0x4 + 0xD000) << 2));\n\t\tbool alive = (attributeBuffer.Load((index * 0x1
+      + 0xF000) << 2));\n\t\tfloat age = asfloat(attributeBuffer.Load((index * 0x1
+      + 0xF800) << 2));\n\t\t\n\n\t\t\n#if VFX_USE_OLDPOSITION_CURRENT\n\t\toldPosition
+      = position;\n#endif\n\t\t\n\t\t{\n\t\t    CalculateForces_C4E51299(index, position,
+      alive, velocity, mass, densityPressure, normal,  /*inout */vorticityTurbulence,
+      \ /*inout */force, (float)0.38125, (float)7.625, (float)998.29, (float)9.9829,
+      (float)0.01, (float)0.3, (float)0.2, (float)0.728, (float)0, solverData_Gravity_a,
+      float4(0.38125,0.1453516,0.05541528,0), float4(9206.448,1554.828,43.08061,0));\n\t\t}\n\t\tReap(age,
+      lifetime,  /*inout */alive);\n\t\t\n\n\t\tattributeBuffer.Store3((index * 0x4
+      + 0x4800) << 2,asuint(force));\n\t\tattributeBuffer.Store3((index * 0x4 + 0x7000)
+      << 2,asuint(oldPosition));\n\t\tattributeBuffer.Store4((index * 0x4 + 0xD000)
+      << 2,asuint(vorticityTurbulence));\n\t\tattributeBuffer.Store((index * 0x1 +
+      0xF000) << 2,uint(alive));\n\t\t\n\n#if VFX_HAS_INDIRECT_DRAW\n        uint
+      indirectIndex = indirectBuffer.IncrementCounter();\n\t\tindirectBuffer[indirectIndex]
+      = index;\n#endif\n#endif\n\t}\n}\n"
+  - compute: 1
+    name: '[System 1]H Update'
+    source: "#pragma kernel CSMain\n#include \"HLSLSupport.cginc\"\n#define NB_THREADS_PER_GROUP
+      64\n#define VFX_USE_LIFETIME_CURRENT 1\n#define VFX_USE_POSITION_CURRENT 1\n#define
+      VFX_USE_VELOCITY_CURRENT 1\n#define VFX_USE_FORCE_CURRENT 1\n#define VFX_USE_MASS_CURRENT
+      1\n#define VFX_USE_OLDPOSITION_CURRENT 1\n#define VFX_USE_ALIVE_CURRENT 1\n#define
+      VFX_USE_AGE_CURRENT 1\n#define VFX_HAS_INDIRECT_DRAW 1\n#define VFX_WORLD_SPACE
+      1\n\n\nCBUFFER_START(parameters)\n    float3 solverData_Gravity_a;\n    float
+      dt_a;\nCBUFFER_END\n\n\n#include \"Packages/com.unity.visualeffectgraph/Shaders/Common/VFXCommonCompute.cginc\"\n#include
+      \"Packages/com.unity.visualeffectgraph/Shaders/VFXCommon.cginc\"\n#include \"Packages/com.thinksquirrel.fluviofx/Shaders/FluvioCompute.cginc\"\n\n\n\nRWByteAddressBuffer
+      attributeBuffer;\n\n#if VFX_USE_ALIVE_CURRENT\nRWStructuredBuffer<uint> deadListOut;\n#endif\n\n#if
+      VFX_HAS_INDIRECT_DRAW\nRWStructuredBuffer<uint> indirectBuffer;\n#endif\n\nCBUFFER_START(updateParams)\n
+      \   uint nbMax;\n\tuint dispatchWidth;\n\tuint systemSeed;\nCBUFFER_END\n\nvoid
+      IntegrateParticles_0(uint index, inout float3 position, bool alive, float mass,
+      float3 force, inout float3 velocity, float3 oldPosition, float solverData_Fluid_SmoothingDistance,
+      float solverData_Fluid_ParticleMass, float solverData_Fluid_Density, float solverData_Fluid_MinimumDensity,
+      float solverData_Fluid_GasConstant, float solverData_Fluid_Viscosity, float
+      solverData_Fluid_TurbulenceProbability, float solverData_Fluid_SurfaceTension,
+      float solverData_Fluid_BuoyancyCoefficient, float3 solverData_Gravity, float4
+      solverData_KernelSize, float4 solverData_KernelFactors, float dt) /*IntegrationMode:Verlet
+      */\n{\n    \n    position += velocity * dt;\n    \n    float invMass = 1.0f
+      / mass;\n    float3 acceleration = force * invMass;\n    float3 v = dt * acceleration;\n
+      \   \n    // Discard excessive velocities\n    if (any(isnan(v) || isinf(v))
+      || dot(v, v) > FLUVIO_MAX_SQR_VELOCITY_CHANGE)\n    {\n        v = 0;\n    }\n
+      \   \n    \n    float3 x = position;\n    position = (x * 2) - oldPosition +
+      (v * dt);\n    velocity += v;\n    \n}\nvoid Age(inout float age, float deltaTime)\n{\n
+      \   age += deltaTime;\n}\nvoid Reap(float age, float lifetime, inout bool alive)\n{\n
+      \   if(age > lifetime) { alive = false; }\n}\n\n\n\n[numthreads(NB_THREADS_PER_GROUP,1,1)]\nvoid
+      CSMain(uint3 groupId          : SV_GroupID,\n            uint3 groupThreadId
+      \   : SV_GroupThreadID)\n{\n\tuint id = groupThreadId.x + groupId.x * NB_THREADS_PER_GROUP
+      + groupId.y * dispatchWidth * NB_THREADS_PER_GROUP;\n\tuint index = id;\n\tif
+      (id < nbMax)\n\t{\n#if VFX_USE_ALIVE_CURRENT\n\t\tbool alive = (attributeBuffer.Load((index
+      * 0x1 + 0xF000) << 2));\n\t\t\n\n\t\tif (alive)\n\t\t{\n\t\t\tfloat lifetime
+      = asfloat(attributeBuffer.Load((index * 0x1 + 0x0) << 2));\n\t\t\tfloat3 position
+      = asfloat(attributeBuffer.Load3((index * 0x4 + 0x800) << 2));\n\t\t\tfloat3
+      velocity = asfloat(attributeBuffer.Load3((index * 0x4 + 0x2800) << 2));\n\t\t\tfloat3
+      force = asfloat(attributeBuffer.Load3((index * 0x4 + 0x4800) << 2));\n\t\t\tfloat
+      mass = asfloat(attributeBuffer.Load((index * 0x1 + 0x6800) << 2));\n\t\t\tfloat3
+      oldPosition = asfloat(attributeBuffer.Load3((index * 0x4 + 0x7000) << 2));\n\t\t\tfloat
+      age = asfloat(attributeBuffer.Load((index * 0x1 + 0xF800) << 2));\n\t\t\t\n\n\t\t\t\n#if
+      VFX_USE_OLDPOSITION_CURRENT\n\t\t\toldPosition = position;\n#endif\n\t\t\t\n\t\t\t{\n\t\t\t
+      \   IntegrateParticles_0(index,  /*inout */position, alive, mass, force,  /*inout
+      */velocity, oldPosition, (float)0.38125, (float)7.625, (float)998.29, (float)9.9829,
+      (float)0.01, (float)0.3, (float)0.2, (float)0.728, (float)0, solverData_Gravity_a,
+      float4(0.38125,0.1453516,0.05541528,0), float4(9206.448,1554.828,43.08061,0),
+      dt_a);\n\t\t\t}\n\t\t\tAge( /*inout */age, dt_a);\n\t\t\tReap(age, lifetime,
+      \ /*inout */alive);\n\t\t\t\n\n\t\t\tif (alive)\n\t\t\t{\n\t\t\t\tattributeBuffer.Store3((index
+      * 0x4 + 0x800) << 2,asuint(position));\n\t\t\t\tattributeBuffer.Store3((index
+      * 0x4 + 0x2800) << 2,asuint(velocity));\n\t\t\t\tattributeBuffer.Store3((index
+      * 0x4 + 0x7000) << 2,asuint(oldPosition));\n\t\t\t\tattributeBuffer.Store((index
+      * 0x1 + 0xF800) << 2,asuint(age));\n\t\t\t\t\n\n#if VFX_HAS_INDIRECT_DRAW\n
+      \               uint indirectIndex = indirectBuffer.IncrementCounter();\n\t\t\t\tindirectBuffer[indirectIndex]
+      = index;\n#endif\n\t\t\t}\n\t\t\telse\n\t\t\t{\n\t\t\t\tattributeBuffer.Store((index
+      * 0x1 + 0xF000) << 2,uint(alive));\n\t\t\t\t\n\n\t\t\t\tuint deadIndex = deadListOut.IncrementCounter();\n\t\t\t\tdeadListOut[deadIndex]
+      = index;\n\t\t\t}\n\t\t}\n#else\n\t\tfloat lifetime = asfloat(attributeBuffer.Load((index
+      * 0x1 + 0x0) << 2));\n\t\tfloat3 position = asfloat(attributeBuffer.Load3((index
+      * 0x4 + 0x800) << 2));\n\t\tfloat3 velocity = asfloat(attributeBuffer.Load3((index
+      * 0x4 + 0x2800) << 2));\n\t\tfloat3 force = asfloat(attributeBuffer.Load3((index
+      * 0x4 + 0x4800) << 2));\n\t\tfloat mass = asfloat(attributeBuffer.Load((index
+      * 0x1 + 0x6800) << 2));\n\t\tfloat3 oldPosition = asfloat(attributeBuffer.Load3((index
+      * 0x4 + 0x7000) << 2));\n\t\tbool alive = (attributeBuffer.Load((index * 0x1
+      + 0xF000) << 2));\n\t\tfloat age = asfloat(attributeBuffer.Load((index * 0x1
+      + 0xF800) << 2));\n\t\t\n\n\t\t\n#if VFX_USE_OLDPOSITION_CURRENT\n\t\toldPosition
+      = position;\n#endif\n\t\t\n\t\t{\n\t\t    IntegrateParticles_0(index,  /*inout
+      */position, alive, mass, force,  /*inout */velocity, oldPosition, (float)0.38125,
+      (float)7.625, (float)998.29, (float)9.9829, (float)0.01, (float)0.3, (float)0.2,
+      (float)0.728, (float)0, solverData_Gravity_a, float4(0.38125,0.1453516,0.05541528,0),
+      float4(9206.448,1554.828,43.08061,0), dt_a);\n\t\t}\n\t\tAge( /*inout */age,
+      dt_a);\n\t\tReap(age, lifetime,  /*inout */alive);\n\t\t\n\n\t\tattributeBuffer.Store3((index
+      * 0x4 + 0x800) << 2,asuint(position));\n\t\tattributeBuffer.Store3((index *
+      0x4 + 0x2800) << 2,asuint(velocity));\n\t\tattributeBuffer.Store3((index * 0x4
+      + 0x7000) << 2,asuint(oldPosition));\n\t\tattributeBuffer.Store((index * 0x1
+      + 0xF000) << 2,uint(alive));\n\t\tattributeBuffer.Store((index * 0x1 + 0xF800)
+      << 2,asuint(age));\n\t\t\n\n#if VFX_HAS_INDIRECT_DRAW\n        uint indirectIndex
+      = indirectBuffer.IncrementCounter();\n\t\tindirectBuffer[indirectIndex] = index;\n#endif\n#endif\n\t}\n}\n"
+  - compute: 1
+    name: '[System 1]E Update'
+    source: "#pragma kernel CSMain\n#include \"HLSLSupport.cginc\"\n#define NB_THREADS_PER_GROUP
+      64\n#define VFX_USE_POSITION_CURRENT 1\n#define VFX_USE_OLDPOSITION_CURRENT
+      1\n#define VFX_HAS_INDIRECT_DRAW 1\n#define VFX_WORLD_SPACE 1\n\n\n\n#include
+      \"Packages/com.unity.visualeffectgraph/Shaders/Common/VFXCommonCompute.cginc\"\n#include
+      \"Packages/com.unity.visualeffectgraph/Shaders/VFXCommon.cginc\"\n\n\n\nRWByteAddressBuffer
+      attributeBuffer;\n\n#if VFX_USE_ALIVE_CURRENT\nRWStructuredBuffer<uint> deadListOut;\n#endif\n\n#if
+      VFX_HAS_INDIRECT_DRAW\nRWStructuredBuffer<uint> indirectBuffer;\n#endif\n\nCBUFFER_START(updateParams)\n
+      \   uint nbMax;\n\tuint dispatchWidth;\n\tuint systemSeed;\nCBUFFER_END\n\n\n\n[numthreads(NB_THREADS_PER_GROUP,1,1)]\nvoid
+      CSMain(uint3 groupId          : SV_GroupID,\n            uint3 groupThreadId
+      \   : SV_GroupThreadID)\n{\n\tuint id = groupThreadId.x + groupId.x * NB_THREADS_PER_GROUP
+      + groupId.y * dispatchWidth * NB_THREADS_PER_GROUP;\n\tuint index = id;\n\tif
+      (id < nbMax)\n\t{\n#if VFX_USE_ALIVE_CURRENT\n\t\t\n\t\tif (alive)\n\t\t{\n\t\t\tfloat3
+      position = asfloat(attributeBuffer.Load3((index * 0x4 + 0x800) << 2));\n\t\t\tfloat3
+      oldPosition = asfloat(attributeBuffer.Load3((index * 0x4 + 0x7000) << 2));\n\t\t\t\n\n\t\t\t\n#if
+      VFX_USE_OLDPOSITION_CURRENT\n\t\t\toldPosition = position;\n#endif\n\t\t\t\n\t\t\t\n\t\t\tif
+      (alive)\n\t\t\t{\n\t\t\t\tattributeBuffer.Store3((index * 0x4 + 0x7000) << 2,asuint(oldPosition));\n\t\t\t\t\n\n#if
+      VFX_HAS_INDIRECT_DRAW\n                uint indirectIndex = indirectBuffer.IncrementCounter();\n\t\t\t\tindirectBuffer[indirectIndex]
+      = index;\n#endif\n\t\t\t}\n\t\t\telse\n\t\t\t{\n\t\t\t\t\n\t\t\t\tuint deadIndex
+      = deadListOut.IncrementCounter();\n\t\t\t\tdeadListOut[deadIndex] = index;\n\t\t\t}\n\t\t}\n#else\n\t\tfloat3
+      position = asfloat(attributeBuffer.Load3((index * 0x4 + 0x800) << 2));\n\t\tfloat3
+      oldPosition = asfloat(attributeBuffer.Load3((index * 0x4 + 0x7000) << 2));\n\t\t\n\n\t\t\n#if
+      VFX_USE_OLDPOSITION_CURRENT\n\t\toldPosition = position;\n#endif\n\t\t\n\t\t\n\t\tattributeBuffer.Store3((index
+      * 0x4 + 0x7000) << 2,asuint(oldPosition));\n\t\t\n\n#if VFX_HAS_INDIRECT_DRAW\n
+      \       uint indirectIndex = indirectBuffer.IncrementCounter();\n\t\tindirectBuffer[indirectIndex]
+      = index;\n#endif\n#endif\n\t}\n}\n"
+  - compute: 1
     name: '[System 1]Initialize'
     source: "#pragma kernel CSMain\n#include \"HLSLSupport.cginc\"\n#define NB_THREADS_PER_GROUP
       64\n#define VFX_USE_LIFETIME_CURRENT 1\n#define VFX_USE_POSITION_CURRENT 1\n#define
@@ -811,12 +854,9 @@ VisualEffectResource:
       1\n#define VFX_USE_FORCE_CURRENT 1\n#define VFX_USE_MASS_CURRENT 1\n#define
       VFX_USE_OLDPOSITION_CURRENT 1\n#define VFX_USE_DENSITYPRESSURE_CURRENT 1\n#define
       VFX_USE_NORMAL_CURRENT 1\n#define VFX_USE_VORTICITYTURBULENCE_CURRENT 1\n#define
-      VFX_USE_ALIVE_CURRENT 1\n#define VFX_USE_AGE_CURRENT 1\n#define VFX_LOCAL_SPACE
-      1\n\n\nCBUFFER_START(parameters)\n    float3 Cone_center_b;\n    float Lifetime_a;\n
-      \   float3 Direction_c;\n    float Cone_radius0_b;\n    float2 sincosSlope_b;\n
-      \   float Cone_radius1_b;\n    float Cone_height_b;\n    float Cone_arc_b;\n
-      \   float fullConeHeight_b;\n    float Speed_c;\n    float DirectionBlend_c;\nCBUFFER_END\n\n\n#include
-      \"Packages/com.unity.visualeffectgraph/Shaders/Common/VFXCommonCompute.cginc\"\n#include
+      VFX_USE_ALIVE_CURRENT 1\n#define VFX_USE_AGE_CURRENT 1\n#define VFX_WORLD_SPACE
+      1\n\n\nCBUFFER_START(parameters)\n    float3 Cone_center_b;\n    uint PADDING_0;\n
+      \   float3 Direction_c;\n    uint PADDING_1;\nCBUFFER_END\n\n\n#include \"Packages/com.unity.visualeffectgraph/Shaders/Common/VFXCommonCompute.cginc\"\n#include
       \"Packages/com.unity.visualeffectgraph/Shaders/VFXCommon.cginc\"\n\n\n\nRWByteAddressBuffer
       attributeBuffer;\nByteAddressBuffer sourceAttributeBuffer;\n\nCBUFFER_START(initParams)\n#if
       !VFX_USE_SPAWNER_FROM_GPU\n    uint nbSpawned;\t\t\t\t\t// Numbers of particle
@@ -871,13 +911,14 @@ VisualEffectResource:
       = float4(0,0,0,0);\n        bool alive = (bool)true;\n        float age = (float)0;\n
       \       \n\n#if VFX_USE_PARTICLEID_CURRENT\n         particleId = particleIndex;\n#endif\n#if
       VFX_USE_SEED_CURRENT\n        seed = WangHash(particleIndex ^ systemSeed);\n#endif\n
-      \       \n        SetAttribute_F0142CB9( /*inout */lifetime, Lifetime_a);\n
-      \       {\n            PositionCone_267A9( /*inout */position,  /*inout */seed,
-      \ /*inout */direction, Cone_center_b, Cone_radius0_b, Cone_radius1_b, Cone_height_b,
-      Cone_arc_b, (float)1, fullConeHeight_b, sincosSlope_b);\n        }\n        VelocityDirection_18D(
-      /*inout */velocity,  /*inout */direction, Direction_c, Speed_c, DirectionBlend_c);\n
-      \       \n\n\n#if VFX_USE_ALIVE_CURRENT\n        if (alive)\n        {\n\t\t\tuint
-      deadIndex = deadListIn.DecrementCounter();\n            uint index = deadListIn[deadIndex];\n
+      \       \n        {\n            SetAttribute_F0142CB9( /*inout */lifetime,
+      (float)0.8);\n        }\n        {\n            PositionCone_267A9( /*inout
+      */position,  /*inout */seed,  /*inout */direction, Cone_center_b, (float)0.2,
+      (float)0.3, (float)0.2, (float)6.283185, (float)1, (float)0.6, float2(0.4472136,0.8944272));\n
+      \       }\n        {\n            VelocityDirection_18D( /*inout */velocity,
+      \ /*inout */direction, Direction_c, (float)5, (float)1);\n        }\n        \n\n\n#if
+      VFX_USE_ALIVE_CURRENT\n        if (alive)\n        {\n\t\t\tuint deadIndex =
+      deadListIn.DecrementCounter();\n            uint index = deadListIn[deadIndex];\n
       \           attributeBuffer.Store((index * 0x1 + 0x0) << 2,asuint(lifetime));\n
       \           attributeBuffer.Store3((index * 0x4 + 0x800) << 2,asuint(position));\n
       \           attributeBuffer.Store3((index * 0x4 + 0x2800) << 2,asuint(velocity));\n
@@ -901,93 +942,6 @@ VisualEffectResource:
       * 0x4 + 0xD000) << 2,asuint(vorticityTurbulence));\n        attributeBuffer.Store((index
       * 0x1 + 0xF000) << 2,uint(alive));\n        attributeBuffer.Store((index * 0x1
       + 0xF800) << 2,asuint(age));\n        \n\n#endif\n    }\n}\n"
-  - compute: 1
-    name: '[System 1]G Update'
-    source: "#pragma kernel CSMain\n#include \"HLSLSupport.cginc\"\n#define NB_THREADS_PER_GROUP
-      64\n#define VFX_USE_LIFETIME_CURRENT 1\n#define VFX_USE_POSITION_CURRENT 1\n#define
-      VFX_USE_VELOCITY_CURRENT 1\n#define VFX_USE_FORCE_CURRENT 1\n#define VFX_USE_MASS_CURRENT
-      1\n#define VFX_USE_OLDPOSITION_CURRENT 1\n#define VFX_USE_ALIVE_CURRENT 1\n#define
-      VFX_USE_AGE_CURRENT 1\n#define VFX_HAS_INDIRECT_DRAW 1\n#define VFX_LOCAL_SPACE
-      1\n\n\nCBUFFER_START(parameters)\n    float4 solverData_KernelSize_a;\n    float4
-      solverData_KernelFactors_a;\n    float3 solverData_Gravity_a;\n    float solverData_Fluid_SmoothingDistance_a;\n
-      \   float solverData_Fluid_ParticleMass_a;\n    float solverData_Fluid_Density_a;\n
-      \   float solverData_Fluid_MinimumDensity_a;\n    float solverData_Fluid_GasConstant_a;\n
-      \   float solverData_Fluid_Viscosity_a;\n    float solverData_Fluid_TurbulenceProbability_a;\n
-      \   float solverData_Fluid_SurfaceTension_a;\n    float solverData_Fluid_BuoyancyCoefficient_a;\n
-      \   float dt_a;\n    uint3 PADDING_0;\nCBUFFER_END\nTexture2D solverData_Tex_a;\nSamplerState
-      samplersolverData_Tex_a;\n\n\n#include \"Packages/com.unity.visualeffectgraph/Shaders/Common/VFXCommonCompute.cginc\"\n#include
-      \"Packages/com.unity.visualeffectgraph/Shaders/VFXCommon.cginc\"\n#include \"Packages/com.thinksquirrel.fluviofx/Shaders/FluvioCompute.cginc\"\n\n\n\nRWByteAddressBuffer
-      attributeBuffer;\n\n#if VFX_USE_ALIVE_CURRENT\nRWStructuredBuffer<uint> deadListOut;\n#endif\n\n#if
-      VFX_HAS_INDIRECT_DRAW\nRWStructuredBuffer<uint> indirectBuffer;\n#endif\n\nCBUFFER_START(updateParams)\n
-      \   uint nbMax;\n\tuint dispatchWidth;\n\tuint systemSeed;\nCBUFFER_END\n\nvoid
-      IntegrateParticles_0(uint index, inout float3 position, bool alive, float mass,
-      float3 force, inout float3 velocity, float3 oldPosition, float solverData_Fluid_SmoothingDistance,
-      float solverData_Fluid_ParticleMass, float solverData_Fluid_Density, float solverData_Fluid_MinimumDensity,
-      float solverData_Fluid_GasConstant, float solverData_Fluid_Viscosity, float
-      solverData_Fluid_TurbulenceProbability, float solverData_Fluid_SurfaceTension,
-      float solverData_Fluid_BuoyancyCoefficient, float3 solverData_Gravity, float4
-      solverData_KernelSize, float4 solverData_KernelFactors, VFXSampler2D solverData_Tex,
-      float2 solverData_TexSize, float dt) /*IntegrationMode:Verlet */\n{\n    \n
-      \   position += velocity * dt;\n    \n    float invMass = 1.0f / mass;\n    float3
-      acceleration = force * invMass;\n    float3 v = dt * acceleration;\n    \n    //
-      Discard excessive velocities\n    if (any(isnan(v) || isinf(v)) || dot(v, v)
-      > (FLUVIO_MAX_SQR_VELOCITY_CHANGE * solverData_KernelSize.w * solverData_KernelSize.w))\n
-      \   {\n        v = 0;\n    }\n    \n    \n    float3 x = position;\n    position
-      = (x * 2) - oldPosition + (v * dt);\n    velocity += v;\n    \n}\nvoid Age(inout
-      float age, float deltaTime)\n{\n    age += deltaTime;\n}\nvoid Reap(float age,
-      float lifetime, inout bool alive)\n{\n    if(age > lifetime) { alive = false;
-      }\n}\n\n\n\n[numthreads(NB_THREADS_PER_GROUP,1,1)]\nvoid CSMain(uint3 groupId
-      \         : SV_GroupID,\n            uint3 groupThreadId    : SV_GroupThreadID)\n{\n\tuint
-      id = groupThreadId.x + groupId.x * NB_THREADS_PER_GROUP + groupId.y * dispatchWidth
-      * NB_THREADS_PER_GROUP;\n\tuint index = id;\n\tif (id < nbMax)\n\t{\n#if VFX_USE_ALIVE_CURRENT\n\t\tbool
-      alive = (attributeBuffer.Load((index * 0x1 + 0xF000) << 2));\n\t\t\n\n\t\tif
-      (alive)\n\t\t{\n\t\t\tfloat lifetime = asfloat(attributeBuffer.Load((index *
-      0x1 + 0x0) << 2));\n\t\t\tfloat3 position = asfloat(attributeBuffer.Load3((index
-      * 0x4 + 0x800) << 2));\n\t\t\tfloat3 velocity = asfloat(attributeBuffer.Load3((index
-      * 0x4 + 0x2800) << 2));\n\t\t\tfloat3 force = asfloat(attributeBuffer.Load3((index
-      * 0x4 + 0x4800) << 2));\n\t\t\tfloat mass = asfloat(attributeBuffer.Load((index
-      * 0x1 + 0x6800) << 2));\n\t\t\tfloat3 oldPosition = asfloat(attributeBuffer.Load3((index
-      * 0x4 + 0x7000) << 2));\n\t\t\tfloat age = asfloat(attributeBuffer.Load((index
-      * 0x1 + 0xF800) << 2));\n\t\t\t\n\n\t\t\t\n#if VFX_USE_OLDPOSITION_CURRENT\n\t\t\toldPosition
-      = position;\n#endif\n\t\t\t\n\t\t\t{\n\t\t\t    IntegrateParticles_0(index,
-      \ /*inout */position, alive, mass, force,  /*inout */velocity, oldPosition,
-      solverData_Fluid_SmoothingDistance_a, solverData_Fluid_ParticleMass_a, solverData_Fluid_Density_a,
-      solverData_Fluid_MinimumDensity_a, solverData_Fluid_GasConstant_a, solverData_Fluid_Viscosity_a,
-      solverData_Fluid_TurbulenceProbability_a, solverData_Fluid_SurfaceTension_a,
-      solverData_Fluid_BuoyancyCoefficient_a, solverData_Gravity_a, solverData_KernelSize_a,
-      solverData_KernelFactors_a, GetVFXSampler(solverData_Tex_a, samplersolverData_Tex_a),
-      float2(0,0), dt_a);\n\t\t\t}\n\t\t\tAge( /*inout */age, dt_a);\n\t\t\tReap(age,
-      lifetime,  /*inout */alive);\n\t\t\t\n\n\t\t\tif (alive)\n\t\t\t{\n\t\t\t\tattributeBuffer.Store3((index
-      * 0x4 + 0x800) << 2,asuint(position));\n\t\t\t\tattributeBuffer.Store3((index
-      * 0x4 + 0x2800) << 2,asuint(velocity));\n\t\t\t\tattributeBuffer.Store3((index
-      * 0x4 + 0x7000) << 2,asuint(oldPosition));\n\t\t\t\tattributeBuffer.Store((index
-      * 0x1 + 0xF800) << 2,asuint(age));\n\t\t\t\t\n\n#if VFX_HAS_INDIRECT_DRAW\n
-      \               uint indirectIndex = indirectBuffer.IncrementCounter();\n\t\t\t\tindirectBuffer[indirectIndex]
-      = index;\n#endif\n\t\t\t}\n\t\t\telse\n\t\t\t{\n\t\t\t\tattributeBuffer.Store((index
-      * 0x1 + 0xF000) << 2,uint(alive));\n\t\t\t\t\n\n\t\t\t\tuint deadIndex = deadListOut.IncrementCounter();\n\t\t\t\tdeadListOut[deadIndex]
-      = index;\n\t\t\t}\n\t\t}\n#else\n\t\tfloat lifetime = asfloat(attributeBuffer.Load((index
-      * 0x1 + 0x0) << 2));\n\t\tfloat3 position = asfloat(attributeBuffer.Load3((index
-      * 0x4 + 0x800) << 2));\n\t\tfloat3 velocity = asfloat(attributeBuffer.Load3((index
-      * 0x4 + 0x2800) << 2));\n\t\tfloat3 force = asfloat(attributeBuffer.Load3((index
-      * 0x4 + 0x4800) << 2));\n\t\tfloat mass = asfloat(attributeBuffer.Load((index
-      * 0x1 + 0x6800) << 2));\n\t\tfloat3 oldPosition = asfloat(attributeBuffer.Load3((index
-      * 0x4 + 0x7000) << 2));\n\t\tbool alive = (attributeBuffer.Load((index * 0x1
-      + 0xF000) << 2));\n\t\tfloat age = asfloat(attributeBuffer.Load((index * 0x1
-      + 0xF800) << 2));\n\t\t\n\n\t\t\n#if VFX_USE_OLDPOSITION_CURRENT\n\t\toldPosition
-      = position;\n#endif\n\t\t\n\t\t{\n\t\t    IntegrateParticles_0(index,  /*inout
-      */position, alive, mass, force,  /*inout */velocity, oldPosition, solverData_Fluid_SmoothingDistance_a,
-      solverData_Fluid_ParticleMass_a, solverData_Fluid_Density_a, solverData_Fluid_MinimumDensity_a,
-      solverData_Fluid_GasConstant_a, solverData_Fluid_Viscosity_a, solverData_Fluid_TurbulenceProbability_a,
-      solverData_Fluid_SurfaceTension_a, solverData_Fluid_BuoyancyCoefficient_a, solverData_Gravity_a,
-      solverData_KernelSize_a, solverData_KernelFactors_a, GetVFXSampler(solverData_Tex_a,
-      samplersolverData_Tex_a), float2(0,0), dt_a);\n\t\t}\n\t\tAge( /*inout */age,
-      dt_a);\n\t\tReap(age, lifetime,  /*inout */alive);\n\t\t\n\n\t\tattributeBuffer.Store3((index
-      * 0x4 + 0x800) << 2,asuint(position));\n\t\tattributeBuffer.Store3((index *
-      0x4 + 0x2800) << 2,asuint(velocity));\n\t\tattributeBuffer.Store3((index * 0x4
-      + 0x7000) << 2,asuint(oldPosition));\n\t\tattributeBuffer.Store((index * 0x1
-      + 0xF000) << 2,uint(alive));\n\t\tattributeBuffer.Store((index * 0x1 + 0xF800)
-      << 2,asuint(age));\n\t\t\n\n#if VFX_HAS_INDIRECT_DRAW\n        uint indirectIndex
-      = indirectBuffer.IncrementCounter();\n\t\tindirectBuffer[indirectIndex] = index;\n#endif\n#endif\n\t}\n}\n"
   - compute: 0
     name: '[System 1]Quad Output'
     source: "Shader \"Hidden/VFX/System 1/Quad Output\"\n{\n\tSubShader\n\t{\t\n\t\tCull
@@ -1006,7 +960,7 @@ VisualEffectResource:
       1\n\t\t#define VFX_USE_SCALEY_CURRENT 1\n\t\t#define VFX_USE_SCALEZ_CURRENT
       1\n\t\t#define VFX_USE_AGE_CURRENT 1\n\t\t#define VFX_BLENDMODE_ALPHA 1\n\t\t#define
       VFX_HAS_INDIRECT_DRAW 1\n\t\t#define USE_DEAD_LIST_COUNT 1\n\t\t\n\t\t\n\t\t\n\t\t#define
-      VFX_LOCAL_SPACE 1\n\t\t\n\n\t\tCBUFFER_START(parameters)\n\t\t    float4 Alpha_b;\n\t\tCBUFFER_END\n\t\tTexture2D
+      VFX_WORLD_SPACE 1\n\t\t\n\n\t\tCBUFFER_START(parameters)\n\t\t    float4 Alpha_b;\n\t\tCBUFFER_END\n\t\tTexture2D
       mainTexture;\n\t\tSamplerState samplermainTexture;\n\t\t\n\n\t\t\n\t\t#define
       VFX_NEEDS_COLOR_INTERPOLATOR (VFX_USE_COLOR_CURRENT || VFX_USE_ALPHA_CURRENT)\n\t\t#define
       IS_TRANSPARENT_PARTICLE (!IS_OPAQUE_PARTICLE)\n\t\t\n\t\t#include \"Packages/com.unity.visualeffectgraph/Shaders/RenderPipeline/HDRP/VFXGlobalDefines.cginc\"\n\t\t\n\n\t\t\n\t\tByteAddressBuffer
@@ -1113,547 +1067,10 @@ VisualEffectResource:
       *= VFXGetTextureColor(VFX_SAMPLER(mainTexture),i);\n\t\t\t\to.color = VFXApplyFog(o.color,i);\n\t\t\t\tVFXClipFragmentColor(o.color.a,i);\n\t\t\t\treturn
       o;\n\t\t\t}\n\t\t\tENDHLSL\n\t\t}\n\t\t\n\n\t\t\n\t}\n}\n"
   - compute: 1
-    name: '[System 1]A Update'
-    source: "#pragma kernel CSMain\n#include \"HLSLSupport.cginc\"\n#define NB_THREADS_PER_GROUP
-      64\n#define VFX_USE_LIFETIME_CURRENT 1\n#define VFX_USE_POSITION_CURRENT 1\n#define
-      VFX_USE_FORCE_CURRENT 1\n#define VFX_USE_MASS_CURRENT 1\n#define VFX_USE_OLDPOSITION_CURRENT
-      1\n#define VFX_USE_ALIVE_CURRENT 1\n#define VFX_USE_AGE_CURRENT 1\n#define VFX_HAS_INDIRECT_DRAW
-      1\n#define VFX_LOCAL_SPACE 1\n\n\nCBUFFER_START(parameters)\n    float4 solverData_KernelSize_a;\n
-      \   float4 solverData_KernelFactors_a;\n    float3 solverData_Gravity_a;\n    float
-      solverData_Fluid_SmoothingDistance_a;\n    float solverData_Fluid_ParticleMass_a;\n
-      \   float solverData_Fluid_Density_a;\n    float solverData_Fluid_MinimumDensity_a;\n
-      \   float solverData_Fluid_GasConstant_a;\n    float solverData_Fluid_Viscosity_a;\n
-      \   float solverData_Fluid_TurbulenceProbability_a;\n    float solverData_Fluid_SurfaceTension_a;\n
-      \   float solverData_Fluid_BuoyancyCoefficient_a;\nCBUFFER_END\nTexture2D solverData_Tex_a;\nSamplerState
-      samplersolverData_Tex_a;\n\n\n#include \"Packages/com.unity.visualeffectgraph/Shaders/Common/VFXCommonCompute.cginc\"\n#include
-      \"Packages/com.unity.visualeffectgraph/Shaders/VFXCommon.cginc\"\n#include \"Packages/com.thinksquirrel.fluviofx/Shaders/FluvioCompute.cginc\"\n\n\n\nRWByteAddressBuffer
-      attributeBuffer;\n\n#if VFX_USE_ALIVE_CURRENT\nRWStructuredBuffer<uint> deadListOut;\n#endif\n\n#if
-      VFX_HAS_INDIRECT_DRAW\nRWStructuredBuffer<uint> indirectBuffer;\n#endif\n\nCBUFFER_START(updateParams)\n
-      \   uint nbMax;\n\tuint dispatchWidth;\n\tuint systemSeed;\nCBUFFER_END\n\nvoid
-      InitializeSolver(uint index, float3 position, inout float3 force, inout float
-      mass, inout float3 oldPosition, float solverData_Fluid_SmoothingDistance, float
-      solverData_Fluid_ParticleMass, float solverData_Fluid_Density, float solverData_Fluid_MinimumDensity,
-      float solverData_Fluid_GasConstant, float solverData_Fluid_Viscosity, float
-      solverData_Fluid_TurbulenceProbability, float solverData_Fluid_SurfaceTension,
-      float solverData_Fluid_BuoyancyCoefficient, float3 solverData_Gravity, float4
-      solverData_KernelSize, float4 solverData_KernelFactors, VFXSampler2D solverData_Tex,
-      float2 solverData_TexSize)\n{\n    \n    // Clear forces\n    force = 0;\n    \n
-      \   #ifdef FLUVIO_INDEX_GRID\n    // Clear grid index\n    gridIndex = 0;\n
-      \   \n    // Clear neighbor count\n    neighborCount = 0;\n    \n    // Set
-      mass\n    mass = solverData_Fluid_ParticleMass;\n    \n    // Set old position\n
-      \   oldPosition = position;\n    \n    #endif\n}\nvoid Reap(float age, float
-      lifetime, inout bool alive)\n{\n    if(age > lifetime) { alive = false; }\n}\n\n\n\n[numthreads(NB_THREADS_PER_GROUP,1,1)]\nvoid
-      CSMain(uint3 groupId          : SV_GroupID,\n            uint3 groupThreadId
-      \   : SV_GroupThreadID)\n{\n\tuint id = groupThreadId.x + groupId.x * NB_THREADS_PER_GROUP
-      + groupId.y * dispatchWidth * NB_THREADS_PER_GROUP;\n\tuint index = id;\n\tif
-      (id < nbMax)\n\t{\n#if VFX_USE_ALIVE_CURRENT\n\t\tbool alive = (attributeBuffer.Load((index
-      * 0x1 + 0xF000) << 2));\n\t\t\n\n\t\tif (alive)\n\t\t{\n\t\t\tfloat lifetime
-      = asfloat(attributeBuffer.Load((index * 0x1 + 0x0) << 2));\n\t\t\tfloat3 position
-      = asfloat(attributeBuffer.Load3((index * 0x4 + 0x800) << 2));\n\t\t\tfloat3
-      force = asfloat(attributeBuffer.Load3((index * 0x4 + 0x4800) << 2));\n\t\t\tfloat
-      mass = asfloat(attributeBuffer.Load((index * 0x1 + 0x6800) << 2));\n\t\t\tfloat3
-      oldPosition = asfloat(attributeBuffer.Load3((index * 0x4 + 0x7000) << 2));\n\t\t\tfloat
-      age = asfloat(attributeBuffer.Load((index * 0x1 + 0xF800) << 2));\n\t\t\t\n\n\t\t\t\n#if
-      VFX_USE_OLDPOSITION_CURRENT\n\t\t\toldPosition = position;\n#endif\n\t\t\t\n\t\t\t{\n\t\t\t
-      \   InitializeSolver(index, position,  /*inout */force,  /*inout */mass,  /*inout
-      */oldPosition, solverData_Fluid_SmoothingDistance_a, solverData_Fluid_ParticleMass_a,
-      solverData_Fluid_Density_a, solverData_Fluid_MinimumDensity_a, solverData_Fluid_GasConstant_a,
-      solverData_Fluid_Viscosity_a, solverData_Fluid_TurbulenceProbability_a, solverData_Fluid_SurfaceTension_a,
-      solverData_Fluid_BuoyancyCoefficient_a, solverData_Gravity_a, solverData_KernelSize_a,
-      solverData_KernelFactors_a, GetVFXSampler(solverData_Tex_a, samplersolverData_Tex_a),
-      float2(0,0));\n\t\t\t}\n\t\t\tReap(age, lifetime,  /*inout */alive);\n\t\t\t\n\n\t\t\tif
-      (alive)\n\t\t\t{\n\t\t\t\tattributeBuffer.Store3((index * 0x4 + 0x4800) << 2,asuint(force));\n\t\t\t\tattributeBuffer.Store((index
-      * 0x1 + 0x6800) << 2,asuint(mass));\n\t\t\t\tattributeBuffer.Store3((index *
-      0x4 + 0x7000) << 2,asuint(oldPosition));\n\t\t\t\t\n\n#if VFX_HAS_INDIRECT_DRAW\n
-      \               uint indirectIndex = indirectBuffer.IncrementCounter();\n\t\t\t\tindirectBuffer[indirectIndex]
-      = index;\n#endif\n\t\t\t}\n\t\t\telse\n\t\t\t{\n\t\t\t\tattributeBuffer.Store((index
-      * 0x1 + 0xF000) << 2,uint(alive));\n\t\t\t\t\n\n\t\t\t\tuint deadIndex = deadListOut.IncrementCounter();\n\t\t\t\tdeadListOut[deadIndex]
-      = index;\n\t\t\t}\n\t\t}\n#else\n\t\tfloat lifetime = asfloat(attributeBuffer.Load((index
-      * 0x1 + 0x0) << 2));\n\t\tfloat3 position = asfloat(attributeBuffer.Load3((index
-      * 0x4 + 0x800) << 2));\n\t\tfloat3 force = asfloat(attributeBuffer.Load3((index
-      * 0x4 + 0x4800) << 2));\n\t\tfloat mass = asfloat(attributeBuffer.Load((index
-      * 0x1 + 0x6800) << 2));\n\t\tfloat3 oldPosition = asfloat(attributeBuffer.Load3((index
-      * 0x4 + 0x7000) << 2));\n\t\tbool alive = (attributeBuffer.Load((index * 0x1
-      + 0xF000) << 2));\n\t\tfloat age = asfloat(attributeBuffer.Load((index * 0x1
-      + 0xF800) << 2));\n\t\t\n\n\t\t\n#if VFX_USE_OLDPOSITION_CURRENT\n\t\toldPosition
-      = position;\n#endif\n\t\t\n\t\t{\n\t\t    InitializeSolver(index, position,
-      \ /*inout */force,  /*inout */mass,  /*inout */oldPosition, solverData_Fluid_SmoothingDistance_a,
-      solverData_Fluid_ParticleMass_a, solverData_Fluid_Density_a, solverData_Fluid_MinimumDensity_a,
-      solverData_Fluid_GasConstant_a, solverData_Fluid_Viscosity_a, solverData_Fluid_TurbulenceProbability_a,
-      solverData_Fluid_SurfaceTension_a, solverData_Fluid_BuoyancyCoefficient_a, solverData_Gravity_a,
-      solverData_KernelSize_a, solverData_KernelFactors_a, GetVFXSampler(solverData_Tex_a,
-      samplersolverData_Tex_a), float2(0,0));\n\t\t}\n\t\tReap(age, lifetime,  /*inout
-      */alive);\n\t\t\n\n\t\tattributeBuffer.Store3((index * 0x4 + 0x4800) << 2,asuint(force));\n\t\tattributeBuffer.Store((index
-      * 0x1 + 0x6800) << 2,asuint(mass));\n\t\tattributeBuffer.Store3((index * 0x4
-      + 0x7000) << 2,asuint(oldPosition));\n\t\tattributeBuffer.Store((index * 0x1
-      + 0xF000) << 2,uint(alive));\n\t\t\n\n#if VFX_HAS_INDIRECT_DRAW\n        uint
-      indirectIndex = indirectBuffer.IncrementCounter();\n\t\tindirectBuffer[indirectIndex]
-      = index;\n#endif\n#endif\n\t}\n}\n"
-  - compute: 1
-    name: '[System 1]B Update'
-    source: "#pragma kernel CSMain\n#include \"HLSLSupport.cginc\"\n#define NB_THREADS_PER_GROUP
-      64\n#define VFX_USE_LIFETIME_CURRENT 1\n#define VFX_USE_POSITION_CURRENT 1\n#define
-      VFX_USE_OLDPOSITION_CURRENT 1\n#define VFX_USE_ALIVE_CURRENT 1\n#define VFX_USE_AGE_CURRENT
-      1\n#define VFX_HAS_INDIRECT_DRAW 1\n#define VFX_LOCAL_SPACE 1\n\n\nCBUFFER_START(parameters)\n
-      \   float4 solverData_KernelSize_a;\n    float4 solverData_KernelFactors_a;\n
-      \   float3 solverData_Gravity_a;\n    float solverData_Fluid_SmoothingDistance_a;\n
-      \   float solverData_Fluid_ParticleMass_a;\n    float solverData_Fluid_Density_a;\n
-      \   float solverData_Fluid_MinimumDensity_a;\n    float solverData_Fluid_GasConstant_a;\n
-      \   float solverData_Fluid_Viscosity_a;\n    float solverData_Fluid_TurbulenceProbability_a;\n
-      \   float solverData_Fluid_SurfaceTension_a;\n    float solverData_Fluid_BuoyancyCoefficient_a;\nCBUFFER_END\nTexture2D
-      solverData_Tex_a;\nSamplerState samplersolverData_Tex_a;\n\n\n#include \"Packages/com.unity.visualeffectgraph/Shaders/Common/VFXCommonCompute.cginc\"\n#include
-      \"Packages/com.unity.visualeffectgraph/Shaders/VFXCommon.cginc\"\n#include \"Packages/com.thinksquirrel.fluviofx/Shaders/FluvioCompute.cginc\"\n\n\n\nRWByteAddressBuffer
-      attributeBuffer;\n\n#if VFX_USE_ALIVE_CURRENT\nRWStructuredBuffer<uint> deadListOut;\n#endif\n\n#if
-      VFX_HAS_INDIRECT_DRAW\nRWStructuredBuffer<uint> indirectBuffer;\n#endif\n\nCBUFFER_START(updateParams)\n
-      \   uint nbMax;\n\tuint dispatchWidth;\n\tuint systemSeed;\nCBUFFER_END\n\nvoid
-      SpacePartitioning(uint index, float3 position, bool alive, float solverData_Fluid_SmoothingDistance,
-      float solverData_Fluid_ParticleMass, float solverData_Fluid_Density, float solverData_Fluid_MinimumDensity,
-      float solverData_Fluid_GasConstant, float solverData_Fluid_Viscosity, float
-      solverData_Fluid_TurbulenceProbability, float solverData_Fluid_SurfaceTension,
-      float solverData_Fluid_BuoyancyCoefficient, float3 solverData_Gravity, float4
-      solverData_KernelSize, float4 solverData_KernelFactors, VFXSampler2D solverData_Tex,
-      float2 solverData_TexSize)\n{\n    \n    #ifdef FLUVIO_INDEX_GRID\n    // indices
-      are +1 for GPU grids (0 = not alive)\n    gridIndex = GetGridIndexFromPosition(position,
-      solverData_KernelSize.x) + 1;\n    #endif\n    \n}\nvoid Reap(float age, float
-      lifetime, inout bool alive)\n{\n    if(age > lifetime) { alive = false; }\n}\n\n\n\n[numthreads(NB_THREADS_PER_GROUP,1,1)]\nvoid
-      CSMain(uint3 groupId          : SV_GroupID,\n            uint3 groupThreadId
-      \   : SV_GroupThreadID)\n{\n\tuint id = groupThreadId.x + groupId.x * NB_THREADS_PER_GROUP
-      + groupId.y * dispatchWidth * NB_THREADS_PER_GROUP;\n\tuint index = id;\n\tif
-      (id < nbMax)\n\t{\n#if VFX_USE_ALIVE_CURRENT\n\t\tbool alive = (attributeBuffer.Load((index
-      * 0x1 + 0xF000) << 2));\n\t\t\n\n\t\tif (alive)\n\t\t{\n\t\t\tfloat lifetime
-      = asfloat(attributeBuffer.Load((index * 0x1 + 0x0) << 2));\n\t\t\tfloat3 position
-      = asfloat(attributeBuffer.Load3((index * 0x4 + 0x800) << 2));\n\t\t\tfloat3
-      oldPosition = asfloat(attributeBuffer.Load3((index * 0x4 + 0x7000) << 2));\n\t\t\tfloat
-      age = asfloat(attributeBuffer.Load((index * 0x1 + 0xF800) << 2));\n\t\t\t\n\n\t\t\t\n#if
-      VFX_USE_OLDPOSITION_CURRENT\n\t\t\toldPosition = position;\n#endif\n\t\t\t\n\t\t\t{\n\t\t\t
-      \   SpacePartitioning(index, position, alive, solverData_Fluid_SmoothingDistance_a,
-      solverData_Fluid_ParticleMass_a, solverData_Fluid_Density_a, solverData_Fluid_MinimumDensity_a,
-      solverData_Fluid_GasConstant_a, solverData_Fluid_Viscosity_a, solverData_Fluid_TurbulenceProbability_a,
-      solverData_Fluid_SurfaceTension_a, solverData_Fluid_BuoyancyCoefficient_a, solverData_Gravity_a,
-      solverData_KernelSize_a, solverData_KernelFactors_a, GetVFXSampler(solverData_Tex_a,
-      samplersolverData_Tex_a), float2(0,0));\n\t\t\t}\n\t\t\tReap(age, lifetime,
-      \ /*inout */alive);\n\t\t\t\n\n\t\t\tif (alive)\n\t\t\t{\n\t\t\t\tattributeBuffer.Store3((index
-      * 0x4 + 0x7000) << 2,asuint(oldPosition));\n\t\t\t\t\n\n#if VFX_HAS_INDIRECT_DRAW\n
-      \               uint indirectIndex = indirectBuffer.IncrementCounter();\n\t\t\t\tindirectBuffer[indirectIndex]
-      = index;\n#endif\n\t\t\t}\n\t\t\telse\n\t\t\t{\n\t\t\t\tattributeBuffer.Store((index
-      * 0x1 + 0xF000) << 2,uint(alive));\n\t\t\t\t\n\n\t\t\t\tuint deadIndex = deadListOut.IncrementCounter();\n\t\t\t\tdeadListOut[deadIndex]
-      = index;\n\t\t\t}\n\t\t}\n#else\n\t\tfloat lifetime = asfloat(attributeBuffer.Load((index
-      * 0x1 + 0x0) << 2));\n\t\tfloat3 position = asfloat(attributeBuffer.Load3((index
-      * 0x4 + 0x800) << 2));\n\t\tfloat3 oldPosition = asfloat(attributeBuffer.Load3((index
-      * 0x4 + 0x7000) << 2));\n\t\tbool alive = (attributeBuffer.Load((index * 0x1
-      + 0xF000) << 2));\n\t\tfloat age = asfloat(attributeBuffer.Load((index * 0x1
-      + 0xF800) << 2));\n\t\t\n\n\t\t\n#if VFX_USE_OLDPOSITION_CURRENT\n\t\toldPosition
-      = position;\n#endif\n\t\t\n\t\t{\n\t\t    SpacePartitioning(index, position,
-      alive, solverData_Fluid_SmoothingDistance_a, solverData_Fluid_ParticleMass_a,
-      solverData_Fluid_Density_a, solverData_Fluid_MinimumDensity_a, solverData_Fluid_GasConstant_a,
-      solverData_Fluid_Viscosity_a, solverData_Fluid_TurbulenceProbability_a, solverData_Fluid_SurfaceTension_a,
-      solverData_Fluid_BuoyancyCoefficient_a, solverData_Gravity_a, solverData_KernelSize_a,
-      solverData_KernelFactors_a, GetVFXSampler(solverData_Tex_a, samplersolverData_Tex_a),
-      float2(0,0));\n\t\t}\n\t\tReap(age, lifetime,  /*inout */alive);\n\t\t\n\n\t\tattributeBuffer.Store3((index
-      * 0x4 + 0x7000) << 2,asuint(oldPosition));\n\t\tattributeBuffer.Store((index
-      * 0x1 + 0xF000) << 2,uint(alive));\n\t\t\n\n#if VFX_HAS_INDIRECT_DRAW\n        uint
-      indirectIndex = indirectBuffer.IncrementCounter();\n\t\tindirectBuffer[indirectIndex]
-      = index;\n#endif\n#endif\n\t}\n}\n"
-  - compute: 1
-    name: '[System 1]C Update'
-    source: "#pragma kernel CSMain\n#include \"HLSLSupport.cginc\"\n#define NB_THREADS_PER_GROUP
-      64\n#define VFX_USE_LIFETIME_CURRENT 1\n#define VFX_USE_POSITION_CURRENT 1\n#define
-      VFX_USE_OLDPOSITION_CURRENT 1\n#define VFX_USE_ALIVE_CURRENT 1\n#define VFX_USE_AGE_CURRENT
-      1\n#define VFX_HAS_INDIRECT_DRAW 1\n#define VFX_LOCAL_SPACE 1\n\n\nCBUFFER_START(parameters)\n
-      \   float4 solverData_KernelSize_a;\n    float4 solverData_KernelFactors_a;\n
-      \   float3 solverData_Gravity_a;\n    float solverData_Fluid_SmoothingDistance_a;\n
-      \   float solverData_Fluid_ParticleMass_a;\n    float solverData_Fluid_Density_a;\n
-      \   float solverData_Fluid_MinimumDensity_a;\n    float solverData_Fluid_GasConstant_a;\n
-      \   float solverData_Fluid_Viscosity_a;\n    float solverData_Fluid_TurbulenceProbability_a;\n
-      \   float solverData_Fluid_SurfaceTension_a;\n    float solverData_Fluid_BuoyancyCoefficient_a;\nCBUFFER_END\nTexture2D
-      solverData_Tex_a;\nSamplerState samplersolverData_Tex_a;\n\n\n#include \"Packages/com.unity.visualeffectgraph/Shaders/Common/VFXCommonCompute.cginc\"\n#include
-      \"Packages/com.unity.visualeffectgraph/Shaders/VFXCommon.cginc\"\n#include \"Packages/com.thinksquirrel.fluviofx/Shaders/FluvioCompute.cginc\"\n\n\n\nRWByteAddressBuffer
-      attributeBuffer;\n\n#if VFX_USE_ALIVE_CURRENT\nRWStructuredBuffer<uint> deadListOut;\n#endif\n\n#if
-      VFX_HAS_INDIRECT_DRAW\nRWStructuredBuffer<uint> indirectBuffer;\n#endif\n\nCBUFFER_START(updateParams)\n
-      \   uint nbMax;\n\tuint dispatchWidth;\n\tuint systemSeed;\nCBUFFER_END\n\nvoid
-      NeighborSearch(uint index, float3 position, bool alive, float solverData_Fluid_SmoothingDistance,
-      float solverData_Fluid_ParticleMass, float solverData_Fluid_Density, float solverData_Fluid_MinimumDensity,
-      float solverData_Fluid_GasConstant, float solverData_Fluid_Viscosity, float
-      solverData_Fluid_TurbulenceProbability, float solverData_Fluid_SurfaceTension,
-      float solverData_Fluid_BuoyancyCoefficient, float3 solverData_Gravity, float4
-      solverData_KernelSize, float4 solverData_KernelFactors, VFXSampler2D solverData_Tex,
-      float2 solverData_TexSize)\n{\n    \n    #ifdef FLUVIO_INDEX_GRID\n    // TODO:
-      Grid structure/neighbor search is not optimized, due to VFX limitations.\n    //
-      At the moment, we are unable to easily pass custom buffers to the system,\n
-      \   // and not all platforms support texture atomics, which would be required\n
-      \   // for a true spatial partition\n    \n    uint3 indexVector = GetGridIndexVector(position,
-      solverData_KernelSize.x);\n    int3 indexVectorOff;\n    uint3 indexVectorOffset;\n
-      \   uint currentGridIndex;\n    uint nCount = 0;\n    float3 candidatePosition,
-      dist;\n    float d;\n    \n    for (uint candidate = 0; candidate < nbMax; ++candidate)\n
-      \   {\n        if (index == candidate) continue;\n    \n        \n        if
-      (candidateGridIndex == 0) continue;\n    \n        for (indexVectorOff.x = -1;
-      indexVectorOff.x <= 1; indexVectorOff.x++)\n        {\n            for (indexVectorOff.y
-      = -1; indexVectorOff.y <= 1; indexVectorOff.y++)\n            {\n                for
-      (indexVectorOff.z = -1; indexVectorOff.z <= 1; indexVectorOff.z++)\n                {\n
-      \                   indexVectorOffset = (uint3)(indexVector + indexVectorOff);\n
-      \                   currentGridIndex = GetGridIndex(indexVectorOffset);\n    \n
-      \                   // indices are +1 for GPU grids (0 = not alive)\n                    if
-      (candidateGridIndex - 1 == currentGridIndex)\n                    {\n                        float3
-      candidatePosition = asfloat(attributeBuffer.Load3((candidate * 0x4 + 0x800)
-      << 2));\n                        dist = candidatePosition - position;\n                        d
-      = dot(dist, dist);\n    \n                        if (d < solverData_KernelSize.y)\n
-      \                       {\n                            SetNeighborIndex(solverData_Tex,
-      solverData_TexSize, index, nCount++, candidate);\n    \n                            if
-      (nCount >= FLUVIO_MAX_NEIGHBORS)\n                            {\n                                neighborCount
-      = FLUVIO_MAX_NEIGHBORS;\n                                return;\n                            }\n
-      \                       }\n                    }\n                }\n            }\n
-      \       }\n    }\n    \n    neighborCount = nCount;\n    #endif\n    \n}\nvoid
-      Reap(float age, float lifetime, inout bool alive)\n{\n    if(age > lifetime)
-      { alive = false; }\n}\n\n\n\n[numthreads(NB_THREADS_PER_GROUP,1,1)]\nvoid CSMain(uint3
-      groupId          : SV_GroupID,\n            uint3 groupThreadId    : SV_GroupThreadID)\n{\n\tuint
-      id = groupThreadId.x + groupId.x * NB_THREADS_PER_GROUP + groupId.y * dispatchWidth
-      * NB_THREADS_PER_GROUP;\n\tuint index = id;\n\tif (id < nbMax)\n\t{\n#if VFX_USE_ALIVE_CURRENT\n\t\tbool
-      alive = (attributeBuffer.Load((index * 0x1 + 0xF000) << 2));\n\t\t\n\n\t\tif
-      (alive)\n\t\t{\n\t\t\tfloat lifetime = asfloat(attributeBuffer.Load((index *
-      0x1 + 0x0) << 2));\n\t\t\tfloat3 position = asfloat(attributeBuffer.Load3((index
-      * 0x4 + 0x800) << 2));\n\t\t\tfloat3 oldPosition = asfloat(attributeBuffer.Load3((index
-      * 0x4 + 0x7000) << 2));\n\t\t\tfloat age = asfloat(attributeBuffer.Load((index
-      * 0x1 + 0xF800) << 2));\n\t\t\t\n\n\t\t\t\n#if VFX_USE_OLDPOSITION_CURRENT\n\t\t\toldPosition
-      = position;\n#endif\n\t\t\t\n\t\t\t{\n\t\t\t    NeighborSearch(index, position,
-      alive, solverData_Fluid_SmoothingDistance_a, solverData_Fluid_ParticleMass_a,
-      solverData_Fluid_Density_a, solverData_Fluid_MinimumDensity_a, solverData_Fluid_GasConstant_a,
-      solverData_Fluid_Viscosity_a, solverData_Fluid_TurbulenceProbability_a, solverData_Fluid_SurfaceTension_a,
-      solverData_Fluid_BuoyancyCoefficient_a, solverData_Gravity_a, solverData_KernelSize_a,
-      solverData_KernelFactors_a, GetVFXSampler(solverData_Tex_a, samplersolverData_Tex_a),
-      float2(0,0));\n\t\t\t}\n\t\t\tReap(age, lifetime,  /*inout */alive);\n\t\t\t\n\n\t\t\tif
-      (alive)\n\t\t\t{\n\t\t\t\tattributeBuffer.Store3((index * 0x4 + 0x7000) << 2,asuint(oldPosition));\n\t\t\t\t\n\n#if
-      VFX_HAS_INDIRECT_DRAW\n                uint indirectIndex = indirectBuffer.IncrementCounter();\n\t\t\t\tindirectBuffer[indirectIndex]
-      = index;\n#endif\n\t\t\t}\n\t\t\telse\n\t\t\t{\n\t\t\t\tattributeBuffer.Store((index
-      * 0x1 + 0xF000) << 2,uint(alive));\n\t\t\t\t\n\n\t\t\t\tuint deadIndex = deadListOut.IncrementCounter();\n\t\t\t\tdeadListOut[deadIndex]
-      = index;\n\t\t\t}\n\t\t}\n#else\n\t\tfloat lifetime = asfloat(attributeBuffer.Load((index
-      * 0x1 + 0x0) << 2));\n\t\tfloat3 position = asfloat(attributeBuffer.Load3((index
-      * 0x4 + 0x800) << 2));\n\t\tfloat3 oldPosition = asfloat(attributeBuffer.Load3((index
-      * 0x4 + 0x7000) << 2));\n\t\tbool alive = (attributeBuffer.Load((index * 0x1
-      + 0xF000) << 2));\n\t\tfloat age = asfloat(attributeBuffer.Load((index * 0x1
-      + 0xF800) << 2));\n\t\t\n\n\t\t\n#if VFX_USE_OLDPOSITION_CURRENT\n\t\toldPosition
-      = position;\n#endif\n\t\t\n\t\t{\n\t\t    NeighborSearch(index, position, alive,
-      solverData_Fluid_SmoothingDistance_a, solverData_Fluid_ParticleMass_a, solverData_Fluid_Density_a,
-      solverData_Fluid_MinimumDensity_a, solverData_Fluid_GasConstant_a, solverData_Fluid_Viscosity_a,
-      solverData_Fluid_TurbulenceProbability_a, solverData_Fluid_SurfaceTension_a,
-      solverData_Fluid_BuoyancyCoefficient_a, solverData_Gravity_a, solverData_KernelSize_a,
-      solverData_KernelFactors_a, GetVFXSampler(solverData_Tex_a, samplersolverData_Tex_a),
-      float2(0,0));\n\t\t}\n\t\tReap(age, lifetime,  /*inout */alive);\n\t\t\n\n\t\tattributeBuffer.Store3((index
-      * 0x4 + 0x7000) << 2,asuint(oldPosition));\n\t\tattributeBuffer.Store((index
-      * 0x1 + 0xF000) << 2,uint(alive));\n\t\t\n\n#if VFX_HAS_INDIRECT_DRAW\n        uint
-      indirectIndex = indirectBuffer.IncrementCounter();\n\t\tindirectBuffer[indirectIndex]
-      = index;\n#endif\n#endif\n\t}\n}\n"
-  - compute: 1
-    name: '[System 1]E Update'
-    source: "#pragma kernel CSMain\n#include \"HLSLSupport.cginc\"\n#define NB_THREADS_PER_GROUP
-      64\n#define VFX_USE_LIFETIME_CURRENT 1\n#define VFX_USE_POSITION_CURRENT 1\n#define
-      VFX_USE_MASS_CURRENT 1\n#define VFX_USE_OLDPOSITION_CURRENT 1\n#define VFX_USE_DENSITYPRESSURE_CURRENT
-      1\n#define VFX_USE_NORMAL_CURRENT 1\n#define VFX_USE_ALIVE_CURRENT 1\n#define
-      VFX_USE_AGE_CURRENT 1\n#define VFX_HAS_INDIRECT_DRAW 1\n#define VFX_LOCAL_SPACE
-      1\n\n\nCBUFFER_START(parameters)\n    float4 solverData_KernelSize_a;\n    float4
-      solverData_KernelFactors_a;\n    float3 solverData_Gravity_a;\n    float solverData_Fluid_SmoothingDistance_a;\n
-      \   float solverData_Fluid_ParticleMass_a;\n    float solverData_Fluid_Density_a;\n
-      \   float solverData_Fluid_MinimumDensity_a;\n    float solverData_Fluid_GasConstant_a;\n
-      \   float solverData_Fluid_Viscosity_a;\n    float solverData_Fluid_TurbulenceProbability_a;\n
-      \   float solverData_Fluid_SurfaceTension_a;\n    float solverData_Fluid_BuoyancyCoefficient_a;\nCBUFFER_END\nTexture2D
-      solverData_Tex_a;\nSamplerState samplersolverData_Tex_a;\n\n\n#include \"Packages/com.unity.visualeffectgraph/Shaders/Common/VFXCommonCompute.cginc\"\n#include
-      \"Packages/com.unity.visualeffectgraph/Shaders/VFXCommon.cginc\"\n#include \"Packages/com.thinksquirrel.fluviofx/Shaders/FluvioCompute.cginc\"\n\n\n\nRWByteAddressBuffer
-      attributeBuffer;\n\n#if VFX_USE_ALIVE_CURRENT\nRWStructuredBuffer<uint> deadListOut;\n#endif\n\n#if
-      VFX_HAS_INDIRECT_DRAW\nRWStructuredBuffer<uint> indirectBuffer;\n#endif\n\nCBUFFER_START(updateParams)\n
-      \   uint nbMax;\n\tuint dispatchWidth;\n\tuint systemSeed;\nCBUFFER_END\n\nvoid
-      SurfaceNormal(uint index, float3 position, bool alive, float mass, float4 densityPressure,
-      inout float4 normal, float solverData_Fluid_SmoothingDistance, float solverData_Fluid_ParticleMass,
-      float solverData_Fluid_Density, float solverData_Fluid_MinimumDensity, float
-      solverData_Fluid_GasConstant, float solverData_Fluid_Viscosity, float solverData_Fluid_TurbulenceProbability,
-      float solverData_Fluid_SurfaceTension, float solverData_Fluid_BuoyancyCoefficient,
-      float3 solverData_Gravity, float4 solverData_KernelSize, float4 solverData_KernelFactors,
-      VFXSampler2D solverData_Tex, float2 solverData_TexSize)\n{\n    \n    float3
-      dist;\n    float3 n = 0;\n    #ifdef FLUVIO_INDEX_GRID\n    uint neighborIndex;\n
-      \   for (uint j = 0; j < neighborCount; ++j)\n    {\n        neighborIndex =
-      GetNeighborIndex(solverData_Tex, solverData_TexSize, index, j);\n    #else\n
-      \   float distLenSq;\n    for (uint neighborIndex = 0; neighborIndex < nbMax;
-      ++neighborIndex)\n    {\n        if (index == neighborIndex) continue;\n        bool
-      neighborAlive = (attributeBuffer.Load((neighborIndex * 0x1 + 0xF000) << 2));\n
-      \       if (!neighborAlive) continue;\n    #endif\n    \n        float3 neighborPosition
-      = asfloat(attributeBuffer.Load3((neighborIndex * 0x4 + 0x800) << 2));\n        float
-      neighborMass = asfloat(attributeBuffer.Load((neighborIndex * 0x1 + 0x6800) <<
-      2));\n        float4 neighborDensityPressure = asfloat(attributeBuffer.Load4((neighborIndex
-      * 0x4 + 0x9000) << 2));\n    \n        dist = position - neighborPosition;\n
-      \   #ifndef FLUVIO_INDEX_GRID\n        distLenSq = dot(dist, dist);\n        if
-      (distLenSq >= solverData_KernelSize.y) continue;\n    #endif\n    \n        n
-      += (neighborMass / neighborDensityPressure.y) * Poly6CalculateGradient(dist,
-      solverData_KernelFactors.x, solverData_KernelSize.y);\n    }\n    \n    // Write
-      to normal texture\n    float normalLen = length(n);\n    normal = float4(n /
-      normalLen, normalLen);\n}\nvoid Reap(float age, float lifetime, inout bool alive)\n{\n
-      \   if(age > lifetime) { alive = false; }\n}\n\n\n\n[numthreads(NB_THREADS_PER_GROUP,1,1)]\nvoid
-      CSMain(uint3 groupId          : SV_GroupID,\n            uint3 groupThreadId
-      \   : SV_GroupThreadID)\n{\n\tuint id = groupThreadId.x + groupId.x * NB_THREADS_PER_GROUP
-      + groupId.y * dispatchWidth * NB_THREADS_PER_GROUP;\n\tuint index = id;\n\tif
-      (id < nbMax)\n\t{\n#if VFX_USE_ALIVE_CURRENT\n\t\tbool alive = (attributeBuffer.Load((index
-      * 0x1 + 0xF000) << 2));\n\t\t\n\n\t\tif (alive)\n\t\t{\n\t\t\tfloat lifetime
-      = asfloat(attributeBuffer.Load((index * 0x1 + 0x0) << 2));\n\t\t\tfloat3 position
-      = asfloat(attributeBuffer.Load3((index * 0x4 + 0x800) << 2));\n\t\t\tfloat mass
-      = asfloat(attributeBuffer.Load((index * 0x1 + 0x6800) << 2));\n\t\t\tfloat3
-      oldPosition = asfloat(attributeBuffer.Load3((index * 0x4 + 0x7000) << 2));\n\t\t\tfloat4
-      densityPressure = asfloat(attributeBuffer.Load4((index * 0x4 + 0x9000) << 2));\n\t\t\tfloat4
-      normal = asfloat(attributeBuffer.Load4((index * 0x4 + 0xB000) << 2));\n\t\t\tfloat
-      age = asfloat(attributeBuffer.Load((index * 0x1 + 0xF800) << 2));\n\t\t\t\n\n\t\t\t\n#if
-      VFX_USE_OLDPOSITION_CURRENT\n\t\t\toldPosition = position;\n#endif\n\t\t\t\n\t\t\t{\n\t\t\t
-      \   SurfaceNormal(index, position, alive, mass, densityPressure,  /*inout */normal,
-      solverData_Fluid_SmoothingDistance_a, solverData_Fluid_ParticleMass_a, solverData_Fluid_Density_a,
-      solverData_Fluid_MinimumDensity_a, solverData_Fluid_GasConstant_a, solverData_Fluid_Viscosity_a,
-      solverData_Fluid_TurbulenceProbability_a, solverData_Fluid_SurfaceTension_a,
-      solverData_Fluid_BuoyancyCoefficient_a, solverData_Gravity_a, solverData_KernelSize_a,
-      solverData_KernelFactors_a, GetVFXSampler(solverData_Tex_a, samplersolverData_Tex_a),
-      float2(0,0));\n\t\t\t}\n\t\t\tReap(age, lifetime,  /*inout */alive);\n\t\t\t\n\n\t\t\tif
-      (alive)\n\t\t\t{\n\t\t\t\tattributeBuffer.Store3((index * 0x4 + 0x7000) << 2,asuint(oldPosition));\n\t\t\t\tattributeBuffer.Store4((index
-      * 0x4 + 0xB000) << 2,asuint(normal));\n\t\t\t\t\n\n#if VFX_HAS_INDIRECT_DRAW\n
-      \               uint indirectIndex = indirectBuffer.IncrementCounter();\n\t\t\t\tindirectBuffer[indirectIndex]
-      = index;\n#endif\n\t\t\t}\n\t\t\telse\n\t\t\t{\n\t\t\t\tattributeBuffer.Store((index
-      * 0x1 + 0xF000) << 2,uint(alive));\n\t\t\t\t\n\n\t\t\t\tuint deadIndex = deadListOut.IncrementCounter();\n\t\t\t\tdeadListOut[deadIndex]
-      = index;\n\t\t\t}\n\t\t}\n#else\n\t\tfloat lifetime = asfloat(attributeBuffer.Load((index
-      * 0x1 + 0x0) << 2));\n\t\tfloat3 position = asfloat(attributeBuffer.Load3((index
-      * 0x4 + 0x800) << 2));\n\t\tfloat mass = asfloat(attributeBuffer.Load((index
-      * 0x1 + 0x6800) << 2));\n\t\tfloat3 oldPosition = asfloat(attributeBuffer.Load3((index
-      * 0x4 + 0x7000) << 2));\n\t\tfloat4 densityPressure = asfloat(attributeBuffer.Load4((index
-      * 0x4 + 0x9000) << 2));\n\t\tfloat4 normal = asfloat(attributeBuffer.Load4((index
-      * 0x4 + 0xB000) << 2));\n\t\tbool alive = (attributeBuffer.Load((index * 0x1
-      + 0xF000) << 2));\n\t\tfloat age = asfloat(attributeBuffer.Load((index * 0x1
-      + 0xF800) << 2));\n\t\t\n\n\t\t\n#if VFX_USE_OLDPOSITION_CURRENT\n\t\toldPosition
-      = position;\n#endif\n\t\t\n\t\t{\n\t\t    SurfaceNormal(index, position, alive,
-      mass, densityPressure,  /*inout */normal, solverData_Fluid_SmoothingDistance_a,
-      solverData_Fluid_ParticleMass_a, solverData_Fluid_Density_a, solverData_Fluid_MinimumDensity_a,
-      solverData_Fluid_GasConstant_a, solverData_Fluid_Viscosity_a, solverData_Fluid_TurbulenceProbability_a,
-      solverData_Fluid_SurfaceTension_a, solverData_Fluid_BuoyancyCoefficient_a, solverData_Gravity_a,
-      solverData_KernelSize_a, solverData_KernelFactors_a, GetVFXSampler(solverData_Tex_a,
-      samplersolverData_Tex_a), float2(0,0));\n\t\t}\n\t\tReap(age, lifetime,  /*inout
-      */alive);\n\t\t\n\n\t\tattributeBuffer.Store3((index * 0x4 + 0x7000) << 2,asuint(oldPosition));\n\t\tattributeBuffer.Store4((index
-      * 0x4 + 0xB000) << 2,asuint(normal));\n\t\tattributeBuffer.Store((index * 0x1
-      + 0xF000) << 2,uint(alive));\n\t\t\n\n#if VFX_HAS_INDIRECT_DRAW\n        uint
-      indirectIndex = indirectBuffer.IncrementCounter();\n\t\tindirectBuffer[indirectIndex]
-      = index;\n#endif\n#endif\n\t}\n}\n"
-  - compute: 1
-    name: '[System 1]F Update'
-    source: "#pragma kernel CSMain\n#include \"HLSLSupport.cginc\"\n#define NB_THREADS_PER_GROUP
-      64\n#define VFX_USE_LIFETIME_CURRENT 1\n#define VFX_USE_POSITION_CURRENT 1\n#define
-      VFX_USE_VELOCITY_CURRENT 1\n#define VFX_USE_FORCE_CURRENT 1\n#define VFX_USE_MASS_CURRENT
-      1\n#define VFX_USE_OLDPOSITION_CURRENT 1\n#define VFX_USE_DENSITYPRESSURE_CURRENT
-      1\n#define VFX_USE_NORMAL_CURRENT 1\n#define VFX_USE_VORTICITYTURBULENCE_CURRENT
-      1\n#define VFX_USE_ALIVE_CURRENT 1\n#define VFX_USE_AGE_CURRENT 1\n#define VFX_HAS_INDIRECT_DRAW
-      1\n#define VFX_LOCAL_SPACE 1\n\n\nCBUFFER_START(parameters)\n    float4 solverData_KernelSize_a;\n
-      \   float4 solverData_KernelFactors_a;\n    float3 solverData_Gravity_a;\n    float
-      solverData_Fluid_SmoothingDistance_a;\n    float solverData_Fluid_ParticleMass_a;\n
-      \   float solverData_Fluid_Density_a;\n    float solverData_Fluid_MinimumDensity_a;\n
-      \   float solverData_Fluid_GasConstant_a;\n    float solverData_Fluid_Viscosity_a;\n
-      \   float solverData_Fluid_TurbulenceProbability_a;\n    float solverData_Fluid_SurfaceTension_a;\n
-      \   float solverData_Fluid_BuoyancyCoefficient_a;\nCBUFFER_END\nTexture2D solverData_Tex_a;\nSamplerState
-      samplersolverData_Tex_a;\n\n\n#include \"Packages/com.unity.visualeffectgraph/Shaders/Common/VFXCommonCompute.cginc\"\n#include
-      \"Packages/com.unity.visualeffectgraph/Shaders/VFXCommon.cginc\"\n#include \"Packages/com.thinksquirrel.fluviofx/Shaders/FluvioCompute.cginc\"\n\n\n\nRWByteAddressBuffer
-      attributeBuffer;\n\n#if VFX_USE_ALIVE_CURRENT\nRWStructuredBuffer<uint> deadListOut;\n#endif\n\n#if
-      VFX_HAS_INDIRECT_DRAW\nRWStructuredBuffer<uint> indirectBuffer;\n#endif\n\nCBUFFER_START(updateParams)\n
-      \   uint nbMax;\n\tuint dispatchWidth;\n\tuint systemSeed;\nCBUFFER_END\n\nvoid
-      CalculateForces_3B85AF8(uint index, float3 position, bool alive, float3 velocity,
-      float mass, float4 densityPressure, float4 normal, inout float4 vorticityTurbulence,
-      inout float3 force, float solverData_Fluid_SmoothingDistance, float solverData_Fluid_ParticleMass,
-      float solverData_Fluid_Density, float solverData_Fluid_MinimumDensity, float
-      solverData_Fluid_GasConstant, float solverData_Fluid_Viscosity, float solverData_Fluid_TurbulenceProbability,
-      float solverData_Fluid_SurfaceTension, float solverData_Fluid_BuoyancyCoefficient,
-      float3 solverData_Gravity, float4 solverData_KernelSize, float4 solverData_KernelFactors,
-      VFXSampler2D solverData_Tex, float2 solverData_TexSize) /*SurfaceTension:True
-      Turbulence:True Gravity:True BuoyancyForce:True */\n{\n    \n    #define FLUVIO_SURFACE_TENSION_ENABLED
-      1\n    #define FLUVIO_TURBULENCE_ENABLED 1\n    #define FLUVIO_GRAVITY_ENABLED
-      1\n    #define FLUVIO_BUOYANCY_FORCE_ENABLED 1\n    float3 dist, f, invNeighborDensity;\n
-      \   float scalar;\n    #ifdef FLUVIO_INDEX_GRID\n    uint neighborIndex;\n    for
-      (uint j = 0; j < neighborCount; ++j)\n    {\n        neighborIndex = GetNeighborIndex(solverData_Tex,
-      solverData_TexSize, index, j);\n    #else\n    float distLenSq;\n    for (uint
-      neighborIndex = 0; neighborIndex < nbMax; ++neighborIndex)\n    {\n        if
-      (index == neighborIndex) continue;\n        bool neighborAlive = (attributeBuffer.Load((neighborIndex
-      * 0x1 + 0xF000) << 2));\n        if (!neighborAlive) continue;\n    #endif\n
-      \   \n        float3 neighborPosition = asfloat(attributeBuffer.Load3((neighborIndex
-      * 0x4 + 0x800) << 2));\n        float neighborMass = asfloat(attributeBuffer.Load((neighborIndex
-      * 0x1 + 0x6800) << 2));\n        float3 neighborVelocity = asfloat(attributeBuffer.Load3((neighborIndex
-      * 0x4 + 0x2800) << 2));\n        float4 neighborDensityPressure = asfloat(attributeBuffer.Load4((neighborIndex
-      * 0x4 + 0x9000) << 2));\n    \n        dist = position - neighborPosition;\n
-      \   #ifndef FLUVIO_INDEX_GRID\n        distLenSq = dot(dist, dist);\n        if
-      (distLenSq >= solverData_KernelSize.y) continue;\n    #endif\n    \n        invNeighborDensity
-      = 1.0f / neighborDensityPressure.x;\n    \n        // Pressure term\n        scalar
-      = neighborMass\n            * (densityPressure.z + neighborDensityPressure.z)
-      / (neighborDensityPressure.x * 2.0f);\n        f = SpikyCalculateGradient(dist,
-      solverData_KernelFactors.y, solverData_KernelSize.x);\n        f *= scalar;\n
-      \   \n        force -= f;\n    \n        // Viscosity term\n        scalar =
-      neighborMass\n            * ViscosityCalculateLaplacian(\n                dist,\n
-      \               solverData_KernelFactors.z,\n                solverData_KernelSize.z,\n
-      \               solverData_KernelSize.x)\n            * invNeighborDensity;\n
-      \   \n        f = (neighborVelocity - velocity) / solverData_KernelSize.w;\n
-      \       f *= scalar * solverData_Fluid_Viscosity;\n    \n        force += f;\n
-      \   \n    #ifdef FLUVIO_SURFACE_TENSION_ENABLED\n        // Surface tension
-      term (external)\n        if (normal.w > FLUVIO_PI && normal.w < FLUVIO_PI *
-      2.0f)\n        {\n            scalar = neighborMass\n                * Poly6CalculateLaplacian(dist,
-      solverData_KernelFactors.x, solverData_KernelSize.y)\n                * solverData_Fluid_SurfaceTension\n
-      \               * invNeighborDensity;\n    \n            f = normal.xyz * scalar;\n
-      \   \n            force -= f;\n        }\n    #endif\n    \n    #ifdef FLUVIO_TURBULENCE_ENABLED\n
-      \   // Turbulence term (external)\n    float4 neighborVorticityTurbulence =
-      asfloat(attributeBuffer.Load4((neighborIndex * 0x4 + 0xD000) << 2));\n    if
-      (vorticityTurbulence.w >= solverData_Fluid_TurbulenceProbability && neighborVorticityTurbulence.w
-      < solverData_Fluid_TurbulenceProbability)\n    {\n        scalar = neighborMass\n
-      \           * ViscosityCalculateLaplacian(\n                dist,\n                solverData_KernelFactors.z,\n
-      \               solverData_KernelSize.z,\n                solverData_KernelSize.x)\n
-      \           * invNeighborDensity;\n    \n        vorticityTurbulence = scalar
-      * (neighborVorticityTurbulence - vorticityTurbulence);\n        f = clamp_len(FLUVIO_TURBULENCE_CONSTANT
-      * cross(dist, vorticityTurbulence.xyz), FLUVIO_MAX_SQR_VELOCITY_CHANGE * mass);\n
-      \   \n        force += f;\n    }\n    #endif\n    }\n    \n    #ifdef FLUVIO_GRAVITY_ENABLED\n
-      \   // Gravity term (external)\n    force += solverData_Gravity;\n    #endif\n
-      \   \n    #ifdef FLUVIO_BUOYANCY_FORCE_ENABLED\n    // Buoyancy term (external)\n
-      \   force += solverData_Gravity * solverData_Fluid_BuoyancyCoefficient * (densityPressure.x
-      - solverData_Fluid_Density);\n    #endif\n}\nvoid Reap(float age, float lifetime,
-      inout bool alive)\n{\n    if(age > lifetime) { alive = false; }\n}\n\n\n\n[numthreads(NB_THREADS_PER_GROUP,1,1)]\nvoid
-      CSMain(uint3 groupId          : SV_GroupID,\n            uint3 groupThreadId
-      \   : SV_GroupThreadID)\n{\n\tuint id = groupThreadId.x + groupId.x * NB_THREADS_PER_GROUP
-      + groupId.y * dispatchWidth * NB_THREADS_PER_GROUP;\n\tuint index = id;\n\tif
-      (id < nbMax)\n\t{\n#if VFX_USE_ALIVE_CURRENT\n\t\tbool alive = (attributeBuffer.Load((index
-      * 0x1 + 0xF000) << 2));\n\t\t\n\n\t\tif (alive)\n\t\t{\n\t\t\tfloat lifetime
-      = asfloat(attributeBuffer.Load((index * 0x1 + 0x0) << 2));\n\t\t\tfloat3 position
-      = asfloat(attributeBuffer.Load3((index * 0x4 + 0x800) << 2));\n\t\t\tfloat3
-      velocity = asfloat(attributeBuffer.Load3((index * 0x4 + 0x2800) << 2));\n\t\t\tfloat3
-      force = asfloat(attributeBuffer.Load3((index * 0x4 + 0x4800) << 2));\n\t\t\tfloat
-      mass = asfloat(attributeBuffer.Load((index * 0x1 + 0x6800) << 2));\n\t\t\tfloat3
-      oldPosition = asfloat(attributeBuffer.Load3((index * 0x4 + 0x7000) << 2));\n\t\t\tfloat4
-      densityPressure = asfloat(attributeBuffer.Load4((index * 0x4 + 0x9000) << 2));\n\t\t\tfloat4
-      normal = asfloat(attributeBuffer.Load4((index * 0x4 + 0xB000) << 2));\n\t\t\tfloat4
-      vorticityTurbulence = asfloat(attributeBuffer.Load4((index * 0x4 + 0xD000) <<
-      2));\n\t\t\tfloat age = asfloat(attributeBuffer.Load((index * 0x1 + 0xF800)
-      << 2));\n\t\t\t\n\n\t\t\t\n#if VFX_USE_OLDPOSITION_CURRENT\n\t\t\toldPosition
-      = position;\n#endif\n\t\t\t\n\t\t\t{\n\t\t\t    CalculateForces_3B85AF8(index,
-      position, alive, velocity, mass, densityPressure, normal,  /*inout */vorticityTurbulence,
-      \ /*inout */force, solverData_Fluid_SmoothingDistance_a, solverData_Fluid_ParticleMass_a,
-      solverData_Fluid_Density_a, solverData_Fluid_MinimumDensity_a, solverData_Fluid_GasConstant_a,
-      solverData_Fluid_Viscosity_a, solverData_Fluid_TurbulenceProbability_a, solverData_Fluid_SurfaceTension_a,
-      solverData_Fluid_BuoyancyCoefficient_a, solverData_Gravity_a, solverData_KernelSize_a,
-      solverData_KernelFactors_a, GetVFXSampler(solverData_Tex_a, samplersolverData_Tex_a),
-      float2(0,0));\n\t\t\t}\n\t\t\tReap(age, lifetime,  /*inout */alive);\n\t\t\t\n\n\t\t\tif
-      (alive)\n\t\t\t{\n\t\t\t\tattributeBuffer.Store3((index * 0x4 + 0x4800) << 2,asuint(force));\n\t\t\t\tattributeBuffer.Store3((index
-      * 0x4 + 0x7000) << 2,asuint(oldPosition));\n\t\t\t\tattributeBuffer.Store4((index
-      * 0x4 + 0xD000) << 2,asuint(vorticityTurbulence));\n\t\t\t\t\n\n#if VFX_HAS_INDIRECT_DRAW\n
-      \               uint indirectIndex = indirectBuffer.IncrementCounter();\n\t\t\t\tindirectBuffer[indirectIndex]
-      = index;\n#endif\n\t\t\t}\n\t\t\telse\n\t\t\t{\n\t\t\t\tattributeBuffer.Store((index
-      * 0x1 + 0xF000) << 2,uint(alive));\n\t\t\t\t\n\n\t\t\t\tuint deadIndex = deadListOut.IncrementCounter();\n\t\t\t\tdeadListOut[deadIndex]
-      = index;\n\t\t\t}\n\t\t}\n#else\n\t\tfloat lifetime = asfloat(attributeBuffer.Load((index
-      * 0x1 + 0x0) << 2));\n\t\tfloat3 position = asfloat(attributeBuffer.Load3((index
-      * 0x4 + 0x800) << 2));\n\t\tfloat3 velocity = asfloat(attributeBuffer.Load3((index
-      * 0x4 + 0x2800) << 2));\n\t\tfloat3 force = asfloat(attributeBuffer.Load3((index
-      * 0x4 + 0x4800) << 2));\n\t\tfloat mass = asfloat(attributeBuffer.Load((index
-      * 0x1 + 0x6800) << 2));\n\t\tfloat3 oldPosition = asfloat(attributeBuffer.Load3((index
-      * 0x4 + 0x7000) << 2));\n\t\tfloat4 densityPressure = asfloat(attributeBuffer.Load4((index
-      * 0x4 + 0x9000) << 2));\n\t\tfloat4 normal = asfloat(attributeBuffer.Load4((index
-      * 0x4 + 0xB000) << 2));\n\t\tfloat4 vorticityTurbulence = asfloat(attributeBuffer.Load4((index
-      * 0x4 + 0xD000) << 2));\n\t\tbool alive = (attributeBuffer.Load((index * 0x1
-      + 0xF000) << 2));\n\t\tfloat age = asfloat(attributeBuffer.Load((index * 0x1
-      + 0xF800) << 2));\n\t\t\n\n\t\t\n#if VFX_USE_OLDPOSITION_CURRENT\n\t\toldPosition
-      = position;\n#endif\n\t\t\n\t\t{\n\t\t    CalculateForces_3B85AF8(index, position,
-      alive, velocity, mass, densityPressure, normal,  /*inout */vorticityTurbulence,
-      \ /*inout */force, solverData_Fluid_SmoothingDistance_a, solverData_Fluid_ParticleMass_a,
-      solverData_Fluid_Density_a, solverData_Fluid_MinimumDensity_a, solverData_Fluid_GasConstant_a,
-      solverData_Fluid_Viscosity_a, solverData_Fluid_TurbulenceProbability_a, solverData_Fluid_SurfaceTension_a,
-      solverData_Fluid_BuoyancyCoefficient_a, solverData_Gravity_a, solverData_KernelSize_a,
-      solverData_KernelFactors_a, GetVFXSampler(solverData_Tex_a, samplersolverData_Tex_a),
-      float2(0,0));\n\t\t}\n\t\tReap(age, lifetime,  /*inout */alive);\n\t\t\n\n\t\tattributeBuffer.Store3((index
-      * 0x4 + 0x4800) << 2,asuint(force));\n\t\tattributeBuffer.Store3((index * 0x4
-      + 0x7000) << 2,asuint(oldPosition));\n\t\tattributeBuffer.Store4((index * 0x4
-      + 0xD000) << 2,asuint(vorticityTurbulence));\n\t\tattributeBuffer.Store((index
-      * 0x1 + 0xF000) << 2,uint(alive));\n\t\t\n\n#if VFX_HAS_INDIRECT_DRAW\n        uint
-      indirectIndex = indirectBuffer.IncrementCounter();\n\t\tindirectBuffer[indirectIndex]
-      = index;\n#endif\n#endif\n\t}\n}\n"
-  - compute: 1
-    name: '[System 1]D Update'
-    source: "#pragma kernel CSMain\n#include \"HLSLSupport.cginc\"\n#define NB_THREADS_PER_GROUP
-      64\n#define VFX_USE_LIFETIME_CURRENT 1\n#define VFX_USE_POSITION_CURRENT 1\n#define
-      VFX_USE_MASS_CURRENT 1\n#define VFX_USE_OLDPOSITION_CURRENT 1\n#define VFX_USE_DENSITYPRESSURE_CURRENT
-      1\n#define VFX_USE_ALIVE_CURRENT 1\n#define VFX_USE_AGE_CURRENT 1\n#define VFX_HAS_INDIRECT_DRAW
-      1\n#define VFX_LOCAL_SPACE 1\n\n\nCBUFFER_START(parameters)\n    float4 solverData_KernelSize_a;\n
-      \   float4 solverData_KernelFactors_a;\n    float3 solverData_Gravity_a;\n    float
-      solverData_Fluid_SmoothingDistance_a;\n    float solverData_Fluid_ParticleMass_a;\n
-      \   float solverData_Fluid_Density_a;\n    float solverData_Fluid_MinimumDensity_a;\n
-      \   float solverData_Fluid_GasConstant_a;\n    float solverData_Fluid_Viscosity_a;\n
-      \   float solverData_Fluid_TurbulenceProbability_a;\n    float solverData_Fluid_SurfaceTension_a;\n
-      \   float solverData_Fluid_BuoyancyCoefficient_a;\nCBUFFER_END\nTexture2D solverData_Tex_a;\nSamplerState
-      samplersolverData_Tex_a;\n\n\n#include \"Packages/com.unity.visualeffectgraph/Shaders/Common/VFXCommonCompute.cginc\"\n#include
-      \"Packages/com.unity.visualeffectgraph/Shaders/VFXCommon.cginc\"\n#include \"Packages/com.thinksquirrel.fluviofx/Shaders/FluvioCompute.cginc\"\n\n\n\nRWByteAddressBuffer
-      attributeBuffer;\n\n#if VFX_USE_ALIVE_CURRENT\nRWStructuredBuffer<uint> deadListOut;\n#endif\n\n#if
-      VFX_HAS_INDIRECT_DRAW\nRWStructuredBuffer<uint> indirectBuffer;\n#endif\n\nCBUFFER_START(updateParams)\n
-      \   uint nbMax;\n\tuint dispatchWidth;\n\tuint systemSeed;\nCBUFFER_END\n\nvoid
-      DensityPressure(uint index, float3 position, bool alive, float mass, inout float4
-      densityPressure, float solverData_Fluid_SmoothingDistance, float solverData_Fluid_ParticleMass,
-      float solverData_Fluid_Density, float solverData_Fluid_MinimumDensity, float
-      solverData_Fluid_GasConstant, float solverData_Fluid_Viscosity, float solverData_Fluid_TurbulenceProbability,
-      float solverData_Fluid_SurfaceTension, float solverData_Fluid_BuoyancyCoefficient,
-      float3 solverData_Gravity, float4 solverData_KernelSize, float4 solverData_KernelFactors,
-      VFXSampler2D solverData_Tex, float2 solverData_TexSize)\n{\n    \n    float3
-      dist;\n    float density = 0;\n    #ifdef FLUVIO_INDEX_GRID\n    uint neighborIndex;\n
-      \   for (uint j = 0; j < neighborCount; ++j)\n    {\n        neighborIndex =
-      GetNeighborIndex(solverData_Tex, solverData_TexSize, index, j);\n    #else\n
-      \   float distLenSq;\n    for (uint neighborIndex = 0; neighborIndex < nbMax;
-      ++neighborIndex)\n    {\n        if (index == neighborIndex) continue;\n        bool
-      neighborAlive = (attributeBuffer.Load((neighborIndex * 0x1 + 0xF000) << 2));\n
-      \       if (!neighborAlive) continue;\n    #endif\n    \n        float3 neighborPosition
-      = asfloat(attributeBuffer.Load3((neighborIndex * 0x4 + 0x800) << 2));\n        float
-      neighborMass = asfloat(attributeBuffer.Load((neighborIndex * 0x1 + 0x6800) <<
-      2));\n    \n        dist = position - neighborPosition;\n    #ifndef FLUVIO_INDEX_GRID\n
-      \       distLenSq = dot(dist, dist);\n        if (distLenSq >= solverData_KernelSize.y)
-      continue;\n    #endif\n    \n        density += neighborMass * Poly6Calculate(dist,
-      solverData_KernelFactors.x, solverData_KernelSize.y);\n    }\n    \n    // Write
-      to density/pressure texture\n    density = max(density, solverData_Fluid_MinimumDensity);\n
-      \   densityPressure = float4(density, density, solverData_Fluid_GasConstant
-      * (density - solverData_Fluid_Density), 0);\n}\nvoid Reap(float age, float lifetime,
-      inout bool alive)\n{\n    if(age > lifetime) { alive = false; }\n}\n\n\n\n[numthreads(NB_THREADS_PER_GROUP,1,1)]\nvoid
-      CSMain(uint3 groupId          : SV_GroupID,\n            uint3 groupThreadId
-      \   : SV_GroupThreadID)\n{\n\tuint id = groupThreadId.x + groupId.x * NB_THREADS_PER_GROUP
-      + groupId.y * dispatchWidth * NB_THREADS_PER_GROUP;\n\tuint index = id;\n\tif
-      (id < nbMax)\n\t{\n#if VFX_USE_ALIVE_CURRENT\n\t\tbool alive = (attributeBuffer.Load((index
-      * 0x1 + 0xF000) << 2));\n\t\t\n\n\t\tif (alive)\n\t\t{\n\t\t\tfloat lifetime
-      = asfloat(attributeBuffer.Load((index * 0x1 + 0x0) << 2));\n\t\t\tfloat3 position
-      = asfloat(attributeBuffer.Load3((index * 0x4 + 0x800) << 2));\n\t\t\tfloat mass
-      = asfloat(attributeBuffer.Load((index * 0x1 + 0x6800) << 2));\n\t\t\tfloat3
-      oldPosition = asfloat(attributeBuffer.Load3((index * 0x4 + 0x7000) << 2));\n\t\t\tfloat4
-      densityPressure = asfloat(attributeBuffer.Load4((index * 0x4 + 0x9000) << 2));\n\t\t\tfloat
-      age = asfloat(attributeBuffer.Load((index * 0x1 + 0xF800) << 2));\n\t\t\t\n\n\t\t\t\n#if
-      VFX_USE_OLDPOSITION_CURRENT\n\t\t\toldPosition = position;\n#endif\n\t\t\t\n\t\t\t{\n\t\t\t
-      \   DensityPressure(index, position, alive, mass,  /*inout */densityPressure,
-      solverData_Fluid_SmoothingDistance_a, solverData_Fluid_ParticleMass_a, solverData_Fluid_Density_a,
-      solverData_Fluid_MinimumDensity_a, solverData_Fluid_GasConstant_a, solverData_Fluid_Viscosity_a,
-      solverData_Fluid_TurbulenceProbability_a, solverData_Fluid_SurfaceTension_a,
-      solverData_Fluid_BuoyancyCoefficient_a, solverData_Gravity_a, solverData_KernelSize_a,
-      solverData_KernelFactors_a, GetVFXSampler(solverData_Tex_a, samplersolverData_Tex_a),
-      float2(0,0));\n\t\t\t}\n\t\t\tReap(age, lifetime,  /*inout */alive);\n\t\t\t\n\n\t\t\tif
-      (alive)\n\t\t\t{\n\t\t\t\tattributeBuffer.Store3((index * 0x4 + 0x7000) << 2,asuint(oldPosition));\n\t\t\t\tattributeBuffer.Store4((index
-      * 0x4 + 0x9000) << 2,asuint(densityPressure));\n\t\t\t\t\n\n#if VFX_HAS_INDIRECT_DRAW\n
-      \               uint indirectIndex = indirectBuffer.IncrementCounter();\n\t\t\t\tindirectBuffer[indirectIndex]
-      = index;\n#endif\n\t\t\t}\n\t\t\telse\n\t\t\t{\n\t\t\t\tattributeBuffer.Store((index
-      * 0x1 + 0xF000) << 2,uint(alive));\n\t\t\t\t\n\n\t\t\t\tuint deadIndex = deadListOut.IncrementCounter();\n\t\t\t\tdeadListOut[deadIndex]
-      = index;\n\t\t\t}\n\t\t}\n#else\n\t\tfloat lifetime = asfloat(attributeBuffer.Load((index
-      * 0x1 + 0x0) << 2));\n\t\tfloat3 position = asfloat(attributeBuffer.Load3((index
-      * 0x4 + 0x800) << 2));\n\t\tfloat mass = asfloat(attributeBuffer.Load((index
-      * 0x1 + 0x6800) << 2));\n\t\tfloat3 oldPosition = asfloat(attributeBuffer.Load3((index
-      * 0x4 + 0x7000) << 2));\n\t\tfloat4 densityPressure = asfloat(attributeBuffer.Load4((index
-      * 0x4 + 0x9000) << 2));\n\t\tbool alive = (attributeBuffer.Load((index * 0x1
-      + 0xF000) << 2));\n\t\tfloat age = asfloat(attributeBuffer.Load((index * 0x1
-      + 0xF800) << 2));\n\t\t\n\n\t\t\n#if VFX_USE_OLDPOSITION_CURRENT\n\t\toldPosition
-      = position;\n#endif\n\t\t\n\t\t{\n\t\t    DensityPressure(index, position, alive,
-      mass,  /*inout */densityPressure, solverData_Fluid_SmoothingDistance_a, solverData_Fluid_ParticleMass_a,
-      solverData_Fluid_Density_a, solverData_Fluid_MinimumDensity_a, solverData_Fluid_GasConstant_a,
-      solverData_Fluid_Viscosity_a, solverData_Fluid_TurbulenceProbability_a, solverData_Fluid_SurfaceTension_a,
-      solverData_Fluid_BuoyancyCoefficient_a, solverData_Gravity_a, solverData_KernelSize_a,
-      solverData_KernelFactors_a, GetVFXSampler(solverData_Tex_a, samplersolverData_Tex_a),
-      float2(0,0));\n\t\t}\n\t\tReap(age, lifetime,  /*inout */alive);\n\t\t\n\n\t\tattributeBuffer.Store3((index
-      * 0x4 + 0x7000) << 2,asuint(oldPosition));\n\t\tattributeBuffer.Store4((index
-      * 0x4 + 0x9000) << 2,asuint(densityPressure));\n\t\tattributeBuffer.Store((index
-      * 0x1 + 0xF000) << 2,uint(alive));\n\t\t\n\n#if VFX_HAS_INDIRECT_DRAW\n        uint
-      indirectIndex = indirectBuffer.IncrementCounter();\n\t\tindirectBuffer[indirectIndex]
-      = index;\n#endif\n#endif\n\t}\n}\n"
-  - compute: 1
     name: '[System 1]CameraSort'
     source: "#pragma kernel CSMain\n#include \"HLSLSupport.cginc\"\n#define NB_THREADS_PER_GROUP
       64\n#define VFX_USE_POSITION_CURRENT 1\n#define USE_DEAD_LIST_COUNT 1\n#define
-      VFX_LOCAL_SPACE 1\n\n\nCBUFFER_START(parameters)\n    float4x4 localToWorld;\nCBUFFER_END\n\n\n#include
-      \"Packages/com.unity.visualeffectgraph/Shaders/Common/VFXCommonCompute.cginc\"\n#include
+      VFX_WORLD_SPACE 1\n\n\n\n#include \"Packages/com.unity.visualeffectgraph/Shaders/Common/VFXCommonCompute.cginc\"\n#include
       \"Packages/com.unity.visualeffectgraph/Shaders/VFXCommon.cginc\"\n\n\n\nCBUFFER_START(params)\n
       \   uint nbMax;\n    uint dispatchWidth;\nCBUFFER_END\n\nCBUFFER_START(cameraParams)\n
       \   float3 cameraPosition;\nCBUFFER_END\n\nByteAddressBuffer attributeBuffer;\nStructuredBuffer<uint>
@@ -1677,253 +1094,97 @@ VisualEffectResource:
         data[0]: -1
         data[1]: -1
         data[2]: -1
-        data[3]: 1
+        data[3]: 13
       - op: 1
         valueIndex: 1
         data[0]: -1
         data[1]: -1
         data[2]: -1
-        data[3]: 1
-      - op: 26
-        valueIndex: 2
-        data[0]: 1
-        data[1]: 0
-        data[2]: -1
-        data[3]: 1
-      - op: 21
-        valueIndex: 3
-        data[0]: 2
-        data[1]: 2
-        data[2]: -1
-        data[3]: 1
-      - op: 21
+        data[3]: 3
+      - op: 9
         valueIndex: 4
-        data[0]: 3
-        data[1]: 2
-        data[2]: -1
-        data[3]: 1
-      - op: 1
-        valueIndex: 5
         data[0]: -1
         data[1]: -1
         data[2]: -1
-        data[3]: 1
-      - op: 1
-        valueIndex: 6
-        data[0]: -1
-        data[1]: -1
-        data[2]: -1
-        data[3]: 1
-      - op: 1
-        valueIndex: 7
-        data[0]: -1
-        data[1]: -1
-        data[2]: -1
-        data[3]: 1
-      - op: 3
-        valueIndex: 8
-        data[0]: 6
-        data[1]: 7
-        data[2]: 5
         data[3]: -1
-      - op: 21
-        valueIndex: 11
-        data[0]: 4
-        data[1]: 2
-        data[2]: -1
-        data[3]: 1
-      - op: 21
-        valueIndex: 12
-        data[0]: 8
-        data[1]: 8
-        data[2]: -1
-        data[3]: 3
-      - op: 21
-        valueIndex: 15
-        data[0]: 9
-        data[1]: 2
-        data[2]: -1
-        data[3]: 1
-      - op: 21
-        valueIndex: 16
-        data[0]: 11
-        data[1]: 2
-        data[2]: -1
-        data[3]: 1
-      - op: 1
-        valueIndex: 17
-        data[0]: -1
-        data[1]: -1
-        data[2]: -1
-        data[3]: 1
-      - op: 5
-        valueIndex: 18
-        data[0]: 10
-        data[1]: -1
-        data[2]: 2
-        data[3]: 3
-      - op: 5
-        valueIndex: 19
-        data[0]: 10
-        data[1]: -1
-        data[2]: 1
-        data[3]: 3
       - op: 1
         valueIndex: 20
         data[0]: -1
         data[1]: -1
         data[2]: -1
-        data[3]: 1
-      - op: 26
-        valueIndex: 21
-        data[0]: 16
-        data[1]: 13
-        data[2]: -1
-        data[3]: 1
-      - op: 21
-        valueIndex: 22
-        data[0]: 12
-        data[1]: 2
-        data[2]: -1
-        data[3]: 1
-      - op: 23
+        data[3]: 3
+      - op: 1
         valueIndex: 23
-        data[0]: 14
-        data[1]: 15
-        data[2]: -1
-        data[3]: 1
-      - op: 1
-        valueIndex: 24
         data[0]: -1
         data[1]: -1
         data[2]: -1
-        data[3]: 1
-      - op: 1
-        valueIndex: 25
-        data[0]: -1
-        data[1]: -1
-        data[2]: -1
-        data[3]: 1
-      - op: 1
+        data[3]: 3
+      - op: 6
         valueIndex: 26
         data[0]: -1
         data[1]: -1
         data[2]: -1
-        data[3]: 1
-      - op: 5
+        data[3]: -1
+      - op: 1
         valueIndex: 27
-        data[0]: 10
+        data[0]: -1
         data[1]: -1
-        data[2]: 0
-        data[3]: 3
-      - op: 1
+        data[2]: -1
+        data[3]: 1
+      - op: 35
         valueIndex: 28
-        data[0]: -1
-        data[1]: -1
+        data[0]: 2
+        data[1]: 4
         data[2]: -1
-        data[3]: 1
-      - op: 25
-        valueIndex: 29
-        data[0]: 17
-        data[1]: 20
-        data[2]: -1
-        data[3]: 1
+        data[3]: -1
       - op: 1
-        valueIndex: 30
-        data[0]: -1
-        data[1]: -1
-        data[2]: -1
-        data[3]: 1
-      - op: 23
         valueIndex: 31
-        data[0]: 19
-        data[1]: 23
+        data[0]: -1
+        data[1]: -1
         data[2]: -1
         data[3]: 1
-      - op: 24
+      - op: 1
         valueIndex: 32
-        data[0]: 21
-        data[1]: 22
+        data[0]: -1
+        data[1]: -1
         data[2]: -1
         data[3]: 1
-      - op: 21
+      - op: 1
         valueIndex: 33
-        data[0]: 18
-        data[1]: 2
+        data[0]: -1
+        data[1]: -1
         data[2]: -1
         data[3]: 1
-      - op: 21
+      - op: 1
         valueIndex: 34
-        data[0]: 29
-        data[1]: 2
-        data[2]: -1
-        data[3]: 1
-      - op: 1
-        valueIndex: 35
         data[0]: -1
         data[1]: -1
         data[2]: -1
-        data[3]: 1
-      - op: 1
+        data[3]: 2
+      - op: 37
         valueIndex: 36
-        data[0]: -1
-        data[1]: -1
+        data[0]: 2
+        data[1]: 3
         data[2]: -1
-        data[3]: 1
-      - op: 27
-        valueIndex: 37
-        data[0]: 27
-        data[1]: 24
-        data[2]: -1
-        data[3]: 1
-      - op: 1
-        valueIndex: 38
-        data[0]: -1
-        data[1]: -1
-        data[2]: -1
-        data[3]: 1
+        data[3]: -1
       - op: 1
         valueIndex: 39
         data[0]: -1
         data[1]: -1
         data[2]: -1
         data[3]: 1
-      - op: 22
+      - op: 44
         valueIndex: 40
-        data[0]: 28
-        data[1]: 26
-        data[2]: -1
-        data[3]: 1
-      - op: 1
-        valueIndex: 41
-        data[0]: -1
+        data[0]: 0
         data[1]: -1
         data[2]: -1
-        data[3]: 1
-      - op: 1
-        valueIndex: 42
-        data[0]: -1
-        data[1]: -1
-        data[2]: -1
-        data[3]: 1
-      - op: 26
-        valueIndex: 43
-        data[0]: 25
-        data[1]: 13
-        data[2]: -1
-        data[3]: 1
+        data[3]: 0
       - op: 1
         valueIndex: 44
         data[0]: -1
         data[1]: -1
         data[2]: -1
-        data[3]: 1
-      - op: 1
-        valueIndex: 45
-        data[0]: -1
-        data[1]: -1
-        data[2]: -1
-        data[3]: 1
+        data[3]: 2
       - op: 1
         valueIndex: 46
         data[0]: -1
@@ -1935,88 +1196,40 @@ VisualEffectResource:
         data[0]: -1
         data[1]: -1
         data[2]: -1
-        data[3]: 1
-      - op: 26
-        valueIndex: 48
-        data[0]: 35
-        data[1]: 0
-        data[2]: -1
-        data[3]: 1
-      - op: 26
-        valueIndex: 49
-        data[0]: 31
-        data[1]: 0
-        data[2]: -1
-        data[3]: 1
-      - op: 26
-        valueIndex: 50
-        data[0]: 38
-        data[1]: 0
-        data[2]: -1
-        data[3]: 1
-      - op: 26
+        data[3]: 4
+      - op: 1
         valueIndex: 51
-        data[0]: 42
-        data[1]: 0
-        data[2]: -1
-        data[3]: 1
-      - op: 1
-        valueIndex: 52
         data[0]: -1
         data[1]: -1
         data[2]: -1
-        data[3]: 1
-      - op: 26
-        valueIndex: 53
-        data[0]: 40
-        data[1]: 0
-        data[2]: -1
-        data[3]: 1
-      - op: 1
-        valueIndex: 54
-        data[0]: -1
-        data[1]: -1
-        data[2]: -1
-        data[3]: 1
-      - op: 1
+        data[3]: 4
+      - op: 36
         valueIndex: 55
+        data[0]: 2
+        data[1]: 1
+        data[2]: -1
+        data[3]: -1
+      - op: 1
+        valueIndex: 58
         data[0]: -1
         data[1]: -1
         data[2]: -1
         data[3]: 1
-      - op: 26
-        valueIndex: 56
-        data[0]: 41
-        data[1]: 13
-        data[2]: -1
-        data[3]: 1
-      - op: 21
-        valueIndex: 57
-        data[0]: 43
-        data[1]: 12
-        data[2]: -1
-        data[3]: 1
-      - op: 26
-        valueIndex: 58
-        data[0]: 32
-        data[1]: 13
-        data[2]: -1
-        data[3]: 1
-      - op: 22
+      - op: 1
         valueIndex: 59
-        data[0]: 20
-        data[1]: 33
+        data[0]: -1
+        data[1]: -1
         data[2]: -1
         data[3]: 1
-      - op: 21
+      - op: 1
         valueIndex: 60
-        data[0]: 34
-        data[1]: 30
+        data[0]: -1
+        data[1]: -1
         data[2]: -1
         data[3]: 1
-      - op: 16
+      - op: 1
         valueIndex: 61
-        data[0]: 36
+        data[0]: -1
         data[1]: -1
         data[2]: -1
         data[3]: 1
@@ -2026,473 +1239,113 @@ VisualEffectResource:
         data[1]: -1
         data[2]: -1
         data[3]: 1
-      - op: 25
+      - op: 1
         valueIndex: 63
-        data[0]: 39
-        data[1]: 20
+        data[0]: -1
+        data[1]: -1
         data[2]: -1
         data[3]: 1
-      - op: 21
+      - op: 1
         valueIndex: 64
-        data[0]: 37
-        data[1]: 4
+        data[0]: -1
+        data[1]: -1
         data[2]: -1
         data[3]: 1
-      - op: 26
+      - op: 1
         valueIndex: 65
-        data[0]: 52
-        data[1]: 13
+        data[0]: -1
+        data[1]: -1
         data[2]: -1
         data[3]: 1
-      - op: 26
+      - op: 1
         valueIndex: 66
-        data[0]: 59
-        data[1]: 13
+        data[0]: -1
+        data[1]: -1
         data[2]: -1
         data[3]: 1
-      - op: 22
+      - op: 1
         valueIndex: 67
-        data[0]: 51
-        data[1]: 56
-        data[2]: -1
-        data[3]: 1
-      - op: 1
-        valueIndex: 68
         data[0]: -1
         data[1]: -1
         data[2]: -1
-        data[3]: 1
+        data[3]: 3
       - op: 1
-        valueIndex: 69
-        data[0]: -1
-        data[1]: -1
-        data[2]: -1
-        data[3]: 1
-      - op: 26
         valueIndex: 70
-        data[0]: 45
-        data[1]: 0
-        data[2]: -1
-        data[3]: 1
-      - op: 1
-        valueIndex: 71
         data[0]: -1
         data[1]: -1
         data[2]: -1
-        data[3]: 1
-      - op: 26
-        valueIndex: 72
-        data[0]: 54
-        data[1]: 13
-        data[2]: -1
-        data[3]: 1
-      - op: 26
+        data[3]: 3
+      - op: 1
         valueIndex: 73
-        data[0]: 48
-        data[1]: 13
+        data[0]: -1
+        data[1]: -1
         data[2]: -1
-        data[3]: 1
-      - op: 26
-        valueIndex: 74
-        data[0]: 47
-        data[1]: 0
-        data[2]: -1
-        data[3]: 1
+        data[3]: 7
       - op: 1
         valueIndex: 75
         data[0]: -1
         data[1]: -1
         data[2]: -1
-        data[3]: 1
-      - op: 1
-        valueIndex: 76
-        data[0]: -1
-        data[1]: -1
-        data[2]: -1
-        data[3]: 13
-      - op: 1
-        valueIndex: 77
-        data[0]: -1
-        data[1]: -1
-        data[2]: -1
-        data[3]: 1
-      - op: 1
-        valueIndex: 78
-        data[0]: -1
-        data[1]: -1
-        data[2]: -1
-        data[3]: 1
-      - op: 1
-        valueIndex: 79
-        data[0]: -1
-        data[1]: -1
-        data[2]: -1
-        data[3]: 1
-      - op: 1
-        valueIndex: 80
-        data[0]: -1
-        data[1]: -1
-        data[2]: -1
-        data[3]: 1
-      - op: 1
-        valueIndex: 81
-        data[0]: -1
-        data[1]: -1
-        data[2]: -1
-        data[3]: 1
-      - op: 1
-        valueIndex: 82
-        data[0]: -1
-        data[1]: -1
-        data[2]: -1
-        data[3]: 1
-      - op: 26
-        valueIndex: 83
-        data[0]: 49
-        data[1]: 0
-        data[2]: -1
-        data[3]: 1
-      - op: 1
-        valueIndex: 84
-        data[0]: -1
-        data[1]: -1
-        data[2]: -1
-        data[3]: 1
-      - op: 26
-        valueIndex: 85
-        data[0]: 46
-        data[1]: 0
-        data[2]: -1
-        data[3]: 1
-      - op: 1
-        valueIndex: 86
-        data[0]: -1
-        data[1]: -1
-        data[2]: -1
-        data[3]: 1
-      - op: 26
-        valueIndex: 87
-        data[0]: 58
-        data[1]: 13
-        data[2]: -1
-        data[3]: 1
-      - op: 22
-        valueIndex: 88
-        data[0]: 50
-        data[1]: 60
-        data[2]: -1
-        data[3]: 1
-      - op: 11
-        valueIndex: 89
-        data[0]: 57
-        data[1]: -1
-        data[2]: -1
-        data[3]: 1
-      - op: 12
-        valueIndex: 90
-        data[0]: 57
-        data[1]: -1
-        data[2]: -1
-        data[3]: 1
-      - op: 3
-        valueIndex: 91
-        data[0]: 55
-        data[1]: 55
-        data[2]: 55
-        data[3]: -1
-      - op: 22
-        valueIndex: 94
-        data[0]: 50
-        data[1]: 53
-        data[2]: -1
-        data[3]: 1
-      - op: 26
-        valueIndex: 95
-        data[0]: 2
-        data[1]: 0
-        data[2]: -1
-        data[3]: 1
-      - op: 26
-        valueIndex: 96
-        data[0]: 44
-        data[1]: 0
-        data[2]: -1
-        data[3]: 1
-      - op: 1
-        valueIndex: 97
-        data[0]: -1
-        data[1]: -1
-        data[2]: -1
-        data[3]: 1
-      - op: 1
-        valueIndex: 98
-        data[0]: -1
-        data[1]: -1
-        data[2]: -1
         data[3]: 7
-      - op: 6
-        valueIndex: 100
-        data[0]: -1
-        data[1]: -1
-        data[2]: -1
-        data[3]: -1
-      - op: 44
-        valueIndex: 101
-        data[0]: 72
-        data[1]: -1
-        data[2]: -1
-        data[3]: 0
-      - op: 4
-        valueIndex: 105
-        data[0]: 63
-        data[1]: 88
-        data[2]: 84
-        data[3]: 13
-      - op: 1
-        valueIndex: 109
-        data[0]: -1
-        data[1]: -1
-        data[2]: -1
-        data[3]: 2
-      - op: 26
-        valueIndex: 111
-        data[0]: 71
-        data[1]: 13
-        data[2]: -1
-        data[3]: 1
-      - op: 3
-        valueIndex: 112
-        data[0]: 67
-        data[1]: 65
-        data[2]: 64
-        data[3]: -1
-      - op: 3
-        valueIndex: 115
-        data[0]: 73
-        data[1]: 74
-        data[2]: 75
-        data[3]: -1
-      - op: 3
-        valueIndex: 118
-        data[0]: 76
-        data[1]: 77
-        data[2]: 78
-        data[3]: -1
-      - op: 1
-        valueIndex: 121
-        data[0]: -1
-        data[1]: -1
-        data[2]: -1
-        data[3]: 1
-      - op: 3
-        valueIndex: 122
-        data[0]: 80
-        data[1]: 91
-        data[2]: 82
-        data[3]: -1
-      - op: 25
-        valueIndex: 125
-        data[0]: 83
-        data[1]: 37
-        data[2]: -1
-        data[3]: 1
-      - op: 22
-        valueIndex: 126
-        data[0]: 21
-        data[1]: 36
-        data[2]: -1
-        data[3]: 1
-      - op: 2
-        valueIndex: 127
-        data[0]: 85
-        data[1]: 86
-        data[2]: -1
-        data[3]: -1
-      - op: 21
-        valueIndex: 129
-        data[0]: 8
-        data[1]: 87
-        data[2]: -1
-        data[3]: 3
-      - op: 1
-        valueIndex: 132
-        data[0]: -1
-        data[1]: -1
-        data[2]: -1
-        data[3]: 1
-      - op: 4
-        valueIndex: 133
-        data[0]: 2
-        data[1]: 3
-        data[2]: 4
-        data[3]: 20
-      - op: 25
-        valueIndex: 137
-        data[0]: 69
-        data[1]: 20
-        data[2]: -1
-        data[3]: 1
-      - op: 26
-        valueIndex: 138
-        data[0]: 90
-        data[1]: 0
-        data[2]: -1
-        data[3]: 1
-      - op: 26
-        valueIndex: 139
-        data[0]: 81
-        data[1]: 0
-        data[2]: -1
-        data[3]: 1
-      - op: 1
-        valueIndex: 140
-        data[0]: -1
-        data[1]: -1
-        data[2]: -1
-        data[3]: 7
-      - op: 26
-        valueIndex: 142
-        data[0]: 70
-        data[1]: 0
-        data[2]: -1
-        data[3]: 1
-      - op: 26
-        valueIndex: 143
-        data[0]: 79
-        data[1]: 0
-        data[2]: -1
-        data[3]: 1
-      - op: 26
-        valueIndex: 144
-        data[0]: 66
-        data[1]: 0
-        data[2]: -1
-        data[3]: 1
-      - op: 25
-        valueIndex: 145
-        data[0]: 62
-        data[1]: 20
-        data[2]: -1
-        data[3]: 1
-      - op: 26
-        valueIndex: 146
-        data[0]: 61
-        data[1]: 13
-        data[2]: -1
-        data[3]: 1
-      - op: 26
-        valueIndex: 147
-        data[0]: 68
-        data[1]: 13
-        data[2]: -1
-        data[3]: 1
-      - op: 26
-        valueIndex: 148
-        data[0]: 89
-        data[1]: 0
-        data[2]: -1
-        data[3]: 1
-      - op: 9
-        valueIndex: 149
-        data[0]: -1
-        data[1]: -1
-        data[2]: -1
-        data[3]: -1
       m_NeedsLocalToWorld: 1
       m_NeedsWorldToLocal: 0
     m_PropertySheet:
       m_Float:
         m_Array:
-        - m_ExpressionIndex: 0
-          m_Value: 9.9999994e-11
-        - m_ExpressionIndex: 1
-          m_Value: 0.38125
-        - m_ExpressionIndex: 5
-          m_Value: 0
         - m_ExpressionIndex: 6
-          m_Value: 0
-        - m_ExpressionIndex: 7
+          m_Value: 0.8
+        - m_ExpressionIndex: 8
+          m_Value: 6.2831855
+        - m_ExpressionIndex: 9
           m_Value: 1
+        - m_ExpressionIndex: 10
+          m_Value: 0.59999996
         - m_ExpressionIndex: 13
-          m_Value: 0
+          m_Value: 5
         - m_ExpressionIndex: 16
-          m_Value: 0.2
+          m_Value: 2000
         - m_ExpressionIndex: 20
-          m_Value: 1
+          m_Value: 0
         - m_ExpressionIndex: 21
-          m_Value: 0.3
+          m_Value: 0.728
         - m_ExpressionIndex: 22
           m_Value: 0.2
-        - m_ExpressionIndex: 24
-          m_Value: 0.5
-        - m_ExpressionIndex: 26
-          m_Value: 0.2
-        - m_ExpressionIndex: 31
+        - m_ExpressionIndex: 23
           m_Value: 0.3
-        - m_ExpressionIndex: 32
-          m_Value: 0
-        - m_ExpressionIndex: 34
-          m_Value: 201.06194
-        - m_ExpressionIndex: 35
-          m_Value: 7.625
-        - m_ExpressionIndex: 37
-          m_Value: 6.2831855
-        - m_ExpressionIndex: 38
-          m_Value: 998.29
-        - m_ExpressionIndex: 40
+        - m_ExpressionIndex: 24
           m_Value: 0.01
-        - m_ExpressionIndex: 41
-          m_Value: 0.728
-        - m_ExpressionIndex: 42
+        - m_ExpressionIndex: 25
           m_Value: 9.9829
-        - m_ExpressionIndex: 43
-          m_Value: 3.1415927
-        - m_ExpressionIndex: 48
-          m_Value: 1
-        - m_ExpressionIndex: 50
-          m_Value: 15
-        - m_ExpressionIndex: 51
-          m_Value: 315
-        - m_ExpressionIndex: 58
-          m_Value: 6.2831855
-        - m_ExpressionIndex: 64
-          m_Value: 0
-        - m_ExpressionIndex: 65
-          m_Value: -9.81
-        - m_ExpressionIndex: 67
-          m_Value: 0
-        - m_ExpressionIndex: 71
-          m_Value: 2000
-        - m_ExpressionIndex: 73
-          m_Value: 0
-        - m_ExpressionIndex: 74
-          m_Value: -0.25
-        - m_ExpressionIndex: 75
-          m_Value: 0
-        - m_ExpressionIndex: 76
-          m_Value: 3
-        - m_ExpressionIndex: 77
-          m_Value: 6.5
-        - m_ExpressionIndex: 78
-          m_Value: 3
-        - m_ExpressionIndex: 80
-          m_Value: -0.017374076
-        - m_ExpressionIndex: 82
-          m_Value: 0
-        - m_ExpressionIndex: 91
-          m_Value: -0.24813068
-        - m_ExpressionIndex: 101
-          m_Value: 0.8
-        - m_ExpressionIndex: 107
-          m_Value: 5
+        - m_ExpressionIndex: 26
+          m_Value: 998.29
+        - m_ExpressionIndex: 27
+          m_Value: 7.625
+        - m_ExpressionIndex: 28
+          m_Value: 0.38125
       m_Vector2f:
         m_Array:
-        - m_ExpressionIndex: 96
+        - m_ExpressionIndex: 11
+          m_Value: {x: 0.44721365, y: 0.8944272}
+        - m_ExpressionIndex: 15
           m_Value: {x: 0, y: 0}
       m_Vector3f:
-        m_Array: []
+        m_Array:
+        - m_ExpressionIndex: 1
+          m_Value: {x: 0, y: -9.81, z: 0}
+        - m_ExpressionIndex: 3
+          m_Value: {x: 0, y: 1, z: 0}
+        - m_ExpressionIndex: 4
+          m_Value: {x: -0.017374076, y: -0.24813068, z: 0}
+        - m_ExpressionIndex: 29
+          m_Value: {x: 3, y: 6.5, z: 3}
+        - m_ExpressionIndex: 30
+          m_Value: {x: 0, y: -0.25, z: 0}
       m_Vector4f:
-        m_Array: []
+        m_Array:
+        - m_ExpressionIndex: 17
+          m_Value: {x: 9206.448, y: 1554.8279, z: 43.08061, w: 0}
+        - m_ExpressionIndex: 18
+          m_Value: {x: 0.38125, y: 0.14535156, z: 0.05541528, w: 0}
       m_Uint:
         m_Array: []
       m_Int:
@@ -2501,7 +1354,7 @@ VisualEffectResource:
         m_Array: []
       m_AnimationCurve:
         m_Array:
-        - m_ExpressionIndex: 72
+        - m_ExpressionIndex: 0
           m_Value:
             serializedVersion: 2
             m_Curve:
@@ -2557,9 +1410,9 @@ VisualEffectResource:
         m_Array: []
       m_NamedObject:
         m_Array:
-        - m_ExpressionIndex: 92
+        - m_ExpressionIndex: 31
           m_Value: {fileID: 0}
-        - m_ExpressionIndex: 112
+        - m_ExpressionIndex: 32
           m_Value: {fileID: 2800000, guid: 276d9e395ae18fe40a9b4988549f2349, type: 3}
       m_Bool:
         m_Array: []
@@ -2796,7 +1649,7 @@ VisualEffectResource:
       buffers: []
       values:
       - nameId: Rate
-        index: 97
+        index: 16
       params: []
       processor: {fileID: 0}
       shaderSourceIndex: -1
@@ -2823,9 +1676,9 @@ VisualEffectResource:
       index: 7
     values:
     - nameId: bounds_center
-      index: 99
+      index: 30
     - nameId: bounds_size
-      index: 100
+      index: 29
     tasks:
     - type: 536870912
       buffers:
@@ -2838,185 +1691,15 @@ VisualEffectResource:
       - nameId: sourceAttributeBuffer
         index: 2
       values:
-      - nameId: Lifetime_a
-        index: 101
       - nameId: Cone_center_b
-        index: 102
-      - nameId: Cone_radius0_b
-        index: 22
-      - nameId: Cone_radius1_b
-        index: 21
-      - nameId: Cone_height_b
-        index: 26
-      - nameId: Cone_arc_b
-        index: 103
-      - nameId: fullConeHeight_b
-        index: 104
-      - nameId: sincosSlope_b
-        index: 105
+        index: 7
       - nameId: Direction_c
-        index: 106
-      - nameId: Speed_c
-        index: 107
-      - nameId: DirectionBlend_c
-        index: 109
+        index: 12
       params:
       - nameId: bounds_center
-        index: 99
+        index: 30
       - nameId: bounds_size
-        index: 100
-      processor: {fileID: 0}
-      shaderSourceIndex: 0
-    - type: 805306368
-      buffers:
-      - nameId: attributeBuffer
-        index: 0
-      - nameId: deadListOut
-        index: 3
-      - nameId: indirectBuffer
-        index: 5
-      values:
-      - nameId: solverData_Fluid_SmoothingDistance_a
-        index: 119
-      - nameId: solverData_Fluid_ParticleMass_a
-        index: 110
-      - nameId: solverData_Fluid_Density_a
-        index: 111
-      - nameId: solverData_Fluid_MinimumDensity_a
-        index: 113
-      - nameId: solverData_Fluid_GasConstant_a
-        index: 114
-      - nameId: solverData_Fluid_Viscosity_a
-        index: 115
-      - nameId: solverData_Fluid_TurbulenceProbability_a
-        index: 116
-      - nameId: solverData_Fluid_SurfaceTension_a
-        index: 117
-      - nameId: solverData_Fluid_BuoyancyCoefficient_a
-        index: 118
-      - nameId: solverData_Gravity_a
-        index: 98
-      - nameId: solverData_KernelSize_a
-        index: 108
-      - nameId: solverData_KernelFactors_a
-        index: 95
-      - nameId: solverData_Tex_a
-        index: 92
-      params: []
-      processor: {fileID: 0}
-      shaderSourceIndex: 3
-    - type: 805306368
-      buffers:
-      - nameId: attributeBuffer
-        index: 0
-      - nameId: deadListOut
-        index: 3
-      - nameId: indirectBuffer
-        index: 5
-      values:
-      - nameId: solverData_Fluid_SmoothingDistance_a
-        index: 119
-      - nameId: solverData_Fluid_ParticleMass_a
-        index: 110
-      - nameId: solverData_Fluid_Density_a
-        index: 111
-      - nameId: solverData_Fluid_MinimumDensity_a
-        index: 113
-      - nameId: solverData_Fluid_GasConstant_a
-        index: 114
-      - nameId: solverData_Fluid_Viscosity_a
-        index: 115
-      - nameId: solverData_Fluid_TurbulenceProbability_a
-        index: 116
-      - nameId: solverData_Fluid_SurfaceTension_a
-        index: 117
-      - nameId: solverData_Fluid_BuoyancyCoefficient_a
-        index: 118
-      - nameId: solverData_Gravity_a
-        index: 98
-      - nameId: solverData_KernelSize_a
-        index: 108
-      - nameId: solverData_KernelFactors_a
-        index: 95
-      - nameId: solverData_Tex_a
-        index: 92
-      params: []
-      processor: {fileID: 0}
-      shaderSourceIndex: 4
-    - type: 805306368
-      buffers:
-      - nameId: attributeBuffer
-        index: 0
-      - nameId: deadListOut
-        index: 3
-      - nameId: indirectBuffer
-        index: 5
-      values:
-      - nameId: solverData_Fluid_SmoothingDistance_a
-        index: 119
-      - nameId: solverData_Fluid_ParticleMass_a
-        index: 110
-      - nameId: solverData_Fluid_Density_a
-        index: 111
-      - nameId: solverData_Fluid_MinimumDensity_a
-        index: 113
-      - nameId: solverData_Fluid_GasConstant_a
-        index: 114
-      - nameId: solverData_Fluid_Viscosity_a
-        index: 115
-      - nameId: solverData_Fluid_TurbulenceProbability_a
-        index: 116
-      - nameId: solverData_Fluid_SurfaceTension_a
-        index: 117
-      - nameId: solverData_Fluid_BuoyancyCoefficient_a
-        index: 118
-      - nameId: solverData_Gravity_a
-        index: 98
-      - nameId: solverData_KernelSize_a
-        index: 108
-      - nameId: solverData_KernelFactors_a
-        index: 95
-      - nameId: solverData_Tex_a
-        index: 92
-      params: []
-      processor: {fileID: 0}
-      shaderSourceIndex: 5
-    - type: 805306368
-      buffers:
-      - nameId: attributeBuffer
-        index: 0
-      - nameId: deadListOut
-        index: 3
-      - nameId: indirectBuffer
-        index: 5
-      values:
-      - nameId: solverData_Fluid_SmoothingDistance_a
-        index: 119
-      - nameId: solverData_Fluid_ParticleMass_a
-        index: 110
-      - nameId: solverData_Fluid_Density_a
-        index: 111
-      - nameId: solverData_Fluid_MinimumDensity_a
-        index: 113
-      - nameId: solverData_Fluid_GasConstant_a
-        index: 114
-      - nameId: solverData_Fluid_Viscosity_a
-        index: 115
-      - nameId: solverData_Fluid_TurbulenceProbability_a
-        index: 116
-      - nameId: solverData_Fluid_SurfaceTension_a
-        index: 117
-      - nameId: solverData_Fluid_BuoyancyCoefficient_a
-        index: 118
-      - nameId: solverData_Gravity_a
-        index: 98
-      - nameId: solverData_KernelSize_a
-        index: 108
-      - nameId: solverData_KernelFactors_a
-        index: 95
-      - nameId: solverData_Tex_a
-        index: 92
-      params: []
+        index: 29
       processor: {fileID: 0}
       shaderSourceIndex: 8
     - type: 805306368
@@ -3028,35 +1711,13 @@ VisualEffectResource:
       - nameId: indirectBuffer
         index: 5
       values:
-      - nameId: solverData_Fluid_SmoothingDistance_a
-        index: 119
-      - nameId: solverData_Fluid_ParticleMass_a
-        index: 110
-      - nameId: solverData_Fluid_Density_a
-        index: 111
-      - nameId: solverData_Fluid_MinimumDensity_a
-        index: 113
-      - nameId: solverData_Fluid_GasConstant_a
-        index: 114
-      - nameId: solverData_Fluid_Viscosity_a
-        index: 115
-      - nameId: solverData_Fluid_TurbulenceProbability_a
-        index: 116
-      - nameId: solverData_Fluid_SurfaceTension_a
-        index: 117
-      - nameId: solverData_Fluid_BuoyancyCoefficient_a
-        index: 118
       - nameId: solverData_Gravity_a
-        index: 98
-      - nameId: solverData_KernelSize_a
-        index: 108
-      - nameId: solverData_KernelFactors_a
-        index: 95
+        index: 19
       - nameId: solverData_Tex_a
-        index: 92
+        index: 31
       params: []
       processor: {fileID: 0}
-      shaderSourceIndex: 6
+      shaderSourceIndex: 0
     - type: 805306368
       buffers:
       - nameId: attributeBuffer
@@ -3066,32 +1727,48 @@ VisualEffectResource:
       - nameId: indirectBuffer
         index: 5
       values:
-      - nameId: solverData_Fluid_SmoothingDistance_a
-        index: 119
-      - nameId: solverData_Fluid_ParticleMass_a
-        index: 110
-      - nameId: solverData_Fluid_Density_a
-        index: 111
-      - nameId: solverData_Fluid_MinimumDensity_a
-        index: 113
-      - nameId: solverData_Fluid_GasConstant_a
-        index: 114
-      - nameId: solverData_Fluid_Viscosity_a
-        index: 115
-      - nameId: solverData_Fluid_TurbulenceProbability_a
-        index: 116
-      - nameId: solverData_Fluid_SurfaceTension_a
-        index: 117
-      - nameId: solverData_Fluid_BuoyancyCoefficient_a
-        index: 118
       - nameId: solverData_Gravity_a
-        index: 98
-      - nameId: solverData_KernelSize_a
-        index: 108
-      - nameId: solverData_KernelFactors_a
-        index: 95
-      - nameId: solverData_Tex_a
-        index: 92
+        index: 19
+      params: []
+      processor: {fileID: 0}
+      shaderSourceIndex: 1
+    - type: 805306368
+      buffers:
+      - nameId: attributeBuffer
+        index: 0
+      - nameId: deadListOut
+        index: 3
+      - nameId: indirectBuffer
+        index: 5
+      values:
+      - nameId: solverData_Gravity_a
+        index: 19
+      params: []
+      processor: {fileID: 0}
+      shaderSourceIndex: 2
+    - type: 805306368
+      buffers:
+      - nameId: attributeBuffer
+        index: 0
+      - nameId: deadListOut
+        index: 3
+      - nameId: indirectBuffer
+        index: 5
+      values:
+      - nameId: solverData_Gravity_a
+        index: 19
+      params: []
+      processor: {fileID: 0}
+      shaderSourceIndex: 3
+    - type: 805306368
+      buffers:
+      - nameId: attributeBuffer
+        index: 0
+      - nameId: deadListOut
+        index: 3
+      - nameId: indirectBuffer
+        index: 5
+      values: []
       params: []
       processor: {fileID: 0}
       shaderSourceIndex: 7
@@ -3104,37 +1781,41 @@ VisualEffectResource:
       - nameId: indirectBuffer
         index: 5
       values:
-      - nameId: solverData_Fluid_SmoothingDistance_a
-        index: 119
-      - nameId: solverData_Fluid_ParticleMass_a
-        index: 110
-      - nameId: solverData_Fluid_Density_a
-        index: 111
-      - nameId: solverData_Fluid_MinimumDensity_a
-        index: 113
-      - nameId: solverData_Fluid_GasConstant_a
-        index: 114
-      - nameId: solverData_Fluid_Viscosity_a
-        index: 115
-      - nameId: solverData_Fluid_TurbulenceProbability_a
-        index: 116
-      - nameId: solverData_Fluid_SurfaceTension_a
-        index: 117
-      - nameId: solverData_Fluid_BuoyancyCoefficient_a
-        index: 118
       - nameId: solverData_Gravity_a
-        index: 98
-      - nameId: solverData_KernelSize_a
-        index: 108
-      - nameId: solverData_KernelFactors_a
-        index: 95
-      - nameId: dt_a
-        index: 93
-      - nameId: solverData_Tex_a
-        index: 92
+        index: 19
       params: []
       processor: {fileID: 0}
-      shaderSourceIndex: 1
+      shaderSourceIndex: 4
+    - type: 805306368
+      buffers:
+      - nameId: attributeBuffer
+        index: 0
+      - nameId: deadListOut
+        index: 3
+      - nameId: indirectBuffer
+        index: 5
+      values:
+      - nameId: solverData_Gravity_a
+        index: 19
+      params: []
+      processor: {fileID: 0}
+      shaderSourceIndex: 5
+    - type: 805306368
+      buffers:
+      - nameId: attributeBuffer
+        index: 0
+      - nameId: deadListOut
+        index: 3
+      - nameId: indirectBuffer
+        index: 5
+      values:
+      - nameId: solverData_Gravity_a
+        index: 19
+      - nameId: dt_a
+        index: 5
+      params: []
+      processor: {fileID: 0}
+      shaderSourceIndex: 6
     - type: 805306369
       buffers:
       - nameId: attributeBuffer
@@ -3145,12 +1826,10 @@ VisualEffectResource:
         index: 6
       - nameId: deadListCount
         index: 4
-      values:
-      - nameId: localToWorld
-        index: 120
+      values: []
       params: []
       processor: {fileID: 0}
-      shaderSourceIndex: 9
+      shaderSourceIndex: 10
     - type: 1073741826
       buffers:
       - nameId: attributeBuffer
@@ -3161,17 +1840,17 @@ VisualEffectResource:
         index: 4
       values:
       - nameId: Alpha_b
-        index: 94
+        index: 14
       - nameId: mainTexture
-        index: 112
+        index: 32
       params:
       - nameId: sortPriority
         index: 0
       - nameId: indirectDraw
         index: 1
       processor: {fileID: 0}
-      shaderSourceIndex: 2
---- !u!114 &8926484042661615670
+      shaderSourceIndex: 9
+--- !u!114 &8926484042661618129
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -3185,185 +1864,27 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Parent: {fileID: 114350483966674976}
   m_Children:
-  - {fileID: 8926484042661615693}
-  m_UIPosition: {x: 716, y: 417}
+  - {fileID: 8926484042661618131}
+  m_UIPosition: {x: 1351.8771, y: 2.0297546}
   m_UICollapsed: 0
   m_UISuperCollapsed: 0
   m_InputSlots: []
   m_OutputSlots: []
   m_Label: 
-  m_Data: {fileID: 114428730288789306}
+  m_Data: {fileID: 8926484042661618195}
   m_InputFlowSlot:
   - link:
-    - context: {fileID: 114946465509916290}
+    - context: {fileID: 8926484042661618185}
       slotIndex: 0
   m_OutputFlowSlot:
   - link:
-    - context: {fileID: 8926484042661615672}
+    - context: {fileID: 8926484042661618162}
       slotIndex: 0
   integration: 1
   angularIntegration: 1
   ageParticles: 0
   reapParticles: 1
---- !u!114 &8926484042661615672
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2dc095764ededfa4bb32fa602511ea4b, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 114350483966674976}
-  m_Children:
-  - {fileID: 8926484042661615723}
-  m_UIPosition: {x: 716, y: 597}
-  m_UICollapsed: 0
-  m_UISuperCollapsed: 0
-  m_InputSlots: []
-  m_OutputSlots: []
-  m_Label: 
-  m_Data: {fileID: 114428730288789306}
-  m_InputFlowSlot:
-  - link:
-    - context: {fileID: 8926484042661615670}
-      slotIndex: 0
-  m_OutputFlowSlot:
-  - link:
-    - context: {fileID: 8926484042661615674}
-      slotIndex: 0
-  integration: 1
-  angularIntegration: 1
-  ageParticles: 0
-  reapParticles: 1
---- !u!114 &8926484042661615674
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2dc095764ededfa4bb32fa602511ea4b, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 114350483966674976}
-  m_Children:
-  - {fileID: 8926484042661615753}
-  m_UIPosition: {x: 716, y: 779}
-  m_UICollapsed: 0
-  m_UISuperCollapsed: 0
-  m_InputSlots: []
-  m_OutputSlots: []
-  m_Label: 
-  m_Data: {fileID: 114428730288789306}
-  m_InputFlowSlot:
-  - link:
-    - context: {fileID: 8926484042661615672}
-      slotIndex: 0
-  m_OutputFlowSlot:
-  - link:
-    - context: {fileID: 8926484042661615844}
-      slotIndex: 0
-  integration: 1
-  angularIntegration: 1
-  ageParticles: 0
-  reapParticles: 1
---- !u!114 &8926484042661615676
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2dc095764ededfa4bb32fa602511ea4b, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 114350483966674976}
-  m_Children:
-  - {fileID: 8926484042661615783}
-  m_UIPosition: {x: 716, y: 1134}
-  m_UICollapsed: 0
-  m_UISuperCollapsed: 0
-  m_InputSlots: []
-  m_OutputSlots: []
-  m_Label: 
-  m_Data: {fileID: 114428730288789306}
-  m_InputFlowSlot:
-  - link:
-    - context: {fileID: 8926484042661615844}
-      slotIndex: 0
-  m_OutputFlowSlot:
-  - link:
-    - context: {fileID: 8926484042661615678}
-      slotIndex: 0
-  integration: 1
-  angularIntegration: 1
-  ageParticles: 0
-  reapParticles: 1
---- !u!114 &8926484042661615678
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2dc095764ededfa4bb32fa602511ea4b, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 114350483966674976}
-  m_Children:
-  - {fileID: 8926484042661615813}
-  m_UIPosition: {x: 716, y: 1314}
-  m_UICollapsed: 0
-  m_UISuperCollapsed: 0
-  m_InputSlots: []
-  m_OutputSlots: []
-  m_Label: 
-  m_Data: {fileID: 114428730288789306}
-  m_InputFlowSlot:
-  - link:
-    - context: {fileID: 8926484042661615676}
-      slotIndex: 0
-  m_OutputFlowSlot:
-  - link:
-    - context: {fileID: 114780028408030698}
-      slotIndex: 0
-  integration: 1
-  angularIntegration: 1
-  ageParticles: 0
-  reapParticles: 1
---- !u!114 &8926484042661615687
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: af49bc557521a417ab5daee69476f797, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 114780028408030698}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 77}
-  m_UICollapsed: 0
-  m_UISuperCollapsed: 0
-  m_InputSlots:
-  - {fileID: 8926484042661617765}
-  m_OutputSlots: []
-  m_Disabled: 0
-  IntegrationMode: 0
---- !u!114 &8926484042661615693
+--- !u!114 &8926484042661618131
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -3375,16 +1896,1197 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 62f882957e18f4fbe9fa015185deb52a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661615670}
+  m_Parent: {fileID: 8926484042661618129}
   m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 0
+  m_UIPosition: {x: 1393.8771, y: -356.97025}
+  m_UICollapsed: 1
   m_UISuperCollapsed: 0
   m_InputSlots:
-  - {fileID: 8926484042661617795}
+  - {fileID: 8926484042661618132}
   m_OutputSlots: []
   m_Disabled: 0
---- !u!114 &8926484042661615723
+--- !u!114 &8926484042661618132
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1b605c022ee79394a8a776c0869b3f9a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 0}
+  m_Children:
+  - {fileID: 8926484042661618133}
+  - {fileID: 8926484042661618143}
+  - {fileID: 8926484042661618148}
+  - {fileID: 8926484042661618153}
+  - {fileID: 8926484042661618158}
+  - {fileID: 8926484042661618159}
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618132}
+  m_MasterData:
+    m_Owner: {fileID: 8926484042661618131}
+    m_Value:
+      m_Type:
+        m_SerializableType: Thinksquirrel.FluvioFX.Editor.SolverData, Thinksquirrel.FluvioFX.Editor,
+          Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+      m_SerializableObject: '{"Fluid":{"SmoothingDistance":0.3812499940395355,"ParticleMass":7.625,"Density":998.2899780273438,"MinimumDensity":499.1449890136719,"GasConstant":0.009999999776482582,"Viscosity":1.0,"TurbulenceProbability":0.0,"SurfaceTension":0.7279999852180481,"BuoyancyCoefficient":0.0},"Gravity":{"vector":{"x":0.0,"y":0.0,"z":0.0}},"KernelSize":{"x":0.3812499940395355,"y":0.1453515589237213,"z":0.055415280163288119,"w":1.0},"KernelFactors":{"x":9206.4482421875,"y":1554.8280029296875,"z":43.08060836791992,"w":0.0},"Tex":{"instanceID":0},"TexSize":{"x":0.0,"y":0.0}}'
+    m_Space: 0
+  m_Property:
+    name: solverData
+    m_serializedType:
+      m_SerializableType: Thinksquirrel.FluvioFX.Editor.SolverData, Thinksquirrel.FluvioFX.Editor,
+        Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+    attributes: []
+  m_Direction: 0
+  m_LinkedSlots:
+  - {fileID: 8926484042661618238}
+--- !u!114 &8926484042661618133
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1b605c022ee79394a8a776c0869b3f9a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618132}
+  m_Children:
+  - {fileID: 8926484042661618134}
+  - {fileID: 8926484042661618135}
+  - {fileID: 8926484042661618136}
+  - {fileID: 8926484042661618137}
+  - {fileID: 8926484042661618138}
+  - {fileID: 8926484042661618139}
+  - {fileID: 8926484042661618140}
+  - {fileID: 8926484042661618141}
+  - {fileID: 8926484042661618142}
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618132}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: Fluid
+    m_serializedType:
+      m_SerializableType: Thinksquirrel.FluvioFX.Editor.Fluid, Thinksquirrel.FluvioFX.Editor,
+        Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+    attributes: []
+  m_Direction: 0
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618134
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618133}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618132}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: SmoothingDistance
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes:
+    - m_Type: 1
+      m_Min: 9.9999994e-11
+      m_Max: Infinity
+      m_Tooltip: 
+      m_Regex: 
+      m_RegexMaxLength: 0
+    - m_Type: 3
+      m_Min: -Infinity
+      m_Max: Infinity
+      m_Tooltip: Controls the smoothing distance of fluid particles. This changes
+        the overall simulation resolution and greatly affects all other properties.
+      m_Regex: 
+      m_RegexMaxLength: 0
+  m_Direction: 0
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618135
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618133}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618132}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: ParticleMass
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes:
+    - m_Type: 1
+      m_Min: 9.9999994e-11
+      m_Max: Infinity
+      m_Tooltip: 
+      m_Regex: 
+      m_RegexMaxLength: 0
+    - m_Type: 3
+      m_Min: -Infinity
+      m_Max: Infinity
+      m_Tooltip: Controls the mass of each fluid particle.
+      m_Regex: 
+      m_RegexMaxLength: 0
+  m_Direction: 0
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618136
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618133}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618132}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: Density
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes:
+    - m_Type: 1
+      m_Min: 9.9999994e-11
+      m_Max: Infinity
+      m_Tooltip: 
+      m_Regex: 
+      m_RegexMaxLength: 0
+    - m_Type: 3
+      m_Min: -Infinity
+      m_Max: Infinity
+      m_Tooltip: Controls the overall density of the fluid.
+      m_Regex: 
+      m_RegexMaxLength: 0
+  m_Direction: 0
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618137
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618133}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618132}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: MinimumDensity
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes:
+    - m_Type: 1
+      m_Min: 9.9999994e-11
+      m_Max: Infinity
+      m_Tooltip: 
+      m_Regex: 
+      m_RegexMaxLength: 0
+    - m_Type: 3
+      m_Min: -Infinity
+      m_Max: Infinity
+      m_Tooltip: Controls the minimum density of any fluid particle. This can be used
+        to help stabilize a low-viscosity fluid.
+      m_Regex: 
+      m_RegexMaxLength: 0
+  m_Direction: 0
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618138
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618133}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618132}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: GasConstant
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes:
+    - m_Type: 1
+      m_Min: 9.9999994e-11
+      m_Max: Infinity
+      m_Tooltip: 
+      m_Regex: 
+      m_RegexMaxLength: 0
+    - m_Type: 3
+      m_Min: -Infinity
+      m_Max: Infinity
+      m_Tooltip: Controls the gas constant of the fluid, which in turn affects the
+        pressure forces applied to particles.
+      m_Regex: 
+      m_RegexMaxLength: 0
+  m_Direction: 0
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618139
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618133}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618132}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: Viscosity
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes:
+    - m_Type: 1
+      m_Min: 9.9999994e-11
+      m_Max: Infinity
+      m_Tooltip: 
+      m_Regex: 
+      m_RegexMaxLength: 0
+    - m_Type: 3
+      m_Min: -Infinity
+      m_Max: Infinity
+      m_Tooltip: Controls the artificial viscosity force of the fluid.
+      m_Regex: 
+      m_RegexMaxLength: 0
+  m_Direction: 0
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618140
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618133}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618132}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: TurbulenceProbability
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes:
+    - m_Type: 0
+      m_Min: 0
+      m_Max: 1
+      m_Tooltip: 
+      m_Regex: 
+      m_RegexMaxLength: 0
+    - m_Type: 3
+      m_Min: -Infinity
+      m_Max: Infinity
+      m_Tooltip: Controls the turbulence probability of the fluid. The turbulence
+        probability is a threshold beyond which a particle may become turbulent. Turbulent
+        particles will not affect non-turbulent particles. Fluid particles are not
+        turbulent by default. Turbulent forces are typically applied through effectors,
+        using the Vorticity property.
+      m_Regex: 
+      m_RegexMaxLength: 0
+  m_Direction: 0
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618141
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618133}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618132}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: SurfaceTension
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes:
+    - m_Type: 1
+      m_Min: 0
+      m_Max: Infinity
+      m_Tooltip: 
+      m_Regex: 
+      m_RegexMaxLength: 0
+    - m_Type: 3
+      m_Min: -Infinity
+      m_Max: Infinity
+      m_Tooltip: Controls the surface tension of the fluid (intended for liquids only).
+        FluvioFX uses a simplified surface tension model that is ideal for realtime
+        use.
+      m_Regex: 
+      m_RegexMaxLength: 0
+  m_Direction: 0
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618142
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618133}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618132}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: BuoyancyCoefficient
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes:
+    - m_Type: 1
+      m_Min: 0
+      m_Max: Infinity
+      m_Tooltip: 
+      m_Regex: 
+      m_RegexMaxLength: 0
+    - m_Type: 3
+      m_Min: -Infinity
+      m_Max: Infinity
+      m_Tooltip: Controls the buoyancy coefficient of a fluid. This controls the buoyancy
+        force, which is a density-dependent force in the opposite direction of gravity.
+        This should be used when simulating gas like smoke or fire, or fluids that
+        are less dense than the surrounding material.
+      m_Regex: 
+      m_RegexMaxLength: 0
+  m_Direction: 0
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618143
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a9f9544b71b7dab44a4644b6807e8bf6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618132}
+  m_Children:
+  - {fileID: 8926484042661618144}
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618132}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: Gravity
+    m_serializedType:
+      m_SerializableType: UnityEditor.VFX.Vector, Unity.VisualEffectGraph.Editor,
+        Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+    attributes: []
+  m_Direction: 0
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618144
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac39bd03fca81b849929b9c966f1836a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618143}
+  m_Children:
+  - {fileID: 8926484042661618145}
+  - {fileID: 8926484042661618146}
+  - {fileID: 8926484042661618147}
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618132}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: vector
+    m_serializedType:
+      m_SerializableType: UnityEngine.Vector3, UnityEngine.CoreModule, Version=0.0.0.0,
+        Culture=neutral, PublicKeyToken=null
+    attributes:
+    - m_Type: 3
+      m_Min: -Infinity
+      m_Max: Infinity
+      m_Tooltip: The vector.
+      m_Regex: 
+      m_RegexMaxLength: 0
+  m_Direction: 0
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618145
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618144}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618132}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: x
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes: []
+  m_Direction: 0
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618146
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618144}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618132}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: y
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes: []
+  m_Direction: 0
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618147
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618144}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618132}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: z
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes: []
+  m_Direction: 0
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618148
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c499060cea9bbb24b8d723eafa343303, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618132}
+  m_Children:
+  - {fileID: 8926484042661618149}
+  - {fileID: 8926484042661618150}
+  - {fileID: 8926484042661618151}
+  - {fileID: 8926484042661618152}
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618132}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: KernelSize
+    m_serializedType:
+      m_SerializableType: UnityEngine.Vector4, UnityEngine.CoreModule, Version=0.0.0.0,
+        Culture=neutral, PublicKeyToken=null
+    attributes: []
+  m_Direction: 0
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618149
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618148}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618132}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: x
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes: []
+  m_Direction: 0
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618150
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618148}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618132}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: y
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes: []
+  m_Direction: 0
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618151
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618148}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618132}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: z
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes: []
+  m_Direction: 0
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618152
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618148}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618132}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: w
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes: []
+  m_Direction: 0
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618153
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c499060cea9bbb24b8d723eafa343303, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618132}
+  m_Children:
+  - {fileID: 8926484042661618154}
+  - {fileID: 8926484042661618155}
+  - {fileID: 8926484042661618156}
+  - {fileID: 8926484042661618157}
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618132}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: KernelFactors
+    m_serializedType:
+      m_SerializableType: UnityEngine.Vector4, UnityEngine.CoreModule, Version=0.0.0.0,
+        Culture=neutral, PublicKeyToken=null
+    attributes: []
+  m_Direction: 0
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618154
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618153}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618132}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: x
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes: []
+  m_Direction: 0
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618155
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618153}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618132}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: y
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes: []
+  m_Direction: 0
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618156
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618153}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618132}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: z
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes: []
+  m_Direction: 0
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618157
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618153}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618132}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: w
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes: []
+  m_Direction: 0
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618158
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 70a331b1d86cc8d4aa106ccbe0da5852, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618132}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618132}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: Tex
+    m_serializedType:
+      m_SerializableType: UnityEngine.Texture2D, UnityEngine.CoreModule, Version=0.0.0.0,
+        Culture=neutral, PublicKeyToken=null
+    attributes: []
+  m_Direction: 0
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618159
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1b2b751071c7fc14f9fa503163991826, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618132}
+  m_Children:
+  - {fileID: 8926484042661618160}
+  - {fileID: 8926484042661618161}
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618132}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: TexSize
+    m_serializedType:
+      m_SerializableType: UnityEngine.Vector2, UnityEngine.CoreModule, Version=0.0.0.0,
+        Culture=neutral, PublicKeyToken=null
+    attributes: []
+  m_Direction: 0
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618160
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618159}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618132}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: x
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes: []
+  m_Direction: 0
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618161
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618159}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618132}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: y
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes: []
+  m_Direction: 0
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618162
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2dc095764ededfa4bb32fa602511ea4b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 114350483966674976}
+  m_Children:
+  - {fileID: 8926484042661618164}
+  m_UIPosition: {x: 1351.8771, y: 160.02975}
+  m_UICollapsed: 0
+  m_UISuperCollapsed: 0
+  m_InputSlots: []
+  m_OutputSlots: []
+  m_Label: 
+  m_Data: {fileID: 8926484042661618195}
+  m_InputFlowSlot:
+  - link:
+    - context: {fileID: 8926484042661618129}
+      slotIndex: 0
+  m_OutputFlowSlot:
+  - link:
+    - context: {fileID: 8926484042661618165}
+      slotIndex: 0
+  integration: 1
+  angularIntegration: 1
+  ageParticles: 0
+  reapParticles: 1
+--- !u!114 &8926484042661618164
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -3396,16 +3098,49 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b24fedd9240514791a200cf1d9ad7673, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661615672}
+  m_Parent: {fileID: 8926484042661618162}
   m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 0
+  m_UIPosition: {x: 1393.8771, y: -356.97025}
+  m_UICollapsed: 1
   m_UISuperCollapsed: 0
-  m_InputSlots:
-  - {fileID: 8926484042661617825}
+  m_InputSlots: []
   m_OutputSlots: []
   m_Disabled: 0
---- !u!114 &8926484042661615753
+--- !u!114 &8926484042661618165
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2dc095764ededfa4bb32fa602511ea4b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 114350483966674976}
+  m_Children:
+  - {fileID: 8926484042661618167}
+  m_UIPosition: {x: 1351.8771, y: 283.02975}
+  m_UICollapsed: 0
+  m_UISuperCollapsed: 0
+  m_InputSlots: []
+  m_OutputSlots: []
+  m_Label: 
+  m_Data: {fileID: 8926484042661618195}
+  m_InputFlowSlot:
+  - link:
+    - context: {fileID: 8926484042661618162}
+      slotIndex: 0
+  m_OutputFlowSlot:
+  - link:
+    - context: {fileID: 8926484042661618168}
+      slotIndex: 0
+  integration: 1
+  angularIntegration: 1
+  ageParticles: 0
+  reapParticles: 1
+--- !u!114 &8926484042661618167
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -3417,16 +3152,103 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 47c40ab96b798458780dd052ee1994d6, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661615674}
+  m_Parent: {fileID: 8926484042661618165}
   m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 0
+  m_UIPosition: {x: 1393.8771, y: -356.97025}
+  m_UICollapsed: 1
   m_UISuperCollapsed: 0
-  m_InputSlots:
-  - {fileID: 8926484042661617855}
+  m_InputSlots: []
   m_OutputSlots: []
   m_Disabled: 0
---- !u!114 &8926484042661615783
+--- !u!114 &8926484042661618168
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2dc095764ededfa4bb32fa602511ea4b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 114350483966674976}
+  m_Children:
+  - {fileID: 8926484042661618170}
+  m_UIPosition: {x: 1351.8771, y: 406.02975}
+  m_UICollapsed: 0
+  m_UISuperCollapsed: 0
+  m_InputSlots: []
+  m_OutputSlots: []
+  m_Label: 
+  m_Data: {fileID: 8926484042661618195}
+  m_InputFlowSlot:
+  - link:
+    - context: {fileID: 8926484042661618165}
+      slotIndex: 0
+  m_OutputFlowSlot:
+  - link:
+    - context: {fileID: 8926484042661618180}
+      slotIndex: 0
+  integration: 1
+  angularIntegration: 1
+  ageParticles: 0
+  reapParticles: 1
+--- !u!114 &8926484042661618170
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bc09ccf3ed7bc4caeabb87acbc42bc10, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618168}
+  m_Children: []
+  m_UIPosition: {x: 1393.8771, y: -356.97025}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_InputSlots: []
+  m_OutputSlots: []
+  m_Disabled: 0
+--- !u!114 &8926484042661618171
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2dc095764ededfa4bb32fa602511ea4b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 114350483966674976}
+  m_Children:
+  - {fileID: 8926484042661618173}
+  m_UIPosition: {x: 1351.8771, y: 842.0298}
+  m_UICollapsed: 0
+  m_UISuperCollapsed: 0
+  m_InputSlots: []
+  m_OutputSlots: []
+  m_Label: 
+  m_Data: {fileID: 8926484042661618195}
+  m_InputFlowSlot:
+  - link:
+    - context: {fileID: 8926484042661618180}
+      slotIndex: 0
+  m_OutputFlowSlot:
+  - link:
+    - context: {fileID: 8926484042661618174}
+      slotIndex: 0
+  integration: 1
+  angularIntegration: 1
+  ageParticles: 0
+  reapParticles: 1
+--- !u!114 &8926484042661618173
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -3438,16 +3260,49 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7f1a69e398cef41a69d4e71a3283432b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661615676}
+  m_Parent: {fileID: 8926484042661618171}
   m_Children: []
-  m_UIPosition: {x: 0, y: 2}
-  m_UICollapsed: 0
+  m_UIPosition: {x: 1393.8771, y: -356.97025}
+  m_UICollapsed: 1
   m_UISuperCollapsed: 0
-  m_InputSlots:
-  - {fileID: 8926484042661617885}
+  m_InputSlots: []
   m_OutputSlots: []
   m_Disabled: 0
---- !u!114 &8926484042661615813
+--- !u!114 &8926484042661618174
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2dc095764ededfa4bb32fa602511ea4b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 114350483966674976}
+  m_Children:
+  - {fileID: 8926484042661618176}
+  m_UIPosition: {x: 1351.8771, y: 965.0298}
+  m_UICollapsed: 0
+  m_UISuperCollapsed: 0
+  m_InputSlots: []
+  m_OutputSlots: []
+  m_Label: 
+  m_Data: {fileID: 8926484042661618195}
+  m_InputFlowSlot:
+  - link:
+    - context: {fileID: 8926484042661618171}
+      slotIndex: 0
+  m_OutputFlowSlot:
+  - link:
+    - context: {fileID: 8926484042661618177}
+      slotIndex: 0
+  integration: 1
+  angularIntegration: 1
+  ageParticles: 0
+  reapParticles: 1
+--- !u!114 &8926484042661618176
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -3459,20 +3314,158 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7cc173ad5f0fb406ba27fcb79ad9ec13, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661615678}
+  m_Parent: {fileID: 8926484042661618174}
   m_Children: []
-  m_UIPosition: {x: 0, y: 2}
+  m_UIPosition: {x: 1393.8771, y: -356.97025}
   m_UICollapsed: 0
   m_UISuperCollapsed: 0
-  m_InputSlots:
-  - {fileID: 8926484042661617915}
+  m_InputSlots: []
   m_OutputSlots: []
   m_Disabled: 0
   SurfaceTension: 1
   Turbulence: 1
   Gravity: 1
   BuoyancyForce: 1
---- !u!114 &8926484042661615843
+  Collision: 1
+--- !u!114 &8926484042661618177
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2dc095764ededfa4bb32fa602511ea4b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 114350483966674976}
+  m_Children:
+  - {fileID: 8926484042661618179}
+  m_UIPosition: {x: 1350.8771, y: 1348.0298}
+  m_UICollapsed: 0
+  m_UISuperCollapsed: 0
+  m_InputSlots: []
+  m_OutputSlots: []
+  m_Label: 
+  m_Data: {fileID: 8926484042661618195}
+  m_InputFlowSlot:
+  - link:
+    - context: {fileID: 8926484042661618174}
+      slotIndex: 0
+  m_OutputFlowSlot:
+  - link:
+    - context: {fileID: 8926484042661618216}
+      slotIndex: 0
+  integration: 1
+  angularIntegration: 0
+  ageParticles: 1
+  reapParticles: 1
+--- !u!114 &8926484042661618179
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: af49bc557521a417ab5daee69476f797, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618177}
+  m_Children: []
+  m_UIPosition: {x: 1393.8771, y: -356.97025}
+  m_UICollapsed: 0
+  m_UISuperCollapsed: 0
+  m_InputSlots: []
+  m_OutputSlots: []
+  m_Disabled: 0
+  IntegrationMode: 0
+--- !u!114 &8926484042661618180
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2dc095764ededfa4bb32fa602511ea4b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 114350483966674976}
+  m_Children: []
+  m_UIPosition: {x: 888.8771, y: 692.0298}
+  m_UICollapsed: 0
+  m_UISuperCollapsed: 0
+  m_InputSlots: []
+  m_OutputSlots: []
+  m_Label: 
+  m_Data: {fileID: 8926484042661618195}
+  m_InputFlowSlot:
+  - link:
+    - context: {fileID: 8926484042661618168}
+      slotIndex: 0
+  m_OutputFlowSlot:
+  - link:
+    - context: {fileID: 8926484042661618171}
+      slotIndex: 0
+  integration: 1
+  angularIntegration: 1
+  ageParticles: 0
+  reapParticles: 0
+--- !u!114 &8926484042661618182
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 73a13919d81fb7444849bae8b5c812a2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 114350483966674976}
+  m_Children:
+  - {fileID: 8926484042661618183}
+  m_UIPosition: {x: 2109.877, y: -1383.9702}
+  m_UICollapsed: 0
+  m_UISuperCollapsed: 0
+  m_InputSlots: []
+  m_OutputSlots: []
+  m_Label: 
+  m_Data: {fileID: 0}
+  m_InputFlowSlot:
+  - link: []
+  - link: []
+  m_OutputFlowSlot:
+  - link:
+    - context: {fileID: 8926484042661618185}
+      slotIndex: 0
+--- !u!114 &8926484042661618183
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f05c6884b705ce14d82ae720f0ec209f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618182}
+  m_Children: []
+  m_UIPosition: {x: 1393.8771, y: -356.97025}
+  m_UICollapsed: 0
+  m_UISuperCollapsed: 0
+  m_InputSlots:
+  - {fileID: 8926484042661618184}
+  m_OutputSlots: []
+  m_Disabled: 0
+--- !u!114 &8926484042661618184
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -3489,9 +3482,462 @@ MonoBehaviour:
   m_UIPosition: {x: 0, y: 0}
   m_UICollapsed: 1
   m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661615843}
+  m_MasterSlot: {fileID: 8926484042661618184}
   m_MasterData:
-    m_Owner: {fileID: 114131763552434164}
+    m_Owner: {fileID: 8926484042661618183}
+    m_Value:
+      m_Type:
+        m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+          PublicKeyToken=b77a5c561934e089
+      m_SerializableObject: 2000
+    m_Space: 2147483647
+  m_Property:
+    name: Rate
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes:
+    - m_Type: 1
+      m_Min: 0
+      m_Max: Infinity
+      m_Tooltip: 
+      m_Regex: 
+      m_RegexMaxLength: 0
+    - m_Type: 3
+      m_Min: -Infinity
+      m_Max: Infinity
+      m_Tooltip: Spawn Rate (in number per seconds)
+      m_Regex: 
+      m_RegexMaxLength: 0
+  m_Direction: 0
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618185
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9dfea48843f53fc438eabc12a3a30abc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 114350483966674976}
+  m_Children:
+  - {fileID: 8926484042661618196}
+  - {fileID: 8926484042661618198}
+  - {fileID: 8926484042661618208}
+  m_UIPosition: {x: 2109.877, y: -1193.9702}
+  m_UICollapsed: 0
+  m_UISuperCollapsed: 0
+  m_InputSlots:
+  - {fileID: 8926484042661618186}
+  m_OutputSlots: []
+  m_Label: 
+  m_Data: {fileID: 8926484042661618195}
+  m_InputFlowSlot:
+  - link:
+    - context: {fileID: 8926484042661618182}
+      slotIndex: 0
+  m_OutputFlowSlot:
+  - link:
+    - context: {fileID: 8926484042661618129}
+      slotIndex: 0
+--- !u!114 &8926484042661618186
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1b605c022ee79394a8a776c0869b3f9a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 0}
+  m_Children:
+  - {fileID: 8926484042661618187}
+  - {fileID: 8926484042661618191}
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 0
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618186}
+  m_MasterData:
+    m_Owner: {fileID: 8926484042661618185}
+    m_Value:
+      m_Type:
+        m_SerializableType: UnityEditor.VFX.AABox, Unity.VisualEffectGraph.Editor,
+          Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+      m_SerializableObject: '{"center":{"x":0.0,"y":-0.25,"z":0.0},"size":{"x":3.0,"y":6.5,"z":3.0}}'
+    m_Space: 0
+  m_Property:
+    name: bounds
+    m_serializedType:
+      m_SerializableType: UnityEditor.VFX.AABox, Unity.VisualEffectGraph.Editor, Version=0.0.0.0,
+        Culture=neutral, PublicKeyToken=null
+    attributes: []
+  m_Direction: 0
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618187
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac39bd03fca81b849929b9c966f1836a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618186}
+  m_Children:
+  - {fileID: 8926484042661618188}
+  - {fileID: 8926484042661618189}
+  - {fileID: 8926484042661618190}
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618186}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: center
+    m_serializedType:
+      m_SerializableType: UnityEngine.Vector3, UnityEngine.CoreModule, Version=0.0.0.0,
+        Culture=neutral, PublicKeyToken=null
+    attributes:
+    - m_Type: 3
+      m_Min: -Infinity
+      m_Max: Infinity
+      m_Tooltip: The centre of the box.
+      m_Regex: 
+      m_RegexMaxLength: 0
+  m_Direction: 0
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618188
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618187}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618186}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: x
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes: []
+  m_Direction: 0
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618189
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618187}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618186}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: y
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes: []
+  m_Direction: 0
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618190
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618187}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618186}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: z
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes: []
+  m_Direction: 0
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618191
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac39bd03fca81b849929b9c966f1836a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618186}
+  m_Children:
+  - {fileID: 8926484042661618192}
+  - {fileID: 8926484042661618193}
+  - {fileID: 8926484042661618194}
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 0
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618186}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: size
+    m_serializedType:
+      m_SerializableType: UnityEngine.Vector3, UnityEngine.CoreModule, Version=0.0.0.0,
+        Culture=neutral, PublicKeyToken=null
+    attributes:
+    - m_Type: 3
+      m_Min: -Infinity
+      m_Max: Infinity
+      m_Tooltip: The size of the box along each axis.
+      m_Regex: 
+      m_RegexMaxLength: 0
+  m_Direction: 0
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618192
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618191}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618186}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: x
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes: []
+  m_Direction: 0
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618193
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618191}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618186}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: y
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes: []
+  m_Direction: 0
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618194
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618191}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618186}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: z
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes: []
+  m_Direction: 0
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618195
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d78581a96eae8bf4398c282eb0b098bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 114350483966674976}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_Owners:
+  - {fileID: 8926484042661618185}
+  - {fileID: 8926484042661618129}
+  - {fileID: 8926484042661618162}
+  - {fileID: 8926484042661618165}
+  - {fileID: 8926484042661618168}
+  - {fileID: 8926484042661618180}
+  - {fileID: 8926484042661618171}
+  - {fileID: 8926484042661618174}
+  - {fileID: 8926484042661618177}
+  - {fileID: 8926484042661618216}
+  m_Capacity: 2000
+  m_Space: 1
+--- !u!114 &8926484042661618196
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a971fa2e110a0ac42ac1d8dae408704b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618185}
+  m_Children: []
+  m_UIPosition: {x: 1393.8771, y: -356.97025}
+  m_UICollapsed: 0
+  m_UISuperCollapsed: 0
+  m_InputSlots:
+  - {fileID: 8926484042661618197}
+  m_OutputSlots: []
+  m_Disabled: 0
+  attribute: lifetime
+  Composition: 0
+  Source: 0
+  Random: 0
+  channels: 6
+--- !u!114 &8926484042661618197
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 0}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618197}
+  m_MasterData:
+    m_Owner: {fileID: 8926484042661618196}
     m_Value:
       m_Type:
         m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
@@ -3506,62 +3952,7 @@ MonoBehaviour:
     attributes: []
   m_Direction: 0
   m_LinkedSlots: []
---- !u!114 &8926484042661615844
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2dc095764ededfa4bb32fa602511ea4b, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 114350483966674976}
-  m_Children:
-  - {fileID: 8926484042661615847}
-  m_UIPosition: {x: 716, y: 956}
-  m_UICollapsed: 0
-  m_UISuperCollapsed: 0
-  m_InputSlots: []
-  m_OutputSlots: []
-  m_Label: 
-  m_Data: {fileID: 114428730288789306}
-  m_InputFlowSlot:
-  - link:
-    - context: {fileID: 8926484042661615674}
-      slotIndex: 0
-  m_OutputFlowSlot:
-  - link:
-    - context: {fileID: 8926484042661615676}
-      slotIndex: 0
-  integration: 1
-  angularIntegration: 1
-  ageParticles: 0
-  reapParticles: 1
---- !u!114 &8926484042661615847
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: bc09ccf3ed7bc4caeabb87acbc42bc10, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661615844}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 0
-  m_UISuperCollapsed: 0
-  m_InputSlots:
-  - {fileID: 8926484042661617945}
-  m_OutputSlots: []
-  m_Disabled: 0
---- !u!114 &8926484042661615881
+--- !u!114 &8926484042661618198
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -3573,19 +3964,19 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a62d0a0d1ca34bc4589538e8cd1996b0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Parent: {fileID: 114946465509916290}
+  m_Parent: {fileID: 8926484042661618185}
   m_Children: []
-  m_UIPosition: {x: 0, y: 154}
+  m_UIPosition: {x: 1393.8771, y: -204.97025}
   m_UICollapsed: 0
   m_UISuperCollapsed: 0
   m_InputSlots:
-  - {fileID: 8926484042661615882}
+  - {fileID: 8926484042661618199}
   m_OutputSlots: []
   m_Disabled: 0
   positionMode: 0
   spawnMode: 0
   heightMode: 1
---- !u!114 &8926484042661615882
+--- !u!114 &8926484042661618199
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -3599,17 +3990,17 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Parent: {fileID: 0}
   m_Children:
-  - {fileID: 8926484042661615883}
-  - {fileID: 8926484042661615887}
-  - {fileID: 8926484042661615888}
-  - {fileID: 8926484042661615889}
-  - {fileID: 8926484042661615890}
+  - {fileID: 8926484042661618200}
+  - {fileID: 8926484042661618204}
+  - {fileID: 8926484042661618205}
+  - {fileID: 8926484042661618206}
+  - {fileID: 8926484042661618207}
   m_UIPosition: {x: 0, y: 0}
   m_UICollapsed: 0
   m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661615882}
+  m_MasterSlot: {fileID: 8926484042661618199}
   m_MasterData:
-    m_Owner: {fileID: 8926484042661615881}
+    m_Owner: {fileID: 8926484042661618198}
     m_Value:
       m_Type:
         m_SerializableType: UnityEditor.VFX.ArcCone, Unity.VisualEffectGraph.Editor,
@@ -3630,7 +4021,7 @@ MonoBehaviour:
       m_RegexMaxLength: 0
   m_Direction: 0
   m_LinkedSlots: []
---- !u!114 &8926484042661615883
+--- !u!114 &8926484042661618200
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -3642,15 +4033,15 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ac39bd03fca81b849929b9c966f1836a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661615882}
+  m_Parent: {fileID: 8926484042661618199}
   m_Children:
-  - {fileID: 8926484042661615884}
-  - {fileID: 8926484042661615885}
-  - {fileID: 8926484042661615886}
+  - {fileID: 8926484042661618201}
+  - {fileID: 8926484042661618202}
+  - {fileID: 8926484042661618203}
   m_UIPosition: {x: 0, y: 0}
   m_UICollapsed: 1
   m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661615882}
+  m_MasterSlot: {fileID: 8926484042661618199}
   m_MasterData:
     m_Owner: {fileID: 0}
     m_Value:
@@ -3672,7 +4063,7 @@ MonoBehaviour:
       m_RegexMaxLength: 0
   m_Direction: 0
   m_LinkedSlots: []
---- !u!114 &8926484042661615884
+--- !u!114 &8926484042661618201
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -3684,12 +4075,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661615883}
+  m_Parent: {fileID: 8926484042661618200}
   m_Children: []
   m_UIPosition: {x: 0, y: 0}
   m_UICollapsed: 1
   m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661615882}
+  m_MasterSlot: {fileID: 8926484042661618199}
   m_MasterData:
     m_Owner: {fileID: 0}
     m_Value:
@@ -3705,7 +4096,7 @@ MonoBehaviour:
     attributes: []
   m_Direction: 0
   m_LinkedSlots: []
---- !u!114 &8926484042661615885
+--- !u!114 &8926484042661618202
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -3717,12 +4108,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661615883}
+  m_Parent: {fileID: 8926484042661618200}
   m_Children: []
   m_UIPosition: {x: 0, y: 0}
   m_UICollapsed: 1
   m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661615882}
+  m_MasterSlot: {fileID: 8926484042661618199}
   m_MasterData:
     m_Owner: {fileID: 0}
     m_Value:
@@ -3738,7 +4129,7 @@ MonoBehaviour:
     attributes: []
   m_Direction: 0
   m_LinkedSlots: []
---- !u!114 &8926484042661615886
+--- !u!114 &8926484042661618203
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -3750,12 +4141,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661615883}
+  m_Parent: {fileID: 8926484042661618200}
   m_Children: []
   m_UIPosition: {x: 0, y: 0}
   m_UICollapsed: 1
   m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661615882}
+  m_MasterSlot: {fileID: 8926484042661618199}
   m_MasterData:
     m_Owner: {fileID: 0}
     m_Value:
@@ -3771,7 +4162,7 @@ MonoBehaviour:
     attributes: []
   m_Direction: 0
   m_LinkedSlots: []
---- !u!114 &8926484042661615887
+--- !u!114 &8926484042661618204
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -3783,12 +4174,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661615882}
+  m_Parent: {fileID: 8926484042661618199}
   m_Children: []
   m_UIPosition: {x: 0, y: 0}
   m_UICollapsed: 1
   m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661615882}
+  m_MasterSlot: {fileID: 8926484042661618199}
   m_MasterData:
     m_Owner: {fileID: 0}
     m_Value:
@@ -3810,7 +4201,7 @@ MonoBehaviour:
       m_RegexMaxLength: 0
   m_Direction: 0
   m_LinkedSlots: []
---- !u!114 &8926484042661615888
+--- !u!114 &8926484042661618205
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -3822,12 +4213,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661615882}
+  m_Parent: {fileID: 8926484042661618199}
   m_Children: []
   m_UIPosition: {x: 0, y: 0}
   m_UICollapsed: 1
   m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661615882}
+  m_MasterSlot: {fileID: 8926484042661618199}
   m_MasterData:
     m_Owner: {fileID: 0}
     m_Value:
@@ -3849,7 +4240,7 @@ MonoBehaviour:
       m_RegexMaxLength: 0
   m_Direction: 0
   m_LinkedSlots: []
---- !u!114 &8926484042661615889
+--- !u!114 &8926484042661618206
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -3861,12 +4252,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661615882}
+  m_Parent: {fileID: 8926484042661618199}
   m_Children: []
   m_UIPosition: {x: 0, y: 0}
   m_UICollapsed: 1
   m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661615882}
+  m_MasterSlot: {fileID: 8926484042661618199}
   m_MasterData:
     m_Owner: {fileID: 0}
     m_Value:
@@ -3888,7 +4279,7 @@ MonoBehaviour:
       m_RegexMaxLength: 0
   m_Direction: 0
   m_LinkedSlots: []
---- !u!114 &8926484042661615890
+--- !u!114 &8926484042661618207
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -3900,12 +4291,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661615882}
+  m_Parent: {fileID: 8926484042661618199}
   m_Children: []
   m_UIPosition: {x: 0, y: 0}
   m_UICollapsed: 1
   m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661615882}
+  m_MasterSlot: {fileID: 8926484042661618199}
   m_MasterData:
     m_Owner: {fileID: 0}
     m_Value:
@@ -3939,9909 +4330,7 @@ MonoBehaviour:
       m_RegexMaxLength: 0
   m_Direction: 0
   m_LinkedSlots: []
---- !u!114 &8926484042661617765
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1b605c022ee79394a8a776c0869b3f9a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 0}
-  m_Children:
-  - {fileID: 8926484042661617766}
-  - {fileID: 8926484042661617776}
-  - {fileID: 8926484042661617781}
-  - {fileID: 8926484042661617786}
-  - {fileID: 8926484042661617791}
-  - {fileID: 8926484042661617792}
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617765}
-  m_MasterData:
-    m_Owner: {fileID: 8926484042661615687}
-    m_Value:
-      m_Type:
-        m_SerializableType: Thinksquirrel.FluvioFX.Editor.SolverData, Thinksquirrel.FluvioFX.Editor,
-          Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-      m_SerializableObject: '{"Fluid":{"SmoothingDistance":0.3812499940395355,"ParticleMass":7.625,"Density":998.2899780273438,"MinimumDensity":499.1449890136719,"GasConstant":0.009999999776482582,"Viscosity":1.0,"Turbulence":0.20000000298023225,"SurfaceTension":0.7279999852180481,"BuoyancyCoefficient":0.0},"Gravity":{"vector":{"x":0.0,"y":0.0,"z":0.0}},"KernelSize":{"x":0.3812499940395355,"y":0.1453515589237213,"z":0.055415280163288119,"w":1.0},"KernelFactors":{"x":9206.4482421875,"y":1554.8280029296875,"z":43.08060836791992,"w":0.0},"Tex":{"instanceID":0},"TexSize":{"x":0.0,"y":0.0}}'
-    m_Space: 0
-  m_Property:
-    name: solverData
-    m_serializedType:
-      m_SerializableType: Thinksquirrel.FluvioFX.Editor.SolverData, Thinksquirrel.FluvioFX.Editor,
-        Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots:
-  - {fileID: 8926484042661618026}
---- !u!114 &8926484042661617766
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1b605c022ee79394a8a776c0869b3f9a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617765}
-  m_Children:
-  - {fileID: 8926484042661617767}
-  - {fileID: 8926484042661617768}
-  - {fileID: 8926484042661617769}
-  - {fileID: 8926484042661617770}
-  - {fileID: 8926484042661617771}
-  - {fileID: 8926484042661617772}
-  - {fileID: 8926484042661617773}
-  - {fileID: 8926484042661617774}
-  - {fileID: 8926484042661617775}
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617765}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: Fluid
-    m_serializedType:
-      m_SerializableType: Thinksquirrel.FluvioFX.Editor.Fluid, Thinksquirrel.FluvioFX.Editor,
-        Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617767
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617766}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617765}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: SmoothingDistance
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 9.9999994e-11
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the smoothing distance of fluid particles. This changes
-        the overall simulation resolution and greatly affects all other properties.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617768
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617766}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617765}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: ParticleMass
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 9.9999994e-11
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the mass of each fluid particle.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617769
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617766}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617765}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: Density
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 9.9999994e-11
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the overall density of the fluid.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617770
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617766}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617765}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: MinimumDensity
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 9.9999994e-11
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the minimum density of any fluid particle. This can be used
-        to help stabilize a low-viscosity fluid.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617771
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617766}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617765}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: GasConstant
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 9.9999994e-11
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the gas constant of the fluid, which in turn affects the
-        pressure forces applied to particles.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617772
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617766}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617765}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: Viscosity
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 9.9999994e-11
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the artificial viscosity force of the fluid.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617773
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617766}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617765}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: TurbulenceProbability
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 0
-      m_Min: 0
-      m_Max: 1
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the turbulence probability of the fluid. The turbulence
-        probability is a threshold beyond which a particle may become turbulent. Turbulent
-        particles will not affect non-turbulent particles. Fluid particles are not
-        turbulent by default. Turbulent forces are typically applied through effectors,
-        using the Vorticity property.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617774
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617766}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617765}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: SurfaceTension
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 0
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the surface tension of the fluid (intended for liquids only).
-        FluvioFX uses a simplified surface tension model that is ideal for realtime
-        use.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617775
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617766}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617765}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: BuoyancyCoefficient
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 0
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the buoyancy coefficient of a fluid. This controls the buoyancy
-        force, which is a density-dependent force in the opposite direction of gravity.
-        This should be used when simulating gas like smoke or fire, or fluids that
-        are less dense than the surrounding material.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617776
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a9f9544b71b7dab44a4644b6807e8bf6, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617765}
-  m_Children:
-  - {fileID: 8926484042661617777}
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617765}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: Gravity
-    m_serializedType:
-      m_SerializableType: UnityEditor.VFX.Vector, Unity.VisualEffectGraph.Editor,
-        Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617777
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ac39bd03fca81b849929b9c966f1836a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617776}
-  m_Children:
-  - {fileID: 8926484042661617778}
-  - {fileID: 8926484042661617779}
-  - {fileID: 8926484042661617780}
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617765}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: vector
-    m_serializedType:
-      m_SerializableType: UnityEngine.Vector3, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-    attributes:
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: The vector.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617778
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617777}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617765}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: x
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617779
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617777}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617765}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: y
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617780
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617777}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617765}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: z
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617781
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c499060cea9bbb24b8d723eafa343303, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617765}
-  m_Children:
-  - {fileID: 8926484042661617782}
-  - {fileID: 8926484042661617783}
-  - {fileID: 8926484042661617784}
-  - {fileID: 8926484042661617785}
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617765}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: KernelSize
-    m_serializedType:
-      m_SerializableType: UnityEngine.Vector4, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617782
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617781}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617765}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: x
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617783
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617781}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617765}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: y
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617784
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617781}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617765}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: z
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617785
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617781}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617765}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: w
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617786
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c499060cea9bbb24b8d723eafa343303, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617765}
-  m_Children:
-  - {fileID: 8926484042661617787}
-  - {fileID: 8926484042661617788}
-  - {fileID: 8926484042661617789}
-  - {fileID: 8926484042661617790}
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617765}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: KernelFactors
-    m_serializedType:
-      m_SerializableType: UnityEngine.Vector4, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617787
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617786}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617765}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: x
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617788
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617786}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617765}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: y
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617789
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617786}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617765}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: z
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617790
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617786}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617765}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: w
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617791
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 70a331b1d86cc8d4aa106ccbe0da5852, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617765}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617765}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: Tex
-    m_serializedType:
-      m_SerializableType: UnityEngine.Texture2D, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617792
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1b2b751071c7fc14f9fa503163991826, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617765}
-  m_Children:
-  - {fileID: 8926484042661617793}
-  - {fileID: 8926484042661617794}
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617765}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: TexSize
-    m_serializedType:
-      m_SerializableType: UnityEngine.Vector2, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617793
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617792}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617765}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: x
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617794
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617792}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617765}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: y
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617795
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1b605c022ee79394a8a776c0869b3f9a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 0}
-  m_Children:
-  - {fileID: 8926484042661617796}
-  - {fileID: 8926484042661617806}
-  - {fileID: 8926484042661617811}
-  - {fileID: 8926484042661617816}
-  - {fileID: 8926484042661617821}
-  - {fileID: 8926484042661617822}
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617795}
-  m_MasterData:
-    m_Owner: {fileID: 8926484042661615693}
-    m_Value:
-      m_Type:
-        m_SerializableType: Thinksquirrel.FluvioFX.Editor.SolverData, Thinksquirrel.FluvioFX.Editor,
-          Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-      m_SerializableObject: '{"Fluid":{"SmoothingDistance":0.3812499940395355,"ParticleMass":7.625,"Density":998.2899780273438,"MinimumDensity":499.1449890136719,"GasConstant":0.009999999776482582,"Viscosity":1.0,"Turbulence":0.20000000298023225,"SurfaceTension":0.7279999852180481,"BuoyancyCoefficient":0.0},"Gravity":{"vector":{"x":0.0,"y":0.0,"z":0.0}},"KernelSize":{"x":0.3812499940395355,"y":0.1453515589237213,"z":0.055415280163288119,"w":1.0},"KernelFactors":{"x":9206.4482421875,"y":1554.8280029296875,"z":43.08060836791992,"w":0.0},"Tex":{"instanceID":0},"TexSize":{"x":0.0,"y":0.0}}'
-    m_Space: 0
-  m_Property:
-    name: solverData
-    m_serializedType:
-      m_SerializableType: Thinksquirrel.FluvioFX.Editor.SolverData, Thinksquirrel.FluvioFX.Editor,
-        Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots:
-  - {fileID: 8926484042661618026}
---- !u!114 &8926484042661617796
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1b605c022ee79394a8a776c0869b3f9a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617795}
-  m_Children:
-  - {fileID: 8926484042661617797}
-  - {fileID: 8926484042661617798}
-  - {fileID: 8926484042661617799}
-  - {fileID: 8926484042661617800}
-  - {fileID: 8926484042661617801}
-  - {fileID: 8926484042661617802}
-  - {fileID: 8926484042661617803}
-  - {fileID: 8926484042661617804}
-  - {fileID: 8926484042661617805}
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617795}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: Fluid
-    m_serializedType:
-      m_SerializableType: Thinksquirrel.FluvioFX.Editor.Fluid, Thinksquirrel.FluvioFX.Editor,
-        Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617797
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617796}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617795}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: SmoothingDistance
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 9.9999994e-11
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the smoothing distance of fluid particles. This changes
-        the overall simulation resolution and greatly affects all other properties.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617798
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617796}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617795}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: ParticleMass
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 9.9999994e-11
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the mass of each fluid particle.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617799
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617796}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617795}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: Density
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 9.9999994e-11
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the overall density of the fluid.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617800
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617796}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617795}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: MinimumDensity
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 9.9999994e-11
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the minimum density of any fluid particle. This can be used
-        to help stabilize a low-viscosity fluid.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617801
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617796}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617795}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: GasConstant
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 9.9999994e-11
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the gas constant of the fluid, which in turn affects the
-        pressure forces applied to particles.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617802
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617796}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617795}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: Viscosity
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 9.9999994e-11
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the artificial viscosity force of the fluid.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617803
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617796}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617795}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: TurbulenceProbability
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 0
-      m_Min: 0
-      m_Max: 1
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the turbulence probability of the fluid. The turbulence
-        probability is a threshold beyond which a particle may become turbulent. Turbulent
-        particles will not affect non-turbulent particles. Fluid particles are not
-        turbulent by default. Turbulent forces are typically applied through effectors,
-        using the Vorticity property.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617804
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617796}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617795}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: SurfaceTension
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 0
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the surface tension of the fluid (intended for liquids only).
-        FluvioFX uses a simplified surface tension model that is ideal for realtime
-        use.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617805
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617796}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617795}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: BuoyancyCoefficient
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 0
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the buoyancy coefficient of a fluid. This controls the buoyancy
-        force, which is a density-dependent force in the opposite direction of gravity.
-        This should be used when simulating gas like smoke or fire, or fluids that
-        are less dense than the surrounding material.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617806
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a9f9544b71b7dab44a4644b6807e8bf6, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617795}
-  m_Children:
-  - {fileID: 8926484042661617807}
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617795}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: Gravity
-    m_serializedType:
-      m_SerializableType: UnityEditor.VFX.Vector, Unity.VisualEffectGraph.Editor,
-        Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617807
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ac39bd03fca81b849929b9c966f1836a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617806}
-  m_Children:
-  - {fileID: 8926484042661617808}
-  - {fileID: 8926484042661617809}
-  - {fileID: 8926484042661617810}
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617795}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: vector
-    m_serializedType:
-      m_SerializableType: UnityEngine.Vector3, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-    attributes:
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: The vector.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617808
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617807}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617795}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: x
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617809
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617807}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617795}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: y
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617810
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617807}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617795}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: z
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617811
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c499060cea9bbb24b8d723eafa343303, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617795}
-  m_Children:
-  - {fileID: 8926484042661617812}
-  - {fileID: 8926484042661617813}
-  - {fileID: 8926484042661617814}
-  - {fileID: 8926484042661617815}
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617795}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: KernelSize
-    m_serializedType:
-      m_SerializableType: UnityEngine.Vector4, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617812
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617811}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617795}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: x
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617813
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617811}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617795}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: y
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617814
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617811}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617795}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: z
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617815
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617811}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617795}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: w
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617816
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c499060cea9bbb24b8d723eafa343303, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617795}
-  m_Children:
-  - {fileID: 8926484042661617817}
-  - {fileID: 8926484042661617818}
-  - {fileID: 8926484042661617819}
-  - {fileID: 8926484042661617820}
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617795}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: KernelFactors
-    m_serializedType:
-      m_SerializableType: UnityEngine.Vector4, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617817
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617816}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617795}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: x
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617818
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617816}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617795}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: y
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617819
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617816}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617795}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: z
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617820
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617816}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617795}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: w
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617821
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 70a331b1d86cc8d4aa106ccbe0da5852, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617795}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617795}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: Tex
-    m_serializedType:
-      m_SerializableType: UnityEngine.Texture2D, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617822
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1b2b751071c7fc14f9fa503163991826, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617795}
-  m_Children:
-  - {fileID: 8926484042661617823}
-  - {fileID: 8926484042661617824}
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617795}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: TexSize
-    m_serializedType:
-      m_SerializableType: UnityEngine.Vector2, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617823
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617822}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617795}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: x
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617824
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617822}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617795}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: y
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617825
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1b605c022ee79394a8a776c0869b3f9a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 0}
-  m_Children:
-  - {fileID: 8926484042661617826}
-  - {fileID: 8926484042661617836}
-  - {fileID: 8926484042661617841}
-  - {fileID: 8926484042661617846}
-  - {fileID: 8926484042661617851}
-  - {fileID: 8926484042661617852}
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617825}
-  m_MasterData:
-    m_Owner: {fileID: 8926484042661615723}
-    m_Value:
-      m_Type:
-        m_SerializableType: Thinksquirrel.FluvioFX.Editor.SolverData, Thinksquirrel.FluvioFX.Editor,
-          Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-      m_SerializableObject: '{"Fluid":{"SmoothingDistance":0.3812499940395355,"ParticleMass":7.625,"Density":998.2899780273438,"MinimumDensity":499.1449890136719,"GasConstant":0.009999999776482582,"Viscosity":1.0,"Turbulence":0.20000000298023225,"SurfaceTension":0.7279999852180481,"BuoyancyCoefficient":0.0},"Gravity":{"vector":{"x":0.0,"y":0.0,"z":0.0}},"KernelSize":{"x":0.3812499940395355,"y":0.1453515589237213,"z":0.055415280163288119,"w":1.0},"KernelFactors":{"x":9206.4482421875,"y":1554.8280029296875,"z":43.08060836791992,"w":0.0},"Tex":{"instanceID":0},"TexSize":{"x":0.0,"y":0.0}}'
-    m_Space: 0
-  m_Property:
-    name: solverData
-    m_serializedType:
-      m_SerializableType: Thinksquirrel.FluvioFX.Editor.SolverData, Thinksquirrel.FluvioFX.Editor,
-        Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots:
-  - {fileID: 8926484042661618026}
---- !u!114 &8926484042661617826
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1b605c022ee79394a8a776c0869b3f9a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617825}
-  m_Children:
-  - {fileID: 8926484042661617827}
-  - {fileID: 8926484042661617828}
-  - {fileID: 8926484042661617829}
-  - {fileID: 8926484042661617830}
-  - {fileID: 8926484042661617831}
-  - {fileID: 8926484042661617832}
-  - {fileID: 8926484042661617833}
-  - {fileID: 8926484042661617834}
-  - {fileID: 8926484042661617835}
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617825}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: Fluid
-    m_serializedType:
-      m_SerializableType: Thinksquirrel.FluvioFX.Editor.Fluid, Thinksquirrel.FluvioFX.Editor,
-        Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617827
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617826}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617825}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: SmoothingDistance
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 9.9999994e-11
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the smoothing distance of fluid particles. This changes
-        the overall simulation resolution and greatly affects all other properties.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617828
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617826}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617825}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: ParticleMass
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 9.9999994e-11
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the mass of each fluid particle.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617829
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617826}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617825}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: Density
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 9.9999994e-11
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the overall density of the fluid.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617830
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617826}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617825}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: MinimumDensity
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 9.9999994e-11
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the minimum density of any fluid particle. This can be used
-        to help stabilize a low-viscosity fluid.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617831
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617826}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617825}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: GasConstant
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 9.9999994e-11
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the gas constant of the fluid, which in turn affects the
-        pressure forces applied to particles.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617832
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617826}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617825}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: Viscosity
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 9.9999994e-11
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the artificial viscosity force of the fluid.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617833
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617826}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617825}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: TurbulenceProbability
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 0
-      m_Min: 0
-      m_Max: 1
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the turbulence probability of the fluid. The turbulence
-        probability is a threshold beyond which a particle may become turbulent. Turbulent
-        particles will not affect non-turbulent particles. Fluid particles are not
-        turbulent by default. Turbulent forces are typically applied through effectors,
-        using the Vorticity property.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617834
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617826}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617825}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: SurfaceTension
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 0
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the surface tension of the fluid (intended for liquids only).
-        FluvioFX uses a simplified surface tension model that is ideal for realtime
-        use.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617835
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617826}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617825}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: BuoyancyCoefficient
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 0
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the buoyancy coefficient of a fluid. This controls the buoyancy
-        force, which is a density-dependent force in the opposite direction of gravity.
-        This should be used when simulating gas like smoke or fire, or fluids that
-        are less dense than the surrounding material.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617836
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a9f9544b71b7dab44a4644b6807e8bf6, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617825}
-  m_Children:
-  - {fileID: 8926484042661617837}
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617825}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: Gravity
-    m_serializedType:
-      m_SerializableType: UnityEditor.VFX.Vector, Unity.VisualEffectGraph.Editor,
-        Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617837
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ac39bd03fca81b849929b9c966f1836a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617836}
-  m_Children:
-  - {fileID: 8926484042661617838}
-  - {fileID: 8926484042661617839}
-  - {fileID: 8926484042661617840}
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617825}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: vector
-    m_serializedType:
-      m_SerializableType: UnityEngine.Vector3, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-    attributes:
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: The vector.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617838
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617837}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617825}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: x
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617839
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617837}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617825}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: y
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617840
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617837}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617825}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: z
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617841
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c499060cea9bbb24b8d723eafa343303, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617825}
-  m_Children:
-  - {fileID: 8926484042661617842}
-  - {fileID: 8926484042661617843}
-  - {fileID: 8926484042661617844}
-  - {fileID: 8926484042661617845}
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617825}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: KernelSize
-    m_serializedType:
-      m_SerializableType: UnityEngine.Vector4, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617842
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617841}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617825}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: x
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617843
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617841}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617825}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: y
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617844
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617841}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617825}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: z
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617845
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617841}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617825}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: w
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617846
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c499060cea9bbb24b8d723eafa343303, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617825}
-  m_Children:
-  - {fileID: 8926484042661617847}
-  - {fileID: 8926484042661617848}
-  - {fileID: 8926484042661617849}
-  - {fileID: 8926484042661617850}
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617825}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: KernelFactors
-    m_serializedType:
-      m_SerializableType: UnityEngine.Vector4, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617847
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617846}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617825}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: x
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617848
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617846}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617825}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: y
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617849
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617846}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617825}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: z
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617850
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617846}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617825}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: w
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617851
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 70a331b1d86cc8d4aa106ccbe0da5852, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617825}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617825}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: Tex
-    m_serializedType:
-      m_SerializableType: UnityEngine.Texture2D, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617852
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1b2b751071c7fc14f9fa503163991826, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617825}
-  m_Children:
-  - {fileID: 8926484042661617853}
-  - {fileID: 8926484042661617854}
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617825}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: TexSize
-    m_serializedType:
-      m_SerializableType: UnityEngine.Vector2, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617853
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617852}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617825}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: x
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617854
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617852}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617825}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: y
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617855
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1b605c022ee79394a8a776c0869b3f9a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 0}
-  m_Children:
-  - {fileID: 8926484042661617856}
-  - {fileID: 8926484042661617866}
-  - {fileID: 8926484042661617871}
-  - {fileID: 8926484042661617876}
-  - {fileID: 8926484042661617881}
-  - {fileID: 8926484042661617882}
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617855}
-  m_MasterData:
-    m_Owner: {fileID: 8926484042661615753}
-    m_Value:
-      m_Type:
-        m_SerializableType: Thinksquirrel.FluvioFX.Editor.SolverData, Thinksquirrel.FluvioFX.Editor,
-          Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-      m_SerializableObject: '{"Fluid":{"SmoothingDistance":0.3812499940395355,"ParticleMass":7.625,"Density":998.2899780273438,"MinimumDensity":499.1449890136719,"GasConstant":0.009999999776482582,"Viscosity":1.0,"Turbulence":0.20000000298023225,"SurfaceTension":0.7279999852180481,"BuoyancyCoefficient":0.0},"Gravity":{"vector":{"x":0.0,"y":0.0,"z":0.0}},"KernelSize":{"x":0.3812499940395355,"y":0.1453515589237213,"z":0.055415280163288119,"w":1.0},"KernelFactors":{"x":9206.4482421875,"y":1554.8280029296875,"z":43.08060836791992,"w":0.0},"Tex":{"instanceID":0},"TexSize":{"x":0.0,"y":0.0}}'
-    m_Space: 0
-  m_Property:
-    name: solverData
-    m_serializedType:
-      m_SerializableType: Thinksquirrel.FluvioFX.Editor.SolverData, Thinksquirrel.FluvioFX.Editor,
-        Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots:
-  - {fileID: 8926484042661618026}
---- !u!114 &8926484042661617856
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1b605c022ee79394a8a776c0869b3f9a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617855}
-  m_Children:
-  - {fileID: 8926484042661617857}
-  - {fileID: 8926484042661617858}
-  - {fileID: 8926484042661617859}
-  - {fileID: 8926484042661617860}
-  - {fileID: 8926484042661617861}
-  - {fileID: 8926484042661617862}
-  - {fileID: 8926484042661617863}
-  - {fileID: 8926484042661617864}
-  - {fileID: 8926484042661617865}
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617855}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: Fluid
-    m_serializedType:
-      m_SerializableType: Thinksquirrel.FluvioFX.Editor.Fluid, Thinksquirrel.FluvioFX.Editor,
-        Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617857
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617856}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617855}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: SmoothingDistance
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 9.9999994e-11
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the smoothing distance of fluid particles. This changes
-        the overall simulation resolution and greatly affects all other properties.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617858
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617856}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617855}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: ParticleMass
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 9.9999994e-11
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the mass of each fluid particle.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617859
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617856}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617855}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: Density
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 9.9999994e-11
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the overall density of the fluid.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617860
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617856}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617855}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: MinimumDensity
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 9.9999994e-11
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the minimum density of any fluid particle. This can be used
-        to help stabilize a low-viscosity fluid.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617861
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617856}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617855}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: GasConstant
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 9.9999994e-11
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the gas constant of the fluid, which in turn affects the
-        pressure forces applied to particles.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617862
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617856}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617855}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: Viscosity
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 9.9999994e-11
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the artificial viscosity force of the fluid.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617863
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617856}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617855}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: TurbulenceProbability
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 0
-      m_Min: 0
-      m_Max: 1
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the turbulence probability of the fluid. The turbulence
-        probability is a threshold beyond which a particle may become turbulent. Turbulent
-        particles will not affect non-turbulent particles. Fluid particles are not
-        turbulent by default. Turbulent forces are typically applied through effectors,
-        using the Vorticity property.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617864
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617856}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617855}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: SurfaceTension
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 0
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the surface tension of the fluid (intended for liquids only).
-        FluvioFX uses a simplified surface tension model that is ideal for realtime
-        use.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617865
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617856}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617855}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: BuoyancyCoefficient
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 0
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the buoyancy coefficient of a fluid. This controls the buoyancy
-        force, which is a density-dependent force in the opposite direction of gravity.
-        This should be used when simulating gas like smoke or fire, or fluids that
-        are less dense than the surrounding material.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617866
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a9f9544b71b7dab44a4644b6807e8bf6, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617855}
-  m_Children:
-  - {fileID: 8926484042661617867}
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617855}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: Gravity
-    m_serializedType:
-      m_SerializableType: UnityEditor.VFX.Vector, Unity.VisualEffectGraph.Editor,
-        Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617867
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ac39bd03fca81b849929b9c966f1836a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617866}
-  m_Children:
-  - {fileID: 8926484042661617868}
-  - {fileID: 8926484042661617869}
-  - {fileID: 8926484042661617870}
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617855}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: vector
-    m_serializedType:
-      m_SerializableType: UnityEngine.Vector3, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-    attributes:
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: The vector.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617868
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617867}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617855}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: x
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617869
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617867}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617855}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: y
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617870
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617867}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617855}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: z
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617871
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c499060cea9bbb24b8d723eafa343303, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617855}
-  m_Children:
-  - {fileID: 8926484042661617872}
-  - {fileID: 8926484042661617873}
-  - {fileID: 8926484042661617874}
-  - {fileID: 8926484042661617875}
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617855}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: KernelSize
-    m_serializedType:
-      m_SerializableType: UnityEngine.Vector4, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617872
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617871}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617855}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: x
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617873
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617871}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617855}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: y
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617874
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617871}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617855}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: z
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617875
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617871}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617855}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: w
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617876
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c499060cea9bbb24b8d723eafa343303, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617855}
-  m_Children:
-  - {fileID: 8926484042661617877}
-  - {fileID: 8926484042661617878}
-  - {fileID: 8926484042661617879}
-  - {fileID: 8926484042661617880}
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617855}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: KernelFactors
-    m_serializedType:
-      m_SerializableType: UnityEngine.Vector4, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617877
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617876}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617855}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: x
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617878
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617876}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617855}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: y
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617879
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617876}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617855}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: z
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617880
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617876}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617855}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: w
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617881
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 70a331b1d86cc8d4aa106ccbe0da5852, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617855}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617855}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: Tex
-    m_serializedType:
-      m_SerializableType: UnityEngine.Texture2D, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617882
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1b2b751071c7fc14f9fa503163991826, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617855}
-  m_Children:
-  - {fileID: 8926484042661617883}
-  - {fileID: 8926484042661617884}
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617855}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: TexSize
-    m_serializedType:
-      m_SerializableType: UnityEngine.Vector2, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617883
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617882}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617855}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: x
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617884
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617882}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617855}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: y
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617885
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1b605c022ee79394a8a776c0869b3f9a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 0}
-  m_Children:
-  - {fileID: 8926484042661617886}
-  - {fileID: 8926484042661617896}
-  - {fileID: 8926484042661617901}
-  - {fileID: 8926484042661617906}
-  - {fileID: 8926484042661617911}
-  - {fileID: 8926484042661617912}
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617885}
-  m_MasterData:
-    m_Owner: {fileID: 8926484042661615783}
-    m_Value:
-      m_Type:
-        m_SerializableType: Thinksquirrel.FluvioFX.Editor.SolverData, Thinksquirrel.FluvioFX.Editor,
-          Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-      m_SerializableObject: '{"Fluid":{"SmoothingDistance":0.3812499940395355,"ParticleMass":7.625,"Density":998.2899780273438,"MinimumDensity":499.1449890136719,"GasConstant":0.009999999776482582,"Viscosity":1.0,"Turbulence":0.20000000298023225,"SurfaceTension":0.7279999852180481,"BuoyancyCoefficient":0.0},"Gravity":{"vector":{"x":0.0,"y":0.0,"z":0.0}},"KernelSize":{"x":0.3812499940395355,"y":0.1453515589237213,"z":0.055415280163288119,"w":1.0},"KernelFactors":{"x":9206.4482421875,"y":1554.8280029296875,"z":43.08060836791992,"w":0.0},"Tex":{"instanceID":0},"TexSize":{"x":0.0,"y":0.0}}'
-    m_Space: 0
-  m_Property:
-    name: solverData
-    m_serializedType:
-      m_SerializableType: Thinksquirrel.FluvioFX.Editor.SolverData, Thinksquirrel.FluvioFX.Editor,
-        Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots:
-  - {fileID: 8926484042661618026}
---- !u!114 &8926484042661617886
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1b605c022ee79394a8a776c0869b3f9a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617885}
-  m_Children:
-  - {fileID: 8926484042661617887}
-  - {fileID: 8926484042661617888}
-  - {fileID: 8926484042661617889}
-  - {fileID: 8926484042661617890}
-  - {fileID: 8926484042661617891}
-  - {fileID: 8926484042661617892}
-  - {fileID: 8926484042661617893}
-  - {fileID: 8926484042661617894}
-  - {fileID: 8926484042661617895}
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617885}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: Fluid
-    m_serializedType:
-      m_SerializableType: Thinksquirrel.FluvioFX.Editor.Fluid, Thinksquirrel.FluvioFX.Editor,
-        Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617887
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617886}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617885}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: SmoothingDistance
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 9.9999994e-11
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the smoothing distance of fluid particles. This changes
-        the overall simulation resolution and greatly affects all other properties.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617888
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617886}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617885}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: ParticleMass
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 9.9999994e-11
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the mass of each fluid particle.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617889
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617886}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617885}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: Density
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 9.9999994e-11
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the overall density of the fluid.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617890
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617886}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617885}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: MinimumDensity
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 9.9999994e-11
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the minimum density of any fluid particle. This can be used
-        to help stabilize a low-viscosity fluid.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617891
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617886}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617885}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: GasConstant
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 9.9999994e-11
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the gas constant of the fluid, which in turn affects the
-        pressure forces applied to particles.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617892
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617886}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617885}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: Viscosity
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 9.9999994e-11
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the artificial viscosity force of the fluid.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617893
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617886}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617885}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: TurbulenceProbability
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 0
-      m_Min: 0
-      m_Max: 1
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the turbulence probability of the fluid. The turbulence
-        probability is a threshold beyond which a particle may become turbulent. Turbulent
-        particles will not affect non-turbulent particles. Fluid particles are not
-        turbulent by default. Turbulent forces are typically applied through effectors,
-        using the Vorticity property.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617894
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617886}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617885}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: SurfaceTension
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 0
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the surface tension of the fluid (intended for liquids only).
-        FluvioFX uses a simplified surface tension model that is ideal for realtime
-        use.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617895
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617886}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617885}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: BuoyancyCoefficient
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 0
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the buoyancy coefficient of a fluid. This controls the buoyancy
-        force, which is a density-dependent force in the opposite direction of gravity.
-        This should be used when simulating gas like smoke or fire, or fluids that
-        are less dense than the surrounding material.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617896
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a9f9544b71b7dab44a4644b6807e8bf6, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617885}
-  m_Children:
-  - {fileID: 8926484042661617897}
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617885}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: Gravity
-    m_serializedType:
-      m_SerializableType: UnityEditor.VFX.Vector, Unity.VisualEffectGraph.Editor,
-        Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617897
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ac39bd03fca81b849929b9c966f1836a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617896}
-  m_Children:
-  - {fileID: 8926484042661617898}
-  - {fileID: 8926484042661617899}
-  - {fileID: 8926484042661617900}
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617885}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: vector
-    m_serializedType:
-      m_SerializableType: UnityEngine.Vector3, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-    attributes:
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: The vector.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617898
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617897}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617885}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: x
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617899
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617897}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617885}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: y
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617900
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617897}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617885}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: z
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617901
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c499060cea9bbb24b8d723eafa343303, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617885}
-  m_Children:
-  - {fileID: 8926484042661617902}
-  - {fileID: 8926484042661617903}
-  - {fileID: 8926484042661617904}
-  - {fileID: 8926484042661617905}
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617885}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: KernelSize
-    m_serializedType:
-      m_SerializableType: UnityEngine.Vector4, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617902
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617901}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617885}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: x
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617903
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617901}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617885}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: y
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617904
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617901}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617885}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: z
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617905
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617901}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617885}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: w
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617906
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c499060cea9bbb24b8d723eafa343303, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617885}
-  m_Children:
-  - {fileID: 8926484042661617907}
-  - {fileID: 8926484042661617908}
-  - {fileID: 8926484042661617909}
-  - {fileID: 8926484042661617910}
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617885}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: KernelFactors
-    m_serializedType:
-      m_SerializableType: UnityEngine.Vector4, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617907
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617906}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617885}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: x
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617908
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617906}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617885}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: y
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617909
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617906}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617885}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: z
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617910
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617906}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617885}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: w
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617911
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 70a331b1d86cc8d4aa106ccbe0da5852, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617885}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617885}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: Tex
-    m_serializedType:
-      m_SerializableType: UnityEngine.Texture2D, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617912
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1b2b751071c7fc14f9fa503163991826, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617885}
-  m_Children:
-  - {fileID: 8926484042661617913}
-  - {fileID: 8926484042661617914}
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617885}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: TexSize
-    m_serializedType:
-      m_SerializableType: UnityEngine.Vector2, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617913
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617912}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617885}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: x
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617914
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617912}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617885}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: y
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617915
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1b605c022ee79394a8a776c0869b3f9a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 0}
-  m_Children:
-  - {fileID: 8926484042661617916}
-  - {fileID: 8926484042661617926}
-  - {fileID: 8926484042661617931}
-  - {fileID: 8926484042661617936}
-  - {fileID: 8926484042661617941}
-  - {fileID: 8926484042661617942}
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617915}
-  m_MasterData:
-    m_Owner: {fileID: 8926484042661615813}
-    m_Value:
-      m_Type:
-        m_SerializableType: Thinksquirrel.FluvioFX.Editor.SolverData, Thinksquirrel.FluvioFX.Editor,
-          Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-      m_SerializableObject: '{"Fluid":{"SmoothingDistance":0.3812499940395355,"ParticleMass":7.625,"Density":998.2899780273438,"MinimumDensity":499.1449890136719,"GasConstant":0.009999999776482582,"Viscosity":1.0,"Turbulence":0.20000000298023225,"SurfaceTension":0.7279999852180481,"BuoyancyCoefficient":0.0},"Gravity":{"vector":{"x":0.0,"y":0.0,"z":0.0}},"KernelSize":{"x":0.3812499940395355,"y":0.1453515589237213,"z":0.055415280163288119,"w":1.0},"KernelFactors":{"x":9206.4482421875,"y":1554.8280029296875,"z":43.08060836791992,"w":0.0},"Tex":{"instanceID":0},"TexSize":{"x":0.0,"y":0.0}}'
-    m_Space: 0
-  m_Property:
-    name: solverData
-    m_serializedType:
-      m_SerializableType: Thinksquirrel.FluvioFX.Editor.SolverData, Thinksquirrel.FluvioFX.Editor,
-        Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots:
-  - {fileID: 8926484042661618026}
---- !u!114 &8926484042661617916
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1b605c022ee79394a8a776c0869b3f9a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617915}
-  m_Children:
-  - {fileID: 8926484042661617917}
-  - {fileID: 8926484042661617918}
-  - {fileID: 8926484042661617919}
-  - {fileID: 8926484042661617920}
-  - {fileID: 8926484042661617921}
-  - {fileID: 8926484042661617922}
-  - {fileID: 8926484042661617923}
-  - {fileID: 8926484042661617924}
-  - {fileID: 8926484042661617925}
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617915}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: Fluid
-    m_serializedType:
-      m_SerializableType: Thinksquirrel.FluvioFX.Editor.Fluid, Thinksquirrel.FluvioFX.Editor,
-        Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617917
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617916}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617915}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: SmoothingDistance
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 9.9999994e-11
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the smoothing distance of fluid particles. This changes
-        the overall simulation resolution and greatly affects all other properties.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617918
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617916}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617915}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: ParticleMass
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 9.9999994e-11
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the mass of each fluid particle.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617919
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617916}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617915}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: Density
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 9.9999994e-11
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the overall density of the fluid.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617920
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617916}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617915}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: MinimumDensity
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 9.9999994e-11
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the minimum density of any fluid particle. This can be used
-        to help stabilize a low-viscosity fluid.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617921
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617916}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617915}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: GasConstant
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 9.9999994e-11
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the gas constant of the fluid, which in turn affects the
-        pressure forces applied to particles.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617922
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617916}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617915}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: Viscosity
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 9.9999994e-11
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the artificial viscosity force of the fluid.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617923
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617916}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617915}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: TurbulenceProbability
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 0
-      m_Min: 0
-      m_Max: 1
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the turbulence probability of the fluid. The turbulence
-        probability is a threshold beyond which a particle may become turbulent. Turbulent
-        particles will not affect non-turbulent particles. Fluid particles are not
-        turbulent by default. Turbulent forces are typically applied through effectors,
-        using the Vorticity property.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617924
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617916}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617915}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: SurfaceTension
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 0
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the surface tension of the fluid (intended for liquids only).
-        FluvioFX uses a simplified surface tension model that is ideal for realtime
-        use.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617925
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617916}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617915}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: BuoyancyCoefficient
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 0
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the buoyancy coefficient of a fluid. This controls the buoyancy
-        force, which is a density-dependent force in the opposite direction of gravity.
-        This should be used when simulating gas like smoke or fire, or fluids that
-        are less dense than the surrounding material.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617926
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a9f9544b71b7dab44a4644b6807e8bf6, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617915}
-  m_Children:
-  - {fileID: 8926484042661617927}
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617915}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: Gravity
-    m_serializedType:
-      m_SerializableType: UnityEditor.VFX.Vector, Unity.VisualEffectGraph.Editor,
-        Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617927
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ac39bd03fca81b849929b9c966f1836a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617926}
-  m_Children:
-  - {fileID: 8926484042661617928}
-  - {fileID: 8926484042661617929}
-  - {fileID: 8926484042661617930}
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617915}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: vector
-    m_serializedType:
-      m_SerializableType: UnityEngine.Vector3, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-    attributes:
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: The vector.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617928
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617927}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617915}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: x
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617929
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617927}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617915}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: y
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617930
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617927}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617915}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: z
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617931
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c499060cea9bbb24b8d723eafa343303, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617915}
-  m_Children:
-  - {fileID: 8926484042661617932}
-  - {fileID: 8926484042661617933}
-  - {fileID: 8926484042661617934}
-  - {fileID: 8926484042661617935}
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617915}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: KernelSize
-    m_serializedType:
-      m_SerializableType: UnityEngine.Vector4, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617932
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617931}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617915}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: x
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617933
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617931}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617915}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: y
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617934
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617931}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617915}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: z
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617935
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617931}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617915}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: w
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617936
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c499060cea9bbb24b8d723eafa343303, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617915}
-  m_Children:
-  - {fileID: 8926484042661617937}
-  - {fileID: 8926484042661617938}
-  - {fileID: 8926484042661617939}
-  - {fileID: 8926484042661617940}
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617915}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: KernelFactors
-    m_serializedType:
-      m_SerializableType: UnityEngine.Vector4, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617937
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617936}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617915}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: x
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617938
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617936}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617915}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: y
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617939
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617936}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617915}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: z
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617940
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617936}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617915}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: w
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617941
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 70a331b1d86cc8d4aa106ccbe0da5852, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617915}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617915}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: Tex
-    m_serializedType:
-      m_SerializableType: UnityEngine.Texture2D, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617942
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1b2b751071c7fc14f9fa503163991826, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617915}
-  m_Children:
-  - {fileID: 8926484042661617943}
-  - {fileID: 8926484042661617944}
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617915}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: TexSize
-    m_serializedType:
-      m_SerializableType: UnityEngine.Vector2, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617943
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617942}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617915}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: x
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617944
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617942}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617915}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: y
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617945
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1b605c022ee79394a8a776c0869b3f9a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 0}
-  m_Children:
-  - {fileID: 8926484042661617946}
-  - {fileID: 8926484042661617956}
-  - {fileID: 8926484042661617961}
-  - {fileID: 8926484042661617966}
-  - {fileID: 8926484042661617971}
-  - {fileID: 8926484042661617972}
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617945}
-  m_MasterData:
-    m_Owner: {fileID: 8926484042661615847}
-    m_Value:
-      m_Type:
-        m_SerializableType: Thinksquirrel.FluvioFX.Editor.SolverData, Thinksquirrel.FluvioFX.Editor,
-          Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-      m_SerializableObject: '{"Fluid":{"SmoothingDistance":0.3812499940395355,"ParticleMass":7.625,"Density":998.2899780273438,"MinimumDensity":499.1449890136719,"GasConstant":0.009999999776482582,"Viscosity":1.0,"Turbulence":0.20000000298023225,"SurfaceTension":0.7279999852180481,"BuoyancyCoefficient":0.0},"Gravity":{"vector":{"x":0.0,"y":0.0,"z":0.0}},"KernelSize":{"x":0.3812499940395355,"y":0.1453515589237213,"z":0.055415280163288119,"w":1.0},"KernelFactors":{"x":9206.4482421875,"y":1554.8280029296875,"z":43.08060836791992,"w":0.0},"Tex":{"instanceID":0},"TexSize":{"x":0.0,"y":0.0}}'
-    m_Space: 0
-  m_Property:
-    name: solverData
-    m_serializedType:
-      m_SerializableType: Thinksquirrel.FluvioFX.Editor.SolverData, Thinksquirrel.FluvioFX.Editor,
-        Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots:
-  - {fileID: 8926484042661618026}
---- !u!114 &8926484042661617946
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1b605c022ee79394a8a776c0869b3f9a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617945}
-  m_Children:
-  - {fileID: 8926484042661617947}
-  - {fileID: 8926484042661617948}
-  - {fileID: 8926484042661617949}
-  - {fileID: 8926484042661617950}
-  - {fileID: 8926484042661617951}
-  - {fileID: 8926484042661617952}
-  - {fileID: 8926484042661617953}
-  - {fileID: 8926484042661617954}
-  - {fileID: 8926484042661617955}
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617945}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: Fluid
-    m_serializedType:
-      m_SerializableType: Thinksquirrel.FluvioFX.Editor.Fluid, Thinksquirrel.FluvioFX.Editor,
-        Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617947
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617946}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617945}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: SmoothingDistance
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 9.9999994e-11
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the smoothing distance of fluid particles. This changes
-        the overall simulation resolution and greatly affects all other properties.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617948
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617946}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617945}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: ParticleMass
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 9.9999994e-11
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the mass of each fluid particle.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617949
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617946}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617945}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: Density
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 9.9999994e-11
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the overall density of the fluid.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617950
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617946}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617945}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: MinimumDensity
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 9.9999994e-11
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the minimum density of any fluid particle. This can be used
-        to help stabilize a low-viscosity fluid.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617951
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617946}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617945}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: GasConstant
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 9.9999994e-11
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the gas constant of the fluid, which in turn affects the
-        pressure forces applied to particles.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617952
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617946}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617945}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: Viscosity
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 9.9999994e-11
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the artificial viscosity force of the fluid.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617953
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617946}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617945}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: TurbulenceProbability
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 0
-      m_Min: 0
-      m_Max: 1
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the turbulence probability of the fluid. The turbulence
-        probability is a threshold beyond which a particle may become turbulent. Turbulent
-        particles will not affect non-turbulent particles. Fluid particles are not
-        turbulent by default. Turbulent forces are typically applied through effectors,
-        using the Vorticity property.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617954
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617946}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617945}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: SurfaceTension
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 0
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the surface tension of the fluid (intended for liquids only).
-        FluvioFX uses a simplified surface tension model that is ideal for realtime
-        use.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617955
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617946}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617945}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: BuoyancyCoefficient
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 0
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the buoyancy coefficient of a fluid. This controls the buoyancy
-        force, which is a density-dependent force in the opposite direction of gravity.
-        This should be used when simulating gas like smoke or fire, or fluids that
-        are less dense than the surrounding material.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617956
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a9f9544b71b7dab44a4644b6807e8bf6, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617945}
-  m_Children:
-  - {fileID: 8926484042661617957}
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617945}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: Gravity
-    m_serializedType:
-      m_SerializableType: UnityEditor.VFX.Vector, Unity.VisualEffectGraph.Editor,
-        Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617957
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ac39bd03fca81b849929b9c966f1836a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617956}
-  m_Children:
-  - {fileID: 8926484042661617958}
-  - {fileID: 8926484042661617959}
-  - {fileID: 8926484042661617960}
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617945}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: vector
-    m_serializedType:
-      m_SerializableType: UnityEngine.Vector3, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-    attributes:
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: The vector.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617958
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617957}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617945}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: x
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617959
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617957}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617945}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: y
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617960
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617957}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617945}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: z
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617961
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c499060cea9bbb24b8d723eafa343303, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617945}
-  m_Children:
-  - {fileID: 8926484042661617962}
-  - {fileID: 8926484042661617963}
-  - {fileID: 8926484042661617964}
-  - {fileID: 8926484042661617965}
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617945}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: KernelSize
-    m_serializedType:
-      m_SerializableType: UnityEngine.Vector4, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617962
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617961}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617945}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: x
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617963
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617961}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617945}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: y
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617964
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617961}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617945}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: z
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617965
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617961}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617945}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: w
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617966
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c499060cea9bbb24b8d723eafa343303, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617945}
-  m_Children:
-  - {fileID: 8926484042661617967}
-  - {fileID: 8926484042661617968}
-  - {fileID: 8926484042661617969}
-  - {fileID: 8926484042661617970}
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617945}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: KernelFactors
-    m_serializedType:
-      m_SerializableType: UnityEngine.Vector4, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617967
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617966}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617945}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: x
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617968
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617966}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617945}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: y
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617969
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617966}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617945}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: z
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617970
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617966}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617945}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: w
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617971
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 70a331b1d86cc8d4aa106ccbe0da5852, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617945}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617945}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: Tex
-    m_serializedType:
-      m_SerializableType: UnityEngine.Texture2D, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617972
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1b2b751071c7fc14f9fa503163991826, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617945}
-  m_Children:
-  - {fileID: 8926484042661617973}
-  - {fileID: 8926484042661617974}
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617945}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: TexSize
-    m_serializedType:
-      m_SerializableType: UnityEngine.Vector2, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617973
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617972}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617945}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: x
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661617974
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661617972}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661617945}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: y
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661618010
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 10192d0a7875141439bffd6edc238361, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 114350483966674976}
-  m_Children: []
-  m_UIPosition: {x: 112, y: 902}
-  m_UICollapsed: 0
-  m_UISuperCollapsed: 0
-  m_InputSlots:
-  - {fileID: 8926484042661618011}
-  - {fileID: 8926484042661618021}
-  m_OutputSlots:
-  - {fileID: 8926484042661618026}
---- !u!114 &8926484042661618011
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1b605c022ee79394a8a776c0869b3f9a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 0}
-  m_Children:
-  - {fileID: 8926484042661618012}
-  - {fileID: 8926484042661618013}
-  - {fileID: 8926484042661618014}
-  - {fileID: 8926484042661618015}
-  - {fileID: 8926484042661618016}
-  - {fileID: 8926484042661618017}
-  - {fileID: 8926484042661618018}
-  - {fileID: 8926484042661618019}
-  - {fileID: 8926484042661618020}
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 0
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618011}
-  m_MasterData:
-    m_Owner: {fileID: 8926484042661618010}
-    m_Value:
-      m_Type:
-        m_SerializableType: Thinksquirrel.FluvioFX.Editor.Fluid, Thinksquirrel.FluvioFX.Editor,
-          Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-      m_SerializableObject: '{"SmoothingDistance":0.3812499940395355,"ParticleMass":7.625,"Density":998.2899780273438,"MinimumDensity":9.98289966583252,"GasConstant":0.009999999776482582,"Viscosity":0.30000001192092898,"TurbulenceProbability":0.20000000298023225,"SurfaceTension":0.7279999852180481,"BuoyancyCoefficient":0.0}'
-    m_Space: 2147483647
-  m_Property:
-    name: Fluid
-    m_serializedType:
-      m_SerializableType: Thinksquirrel.FluvioFX.Editor.Fluid, Thinksquirrel.FluvioFX.Editor,
-        Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661618012
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618011}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618011}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: SmoothingDistance
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 9.9999994e-11
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the smoothing distance of fluid particles. This changes
-        the overall simulation resolution and greatly affects all other properties.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661618013
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618011}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618011}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: ParticleMass
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 9.9999994e-11
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the mass of each fluid particle.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661618014
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618011}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618011}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: Density
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 9.9999994e-11
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the overall density of the fluid.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661618015
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618011}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618011}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: MinimumDensity
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 9.9999994e-11
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the minimum density of any fluid particle. This can be used
-        to help stabilize a low-viscosity fluid.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661618016
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618011}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618011}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: GasConstant
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 9.9999994e-11
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the gas constant of the fluid, which in turn affects the
-        pressure forces applied to particles.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661618017
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618011}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618011}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: Viscosity
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 9.9999994e-11
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the artificial viscosity force of the fluid.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661618018
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618011}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618011}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: TurbulenceProbability
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 0
-      m_Min: 0
-      m_Max: 1
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the turbulence probability of the fluid. The turbulence
-        probability is a threshold beyond which a particle may become turbulent. Turbulent
-        particles will not affect non-turbulent particles. Fluid particles are not
-        turbulent by default. Turbulent forces are typically applied through effectors,
-        using the Vorticity property.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661618019
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618011}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618011}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: SurfaceTension
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 0
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the surface tension of the fluid (intended for liquids only).
-        FluvioFX uses a simplified surface tension model that is ideal for realtime
-        use.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661618020
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618011}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618011}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: BuoyancyCoefficient
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 0
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the buoyancy coefficient of a fluid. This controls the buoyancy
-        force, which is a density-dependent force in the opposite direction of gravity.
-        This should be used when simulating gas like smoke or fire, or fluids that
-        are less dense than the surrounding material.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661618021
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a9f9544b71b7dab44a4644b6807e8bf6, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 0}
-  m_Children:
-  - {fileID: 8926484042661618022}
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 0
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618021}
-  m_MasterData:
-    m_Owner: {fileID: 8926484042661618010}
-    m_Value:
-      m_Type:
-        m_SerializableType: UnityEditor.VFX.Vector, Unity.VisualEffectGraph.Editor,
-          Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-      m_SerializableObject: '{"vector":{"x":0.0,"y":-9.8100004196167,"z":0.0}}'
-    m_Space: 0
-  m_Property:
-    name: Gravity
-    m_serializedType:
-      m_SerializableType: UnityEditor.VFX.Vector, Unity.VisualEffectGraph.Editor,
-        Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661618022
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ac39bd03fca81b849929b9c966f1836a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618021}
-  m_Children:
-  - {fileID: 8926484042661618023}
-  - {fileID: 8926484042661618024}
-  - {fileID: 8926484042661618025}
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 0
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618021}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: vector
-    m_serializedType:
-      m_SerializableType: UnityEngine.Vector3, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-    attributes:
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: The vector.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661618023
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618022}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618021}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: x
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661618024
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618022}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618021}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: y
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661618025
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618022}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618021}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: z
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661618026
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1b605c022ee79394a8a776c0869b3f9a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 0}
-  m_Children:
-  - {fileID: 8926484042661618027}
-  - {fileID: 8926484042661618037}
-  - {fileID: 8926484042661618042}
-  - {fileID: 8926484042661618047}
-  - {fileID: 8926484042661618052}
-  - {fileID: 8926484042661618053}
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618026}
-  m_MasterData:
-    m_Owner: {fileID: 8926484042661618010}
-    m_Value:
-      m_Type:
-        m_SerializableType: Thinksquirrel.FluvioFX.Editor.SolverData, Thinksquirrel.FluvioFX.Editor,
-          Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-      m_SerializableObject: '{"Fluid":{"SmoothingDistance":0.0,"ParticleMass":0.0,"Density":0.0,"MinimumDensity":0.0,"GasConstant":0.0,"Viscosity":0.0,"Turbulence":0.0,"SurfaceTension":0.0,"BuoyancyCoefficient":0.0},"Gravity":{"vector":{"x":0.0,"y":0.0,"z":0.0}},"KernelSize":{"x":0.0,"y":0.0,"z":0.0,"w":0.0},"KernelFactors":{"x":0.0,"y":0.0,"z":0.0,"w":0.0},"Tex":{"instanceID":0},"TexSize":{"x":0.0,"y":0.0}}'
-    m_Space: 0
-  m_Property:
-    name: SolverData
-    m_serializedType:
-      m_SerializableType: Thinksquirrel.FluvioFX.Editor.SolverData, Thinksquirrel.FluvioFX.Editor,
-        Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-    attributes: []
-  m_Direction: 1
-  m_LinkedSlots:
-  - {fileID: 8926484042661617765}
-  - {fileID: 8926484042661617795}
-  - {fileID: 8926484042661617825}
-  - {fileID: 8926484042661617855}
-  - {fileID: 8926484042661617885}
-  - {fileID: 8926484042661617915}
-  - {fileID: 8926484042661617945}
---- !u!114 &8926484042661618027
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1b605c022ee79394a8a776c0869b3f9a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618026}
-  m_Children:
-  - {fileID: 8926484042661618028}
-  - {fileID: 8926484042661618029}
-  - {fileID: 8926484042661618030}
-  - {fileID: 8926484042661618031}
-  - {fileID: 8926484042661618032}
-  - {fileID: 8926484042661618033}
-  - {fileID: 8926484042661618034}
-  - {fileID: 8926484042661618035}
-  - {fileID: 8926484042661618036}
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618026}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: Fluid
-    m_serializedType:
-      m_SerializableType: Thinksquirrel.FluvioFX.Editor.Fluid, Thinksquirrel.FluvioFX.Editor,
-        Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-    attributes: []
-  m_Direction: 1
-  m_LinkedSlots: []
---- !u!114 &8926484042661618028
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618027}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618026}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: SmoothingDistance
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 9.9999994e-11
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the smoothing distance of fluid particles. This changes
-        the overall simulation resolution and greatly affects all other properties.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 1
-  m_LinkedSlots: []
---- !u!114 &8926484042661618029
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618027}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618026}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: ParticleMass
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 9.9999994e-11
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the mass of each fluid particle.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 1
-  m_LinkedSlots: []
---- !u!114 &8926484042661618030
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618027}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618026}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: Density
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 9.9999994e-11
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the overall density of the fluid.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 1
-  m_LinkedSlots: []
---- !u!114 &8926484042661618031
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618027}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618026}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: MinimumDensity
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 9.9999994e-11
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the minimum density of any fluid particle. This can be used
-        to help stabilize a low-viscosity fluid.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 1
-  m_LinkedSlots: []
---- !u!114 &8926484042661618032
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618027}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618026}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: GasConstant
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 9.9999994e-11
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the gas constant of the fluid, which in turn affects the
-        pressure forces applied to particles.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 1
-  m_LinkedSlots: []
---- !u!114 &8926484042661618033
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618027}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618026}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: Viscosity
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 9.9999994e-11
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the artificial viscosity force of the fluid.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 1
-  m_LinkedSlots: []
---- !u!114 &8926484042661618034
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618027}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618026}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: TurbulenceProbability
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 0
-      m_Min: 0
-      m_Max: 1
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the turbulence probability of the fluid. The turbulence
-        probability is a threshold beyond which a particle may become turbulent. Turbulent
-        particles will not affect non-turbulent particles. Fluid particles are not
-        turbulent by default. Turbulent forces are typically applied through effectors,
-        using the Vorticity property.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 1
-  m_LinkedSlots: []
---- !u!114 &8926484042661618035
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618027}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618026}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: SurfaceTension
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 0
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the surface tension of the fluid (intended for liquids only).
-        FluvioFX uses a simplified surface tension model that is ideal for realtime
-        use.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 1
-  m_LinkedSlots: []
---- !u!114 &8926484042661618036
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618027}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618026}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: BuoyancyCoefficient
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 0
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the buoyancy coefficient of a fluid. This controls the buoyancy
-        force, which is a density-dependent force in the opposite direction of gravity.
-        This should be used when simulating gas like smoke or fire, or fluids that
-        are less dense than the surrounding material.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 1
-  m_LinkedSlots: []
---- !u!114 &8926484042661618037
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a9f9544b71b7dab44a4644b6807e8bf6, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618026}
-  m_Children:
-  - {fileID: 8926484042661618038}
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618026}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: Gravity
-    m_serializedType:
-      m_SerializableType: UnityEditor.VFX.Vector, Unity.VisualEffectGraph.Editor,
-        Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-    attributes: []
-  m_Direction: 1
-  m_LinkedSlots: []
---- !u!114 &8926484042661618038
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ac39bd03fca81b849929b9c966f1836a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618037}
-  m_Children:
-  - {fileID: 8926484042661618039}
-  - {fileID: 8926484042661618040}
-  - {fileID: 8926484042661618041}
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618026}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: vector
-    m_serializedType:
-      m_SerializableType: UnityEngine.Vector3, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-    attributes:
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: The vector.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 1
-  m_LinkedSlots: []
---- !u!114 &8926484042661618039
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618038}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618026}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: x
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 1
-  m_LinkedSlots: []
---- !u!114 &8926484042661618040
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618038}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618026}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: y
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 1
-  m_LinkedSlots: []
---- !u!114 &8926484042661618041
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618038}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618026}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: z
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 1
-  m_LinkedSlots: []
---- !u!114 &8926484042661618042
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c499060cea9bbb24b8d723eafa343303, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618026}
-  m_Children:
-  - {fileID: 8926484042661618043}
-  - {fileID: 8926484042661618044}
-  - {fileID: 8926484042661618045}
-  - {fileID: 8926484042661618046}
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618026}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: KernelSize
-    m_serializedType:
-      m_SerializableType: UnityEngine.Vector4, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-    attributes: []
-  m_Direction: 1
-  m_LinkedSlots: []
---- !u!114 &8926484042661618043
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618042}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618026}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: x
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 1
-  m_LinkedSlots: []
---- !u!114 &8926484042661618044
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618042}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618026}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: y
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 1
-  m_LinkedSlots: []
---- !u!114 &8926484042661618045
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618042}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618026}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: z
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 1
-  m_LinkedSlots: []
---- !u!114 &8926484042661618046
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618042}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618026}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: w
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 1
-  m_LinkedSlots: []
---- !u!114 &8926484042661618047
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c499060cea9bbb24b8d723eafa343303, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618026}
-  m_Children:
-  - {fileID: 8926484042661618048}
-  - {fileID: 8926484042661618049}
-  - {fileID: 8926484042661618050}
-  - {fileID: 8926484042661618051}
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618026}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: KernelFactors
-    m_serializedType:
-      m_SerializableType: UnityEngine.Vector4, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-    attributes: []
-  m_Direction: 1
-  m_LinkedSlots: []
---- !u!114 &8926484042661618048
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618047}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618026}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: x
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 1
-  m_LinkedSlots: []
---- !u!114 &8926484042661618049
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618047}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618026}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: y
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 1
-  m_LinkedSlots: []
---- !u!114 &8926484042661618050
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618047}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618026}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: z
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 1
-  m_LinkedSlots: []
---- !u!114 &8926484042661618051
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618047}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618026}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: w
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 1
-  m_LinkedSlots: []
---- !u!114 &8926484042661618052
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 70a331b1d86cc8d4aa106ccbe0da5852, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618026}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618026}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: Tex
-    m_serializedType:
-      m_SerializableType: UnityEngine.Texture2D, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-    attributes: []
-  m_Direction: 1
-  m_LinkedSlots: []
---- !u!114 &8926484042661618053
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1b2b751071c7fc14f9fa503163991826, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618026}
-  m_Children:
-  - {fileID: 8926484042661618054}
-  - {fileID: 8926484042661618055}
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618026}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: TexSize
-    m_serializedType:
-      m_SerializableType: UnityEngine.Vector2, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-    attributes: []
-  m_Direction: 1
-  m_LinkedSlots: []
---- !u!114 &8926484042661618054
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618053}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618026}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: x
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 1
-  m_LinkedSlots: []
---- !u!114 &8926484042661618055
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618053}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618026}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: y
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 1
-  m_LinkedSlots: []
---- !u!114 &8926484042661618061
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 01ec2c1930009b04ea08905b47262415, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 114063133802684794}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 0
-  m_UISuperCollapsed: 0
-  m_InputSlots:
-  - {fileID: 8926484042661618062}
-  m_OutputSlots: []
-  m_Disabled: 0
-  attribute: alpha
-  Composition: 0
-  AlphaComposition: 0
-  SampleMode: 0
-  Mode: 1
-  ColorMode: 3
-  channels: 6
---- !u!114 &8926484042661618062
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c117b74c5c58db542bffe25c78fe92db, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 0}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618062}
-  m_MasterData:
-    m_Owner: {fileID: 8926484042661618061}
-    m_Value:
-      m_Type:
-        m_SerializableType: UnityEngine.AnimationCurve, UnityEngine.CoreModule, Version=0.0.0.0,
-          Culture=neutral, PublicKeyToken=null
-      m_SerializableObject: '{"frames":[{"time":0.0,"value":0.0,"inTangent":5.0,"outTangent":5.0,"tangentMode":0,"leftTangentMode":1,"rightTangentMode":1,"broken":false},{"time":0.10000000149011612,"value":0.5,"inTangent":3.125,"outTangent":3.125,"tangentMode":0,"leftTangentMode":1,"rightTangentMode":1,"broken":false},{"time":0.5,"value":1.0,"inTangent":-5.960464477539063e-8,"outTangent":-5.960464477539063e-8,"tangentMode":0,"leftTangentMode":1,"rightTangentMode":1,"broken":false},{"time":0.8999999761581421,"value":0.5,"inTangent":-3.124999523162842,"outTangent":-3.124999523162842,"tangentMode":0,"leftTangentMode":1,"rightTangentMode":1,"broken":false},{"time":1.0,"value":0.0,"inTangent":-4.999999046325684,"outTangent":-4.999999046325684,"tangentMode":0,"leftTangentMode":1,"rightTangentMode":1,"broken":false}],"preWrapMode":8,"postWrapMode":8,"version":1}'
-    m_Space: 2147483647
-  m_Property:
-    name: Alpha
-    m_serializedType:
-      m_SerializableType: UnityEngine.AnimationCurve, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661618068
+--- !u!114 &8926484042661618208
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -13853,20 +4342,20 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 26096dfac7c062b4b94c293605ba085e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Parent: {fileID: 114946465509916290}
+  m_Parent: {fileID: 8926484042661618185}
   m_Children: []
-  m_UIPosition: {x: 0, y: 77}
+  m_UIPosition: {x: 1393.8771, y: -281.97025}
   m_UICollapsed: 0
   m_UISuperCollapsed: 0
   m_InputSlots:
-  - {fileID: 8926484042661618069}
-  - {fileID: 8926484042661618074}
-  - {fileID: 8926484042661618075}
+  - {fileID: 8926484042661618209}
+  - {fileID: 8926484042661618214}
+  - {fileID: 8926484042661618215}
   m_OutputSlots: []
   m_Disabled: 0
   composition: 1
   speedMode: 0
---- !u!114 &8926484042661618069
+--- !u!114 &8926484042661618209
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -13880,13 +4369,13 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Parent: {fileID: 0}
   m_Children:
-  - {fileID: 8926484042661618070}
+  - {fileID: 8926484042661618210}
   m_UIPosition: {x: 0, y: 0}
   m_UICollapsed: 1
   m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618069}
+  m_MasterSlot: {fileID: 8926484042661618209}
   m_MasterData:
-    m_Owner: {fileID: 8926484042661618068}
+    m_Owner: {fileID: 8926484042661618208}
     m_Value:
       m_Type:
         m_SerializableType: UnityEditor.VFX.DirectionType, Unity.VisualEffectGraph.Editor,
@@ -13907,7 +4396,7 @@ MonoBehaviour:
       m_RegexMaxLength: 0
   m_Direction: 0
   m_LinkedSlots: []
---- !u!114 &8926484042661618070
+--- !u!114 &8926484042661618210
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -13919,15 +4408,15 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ac39bd03fca81b849929b9c966f1836a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618069}
+  m_Parent: {fileID: 8926484042661618209}
   m_Children:
-  - {fileID: 8926484042661618071}
-  - {fileID: 8926484042661618072}
-  - {fileID: 8926484042661618073}
+  - {fileID: 8926484042661618211}
+  - {fileID: 8926484042661618212}
+  - {fileID: 8926484042661618213}
   m_UIPosition: {x: 0, y: 0}
   m_UICollapsed: 1
   m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618069}
+  m_MasterSlot: {fileID: 8926484042661618209}
   m_MasterData:
     m_Owner: {fileID: 0}
     m_Value:
@@ -13949,7 +4438,7 @@ MonoBehaviour:
       m_RegexMaxLength: 0
   m_Direction: 0
   m_LinkedSlots: []
---- !u!114 &8926484042661618071
+--- !u!114 &8926484042661618211
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -13961,12 +4450,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618070}
+  m_Parent: {fileID: 8926484042661618210}
   m_Children: []
   m_UIPosition: {x: 0, y: 0}
   m_UICollapsed: 1
   m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618069}
+  m_MasterSlot: {fileID: 8926484042661618209}
   m_MasterData:
     m_Owner: {fileID: 0}
     m_Value:
@@ -13982,7 +4471,7 @@ MonoBehaviour:
     attributes: []
   m_Direction: 0
   m_LinkedSlots: []
---- !u!114 &8926484042661618072
+--- !u!114 &8926484042661618212
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -13994,12 +4483,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618070}
+  m_Parent: {fileID: 8926484042661618210}
   m_Children: []
   m_UIPosition: {x: 0, y: 0}
   m_UICollapsed: 1
   m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618069}
+  m_MasterSlot: {fileID: 8926484042661618209}
   m_MasterData:
     m_Owner: {fileID: 0}
     m_Value:
@@ -14015,7 +4504,7 @@ MonoBehaviour:
     attributes: []
   m_Direction: 0
   m_LinkedSlots: []
---- !u!114 &8926484042661618073
+--- !u!114 &8926484042661618213
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -14027,12 +4516,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618070}
+  m_Parent: {fileID: 8926484042661618210}
   m_Children: []
   m_UIPosition: {x: 0, y: 0}
   m_UICollapsed: 1
   m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618069}
+  m_MasterSlot: {fileID: 8926484042661618209}
   m_MasterData:
     m_Owner: {fileID: 0}
     m_Value:
@@ -14048,7 +4537,7 @@ MonoBehaviour:
     attributes: []
   m_Direction: 0
   m_LinkedSlots: []
---- !u!114 &8926484042661618074
+--- !u!114 &8926484042661618214
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -14065,9 +4554,9 @@ MonoBehaviour:
   m_UIPosition: {x: 0, y: 0}
   m_UICollapsed: 1
   m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618074}
+  m_MasterSlot: {fileID: 8926484042661618214}
   m_MasterData:
-    m_Owner: {fileID: 8926484042661618068}
+    m_Owner: {fileID: 8926484042661618208}
     m_Value:
       m_Type:
         m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
@@ -14088,7 +4577,7 @@ MonoBehaviour:
       m_RegexMaxLength: 0
   m_Direction: 0
   m_LinkedSlots: []
---- !u!114 &8926484042661618075
+--- !u!114 &8926484042661618215
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -14105,9 +4594,9 @@ MonoBehaviour:
   m_UIPosition: {x: 0, y: 0}
   m_UICollapsed: 1
   m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618075}
+  m_MasterSlot: {fileID: 8926484042661618215}
   m_MasterData:
-    m_Owner: {fileID: 8926484042661618068}
+    m_Owner: {fileID: 8926484042661618208}
     m_Value:
       m_Type:
         m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
@@ -14134,4 +4623,1968 @@ MonoBehaviour:
       m_Regex: 
       m_RegexMaxLength: 0
   m_Direction: 0
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618216
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a0b9e6b9139e58d4c957ec54595da7d3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 114350483966674976}
+  m_Children:
+  - {fileID: 8926484042661618219}
+  - {fileID: 8926484042661618220}
+  m_UIPosition: {x: 2108.877, y: 1774.0298}
+  m_UICollapsed: 0
+  m_UISuperCollapsed: 0
+  m_InputSlots:
+  - {fileID: 8926484042661618217}
+  m_OutputSlots: []
+  m_Label: 
+  m_Data: {fileID: 8926484042661618195}
+  m_InputFlowSlot:
+  - link:
+    - context: {fileID: 8926484042661618177}
+      slotIndex: 0
+  m_OutputFlowSlot:
+  - link: []
+  blendMode: 1
+  cullMode: 0
+  zWriteMode: 0
+  zTestMode: 0
+  uvMode: 0
+  useSoftParticle: 0
+  sortPriority: 0
+  sort: 0
+  indirectDraw: 0
+  castShadows: 0
+  preRefraction: 0
+  useGeometryShader: 0
+--- !u!114 &8926484042661618217
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 70a331b1d86cc8d4aa106ccbe0da5852, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 0}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618217}
+  m_MasterData:
+    m_Owner: {fileID: 8926484042661618216}
+    m_Value:
+      m_Type:
+        m_SerializableType: UnityEngine.Texture2D, UnityEngine.CoreModule, Version=0.0.0.0,
+          Culture=neutral, PublicKeyToken=null
+      m_SerializableObject: '{"obj":{"fileID":2800000,"guid":"276d9e395ae18fe40a9b4988549f2349","type":3}}'
+    m_Space: 2147483647
+  m_Property:
+    name: mainTexture
+    m_serializedType:
+      m_SerializableType: UnityEngine.Texture2D, UnityEngine.CoreModule, Version=0.0.0.0,
+        Culture=neutral, PublicKeyToken=null
+    attributes: []
+  m_Direction: 0
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618219
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d16c6aeaef944094b9a1633041804207, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618216}
+  m_Children: []
+  m_UIPosition: {x: 1393.8771, y: -356.97025}
+  m_UICollapsed: 0
+  m_UISuperCollapsed: 0
+  m_InputSlots: []
+  m_OutputSlots: []
+  m_Disabled: 0
+  mode: 0
+--- !u!114 &8926484042661618220
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 01ec2c1930009b04ea08905b47262415, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618216}
+  m_Children: []
+  m_UIPosition: {x: 1393.8771, y: -358.97025}
+  m_UICollapsed: 0
+  m_UISuperCollapsed: 0
+  m_InputSlots:
+  - {fileID: 8926484042661618221}
+  m_OutputSlots: []
+  m_Disabled: 0
+  attribute: alpha
+  Composition: 0
+  AlphaComposition: 0
+  SampleMode: 0
+  Mode: 1
+  ColorMode: 3
+  channels: 6
+--- !u!114 &8926484042661618221
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c117b74c5c58db542bffe25c78fe92db, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 0}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618221}
+  m_MasterData:
+    m_Owner: {fileID: 8926484042661618220}
+    m_Value:
+      m_Type:
+        m_SerializableType: UnityEngine.AnimationCurve, UnityEngine.CoreModule, Version=0.0.0.0,
+          Culture=neutral, PublicKeyToken=null
+      m_SerializableObject: '{"frames":[{"time":0.0,"value":0.0,"inTangent":5.0,"outTangent":5.0,"tangentMode":0,"leftTangentMode":1,"rightTangentMode":1,"broken":false},{"time":0.10000000149011612,"value":0.5,"inTangent":3.125,"outTangent":3.125,"tangentMode":0,"leftTangentMode":1,"rightTangentMode":1,"broken":false},{"time":0.5,"value":1.0,"inTangent":-5.960464477539063e-8,"outTangent":-5.960464477539063e-8,"tangentMode":0,"leftTangentMode":1,"rightTangentMode":1,"broken":false},{"time":0.8999999761581421,"value":0.5,"inTangent":-3.124999523162842,"outTangent":-3.124999523162842,"tangentMode":0,"leftTangentMode":1,"rightTangentMode":1,"broken":false},{"time":1.0,"value":0.0,"inTangent":-4.999999046325684,"outTangent":-4.999999046325684,"tangentMode":0,"leftTangentMode":1,"rightTangentMode":1,"broken":false}],"preWrapMode":8,"postWrapMode":8,"version":1}'
+    m_Space: 2147483647
+  m_Property:
+    name: Alpha
+    m_serializedType:
+      m_SerializableType: UnityEngine.AnimationCurve, UnityEngine.CoreModule, Version=0.0.0.0,
+        Culture=neutral, PublicKeyToken=null
+    attributes: []
+  m_Direction: 0
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618222
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 10192d0a7875141439bffd6edc238361, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 114350483966674976}
+  m_Children: []
+  m_UIPosition: {x: 859.8771, y: 66.029755}
+  m_UICollapsed: 0
+  m_UISuperCollapsed: 0
+  m_InputSlots:
+  - {fileID: 8926484042661618223}
+  - {fileID: 8926484042661618233}
+  m_OutputSlots:
+  - {fileID: 8926484042661618238}
+--- !u!114 &8926484042661618223
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1b605c022ee79394a8a776c0869b3f9a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 0}
+  m_Children:
+  - {fileID: 8926484042661618224}
+  - {fileID: 8926484042661618225}
+  - {fileID: 8926484042661618226}
+  - {fileID: 8926484042661618227}
+  - {fileID: 8926484042661618228}
+  - {fileID: 8926484042661618229}
+  - {fileID: 8926484042661618230}
+  - {fileID: 8926484042661618231}
+  - {fileID: 8926484042661618232}
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 0
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618223}
+  m_MasterData:
+    m_Owner: {fileID: 8926484042661618222}
+    m_Value:
+      m_Type:
+        m_SerializableType: Thinksquirrel.FluvioFX.Editor.Fluid, Thinksquirrel.FluvioFX.Editor,
+          Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+      m_SerializableObject: '{"SmoothingDistance":0.3812499940395355,"ParticleMass":7.625,"Density":998.2899780273438,"MinimumDensity":9.98289966583252,"GasConstant":0.009999999776482582,"Viscosity":0.30000001192092898,"TurbulenceProbability":0.20000000298023225,"SurfaceTension":0.7279999852180481,"BuoyancyCoefficient":0.0}'
+    m_Space: 2147483647
+  m_Property:
+    name: Fluid
+    m_serializedType:
+      m_SerializableType: Thinksquirrel.FluvioFX.Editor.Fluid, Thinksquirrel.FluvioFX.Editor,
+        Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+    attributes: []
+  m_Direction: 0
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618224
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618223}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618223}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: SmoothingDistance
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes:
+    - m_Type: 1
+      m_Min: 9.9999994e-11
+      m_Max: Infinity
+      m_Tooltip: 
+      m_Regex: 
+      m_RegexMaxLength: 0
+    - m_Type: 3
+      m_Min: -Infinity
+      m_Max: Infinity
+      m_Tooltip: Controls the smoothing distance of fluid particles. This changes
+        the overall simulation resolution and greatly affects all other properties.
+      m_Regex: 
+      m_RegexMaxLength: 0
+  m_Direction: 0
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618225
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618223}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618223}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: ParticleMass
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes:
+    - m_Type: 1
+      m_Min: 9.9999994e-11
+      m_Max: Infinity
+      m_Tooltip: 
+      m_Regex: 
+      m_RegexMaxLength: 0
+    - m_Type: 3
+      m_Min: -Infinity
+      m_Max: Infinity
+      m_Tooltip: Controls the mass of each fluid particle.
+      m_Regex: 
+      m_RegexMaxLength: 0
+  m_Direction: 0
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618226
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618223}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618223}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: Density
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes:
+    - m_Type: 1
+      m_Min: 9.9999994e-11
+      m_Max: Infinity
+      m_Tooltip: 
+      m_Regex: 
+      m_RegexMaxLength: 0
+    - m_Type: 3
+      m_Min: -Infinity
+      m_Max: Infinity
+      m_Tooltip: Controls the overall density of the fluid.
+      m_Regex: 
+      m_RegexMaxLength: 0
+  m_Direction: 0
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618227
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618223}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618223}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: MinimumDensity
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes:
+    - m_Type: 1
+      m_Min: 9.9999994e-11
+      m_Max: Infinity
+      m_Tooltip: 
+      m_Regex: 
+      m_RegexMaxLength: 0
+    - m_Type: 3
+      m_Min: -Infinity
+      m_Max: Infinity
+      m_Tooltip: Controls the minimum density of any fluid particle. This can be used
+        to help stabilize a low-viscosity fluid.
+      m_Regex: 
+      m_RegexMaxLength: 0
+  m_Direction: 0
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618228
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618223}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618223}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: GasConstant
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes:
+    - m_Type: 1
+      m_Min: 9.9999994e-11
+      m_Max: Infinity
+      m_Tooltip: 
+      m_Regex: 
+      m_RegexMaxLength: 0
+    - m_Type: 3
+      m_Min: -Infinity
+      m_Max: Infinity
+      m_Tooltip: Controls the gas constant of the fluid, which in turn affects the
+        pressure forces applied to particles.
+      m_Regex: 
+      m_RegexMaxLength: 0
+  m_Direction: 0
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618229
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618223}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618223}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: Viscosity
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes:
+    - m_Type: 1
+      m_Min: 9.9999994e-11
+      m_Max: Infinity
+      m_Tooltip: 
+      m_Regex: 
+      m_RegexMaxLength: 0
+    - m_Type: 3
+      m_Min: -Infinity
+      m_Max: Infinity
+      m_Tooltip: Controls the artificial viscosity force of the fluid.
+      m_Regex: 
+      m_RegexMaxLength: 0
+  m_Direction: 0
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618230
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618223}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618223}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: TurbulenceProbability
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes:
+    - m_Type: 0
+      m_Min: 0
+      m_Max: 1
+      m_Tooltip: 
+      m_Regex: 
+      m_RegexMaxLength: 0
+    - m_Type: 3
+      m_Min: -Infinity
+      m_Max: Infinity
+      m_Tooltip: Controls the turbulence probability of the fluid. The turbulence
+        probability is a threshold beyond which a particle may become turbulent. Turbulent
+        particles will not affect non-turbulent particles. Fluid particles are not
+        turbulent by default. Turbulent forces are typically applied through effectors,
+        using the Vorticity property.
+      m_Regex: 
+      m_RegexMaxLength: 0
+  m_Direction: 0
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618231
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618223}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618223}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: SurfaceTension
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes:
+    - m_Type: 1
+      m_Min: 0
+      m_Max: Infinity
+      m_Tooltip: 
+      m_Regex: 
+      m_RegexMaxLength: 0
+    - m_Type: 3
+      m_Min: -Infinity
+      m_Max: Infinity
+      m_Tooltip: Controls the surface tension of the fluid (intended for liquids only).
+        FluvioFX uses a simplified surface tension model that is ideal for realtime
+        use.
+      m_Regex: 
+      m_RegexMaxLength: 0
+  m_Direction: 0
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618232
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618223}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618223}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: BuoyancyCoefficient
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes:
+    - m_Type: 1
+      m_Min: 0
+      m_Max: Infinity
+      m_Tooltip: 
+      m_Regex: 
+      m_RegexMaxLength: 0
+    - m_Type: 3
+      m_Min: -Infinity
+      m_Max: Infinity
+      m_Tooltip: Controls the buoyancy coefficient of a fluid. This controls the buoyancy
+        force, which is a density-dependent force in the opposite direction of gravity.
+        This should be used when simulating gas like smoke or fire, or fluids that
+        are less dense than the surrounding material.
+      m_Regex: 
+      m_RegexMaxLength: 0
+  m_Direction: 0
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618233
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a9f9544b71b7dab44a4644b6807e8bf6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 0}
+  m_Children:
+  - {fileID: 8926484042661618234}
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 0
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618233}
+  m_MasterData:
+    m_Owner: {fileID: 8926484042661618222}
+    m_Value:
+      m_Type:
+        m_SerializableType: UnityEditor.VFX.Vector, Unity.VisualEffectGraph.Editor,
+          Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+      m_SerializableObject: '{"vector":{"x":0.0,"y":-9.8100004196167,"z":0.0}}'
+    m_Space: 0
+  m_Property:
+    name: Gravity
+    m_serializedType:
+      m_SerializableType: UnityEditor.VFX.Vector, Unity.VisualEffectGraph.Editor,
+        Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+    attributes: []
+  m_Direction: 0
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618234
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac39bd03fca81b849929b9c966f1836a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618233}
+  m_Children:
+  - {fileID: 8926484042661618235}
+  - {fileID: 8926484042661618236}
+  - {fileID: 8926484042661618237}
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 0
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618233}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: vector
+    m_serializedType:
+      m_SerializableType: UnityEngine.Vector3, UnityEngine.CoreModule, Version=0.0.0.0,
+        Culture=neutral, PublicKeyToken=null
+    attributes:
+    - m_Type: 3
+      m_Min: -Infinity
+      m_Max: Infinity
+      m_Tooltip: The vector.
+      m_Regex: 
+      m_RegexMaxLength: 0
+  m_Direction: 0
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618235
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618234}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618233}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: x
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes: []
+  m_Direction: 0
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618236
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618234}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618233}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: y
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes: []
+  m_Direction: 0
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618237
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618234}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618233}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: z
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes: []
+  m_Direction: 0
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618238
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1b605c022ee79394a8a776c0869b3f9a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 0}
+  m_Children:
+  - {fileID: 8926484042661618239}
+  - {fileID: 8926484042661618249}
+  - {fileID: 8926484042661618254}
+  - {fileID: 8926484042661618259}
+  - {fileID: 8926484042661618264}
+  - {fileID: 8926484042661618265}
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618238}
+  m_MasterData:
+    m_Owner: {fileID: 8926484042661618222}
+    m_Value:
+      m_Type:
+        m_SerializableType: Thinksquirrel.FluvioFX.Editor.SolverData, Thinksquirrel.FluvioFX.Editor,
+          Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+      m_SerializableObject: '{"Fluid":{"SmoothingDistance":0.0,"ParticleMass":0.0,"Density":0.0,"MinimumDensity":0.0,"GasConstant":0.0,"Viscosity":0.0,"TurbulenceProbability":0.0,"SurfaceTension":0.0,"BuoyancyCoefficient":0.0},"Gravity":{"vector":{"x":0.0,"y":0.0,"z":0.0}},"KernelSize":{"x":0.0,"y":0.0,"z":0.0,"w":0.0},"KernelFactors":{"x":0.0,"y":0.0,"z":0.0,"w":0.0},"Tex":{"instanceID":0},"TexSize":{"x":0.0,"y":0.0}}'
+    m_Space: 0
+  m_Property:
+    name: SolverData
+    m_serializedType:
+      m_SerializableType: Thinksquirrel.FluvioFX.Editor.SolverData, Thinksquirrel.FluvioFX.Editor,
+        Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+    attributes: []
+  m_Direction: 1
+  m_LinkedSlots:
+  - {fileID: 8926484042661618132}
+--- !u!114 &8926484042661618239
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1b605c022ee79394a8a776c0869b3f9a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618238}
+  m_Children:
+  - {fileID: 8926484042661618240}
+  - {fileID: 8926484042661618241}
+  - {fileID: 8926484042661618242}
+  - {fileID: 8926484042661618243}
+  - {fileID: 8926484042661618244}
+  - {fileID: 8926484042661618245}
+  - {fileID: 8926484042661618246}
+  - {fileID: 8926484042661618247}
+  - {fileID: 8926484042661618248}
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618238}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: Fluid
+    m_serializedType:
+      m_SerializableType: Thinksquirrel.FluvioFX.Editor.Fluid, Thinksquirrel.FluvioFX.Editor,
+        Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+    attributes: []
+  m_Direction: 1
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618240
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618239}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618238}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: SmoothingDistance
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes:
+    - m_Type: 1
+      m_Min: 9.9999994e-11
+      m_Max: Infinity
+      m_Tooltip: 
+      m_Regex: 
+      m_RegexMaxLength: 0
+    - m_Type: 3
+      m_Min: -Infinity
+      m_Max: Infinity
+      m_Tooltip: Controls the smoothing distance of fluid particles. This changes
+        the overall simulation resolution and greatly affects all other properties.
+      m_Regex: 
+      m_RegexMaxLength: 0
+  m_Direction: 1
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618241
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618239}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618238}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: ParticleMass
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes:
+    - m_Type: 1
+      m_Min: 9.9999994e-11
+      m_Max: Infinity
+      m_Tooltip: 
+      m_Regex: 
+      m_RegexMaxLength: 0
+    - m_Type: 3
+      m_Min: -Infinity
+      m_Max: Infinity
+      m_Tooltip: Controls the mass of each fluid particle.
+      m_Regex: 
+      m_RegexMaxLength: 0
+  m_Direction: 1
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618242
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618239}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618238}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: Density
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes:
+    - m_Type: 1
+      m_Min: 9.9999994e-11
+      m_Max: Infinity
+      m_Tooltip: 
+      m_Regex: 
+      m_RegexMaxLength: 0
+    - m_Type: 3
+      m_Min: -Infinity
+      m_Max: Infinity
+      m_Tooltip: Controls the overall density of the fluid.
+      m_Regex: 
+      m_RegexMaxLength: 0
+  m_Direction: 1
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618243
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618239}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618238}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: MinimumDensity
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes:
+    - m_Type: 1
+      m_Min: 9.9999994e-11
+      m_Max: Infinity
+      m_Tooltip: 
+      m_Regex: 
+      m_RegexMaxLength: 0
+    - m_Type: 3
+      m_Min: -Infinity
+      m_Max: Infinity
+      m_Tooltip: Controls the minimum density of any fluid particle. This can be used
+        to help stabilize a low-viscosity fluid.
+      m_Regex: 
+      m_RegexMaxLength: 0
+  m_Direction: 1
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618244
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618239}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618238}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: GasConstant
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes:
+    - m_Type: 1
+      m_Min: 9.9999994e-11
+      m_Max: Infinity
+      m_Tooltip: 
+      m_Regex: 
+      m_RegexMaxLength: 0
+    - m_Type: 3
+      m_Min: -Infinity
+      m_Max: Infinity
+      m_Tooltip: Controls the gas constant of the fluid, which in turn affects the
+        pressure forces applied to particles.
+      m_Regex: 
+      m_RegexMaxLength: 0
+  m_Direction: 1
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618245
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618239}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618238}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: Viscosity
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes:
+    - m_Type: 1
+      m_Min: 9.9999994e-11
+      m_Max: Infinity
+      m_Tooltip: 
+      m_Regex: 
+      m_RegexMaxLength: 0
+    - m_Type: 3
+      m_Min: -Infinity
+      m_Max: Infinity
+      m_Tooltip: Controls the artificial viscosity force of the fluid.
+      m_Regex: 
+      m_RegexMaxLength: 0
+  m_Direction: 1
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618246
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618239}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618238}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: TurbulenceProbability
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes:
+    - m_Type: 0
+      m_Min: 0
+      m_Max: 1
+      m_Tooltip: 
+      m_Regex: 
+      m_RegexMaxLength: 0
+    - m_Type: 3
+      m_Min: -Infinity
+      m_Max: Infinity
+      m_Tooltip: Controls the turbulence probability of the fluid. The turbulence
+        probability is a threshold beyond which a particle may become turbulent. Turbulent
+        particles will not affect non-turbulent particles. Fluid particles are not
+        turbulent by default. Turbulent forces are typically applied through effectors,
+        using the Vorticity property.
+      m_Regex: 
+      m_RegexMaxLength: 0
+  m_Direction: 1
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618247
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618239}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618238}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: SurfaceTension
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes:
+    - m_Type: 1
+      m_Min: 0
+      m_Max: Infinity
+      m_Tooltip: 
+      m_Regex: 
+      m_RegexMaxLength: 0
+    - m_Type: 3
+      m_Min: -Infinity
+      m_Max: Infinity
+      m_Tooltip: Controls the surface tension of the fluid (intended for liquids only).
+        FluvioFX uses a simplified surface tension model that is ideal for realtime
+        use.
+      m_Regex: 
+      m_RegexMaxLength: 0
+  m_Direction: 1
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618248
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618239}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618238}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: BuoyancyCoefficient
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes:
+    - m_Type: 1
+      m_Min: 0
+      m_Max: Infinity
+      m_Tooltip: 
+      m_Regex: 
+      m_RegexMaxLength: 0
+    - m_Type: 3
+      m_Min: -Infinity
+      m_Max: Infinity
+      m_Tooltip: Controls the buoyancy coefficient of a fluid. This controls the buoyancy
+        force, which is a density-dependent force in the opposite direction of gravity.
+        This should be used when simulating gas like smoke or fire, or fluids that
+        are less dense than the surrounding material.
+      m_Regex: 
+      m_RegexMaxLength: 0
+  m_Direction: 1
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618249
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a9f9544b71b7dab44a4644b6807e8bf6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618238}
+  m_Children:
+  - {fileID: 8926484042661618250}
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618238}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: Gravity
+    m_serializedType:
+      m_SerializableType: UnityEditor.VFX.Vector, Unity.VisualEffectGraph.Editor,
+        Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+    attributes: []
+  m_Direction: 1
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618250
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac39bd03fca81b849929b9c966f1836a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618249}
+  m_Children:
+  - {fileID: 8926484042661618251}
+  - {fileID: 8926484042661618252}
+  - {fileID: 8926484042661618253}
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618238}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: vector
+    m_serializedType:
+      m_SerializableType: UnityEngine.Vector3, UnityEngine.CoreModule, Version=0.0.0.0,
+        Culture=neutral, PublicKeyToken=null
+    attributes:
+    - m_Type: 3
+      m_Min: -Infinity
+      m_Max: Infinity
+      m_Tooltip: The vector.
+      m_Regex: 
+      m_RegexMaxLength: 0
+  m_Direction: 1
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618251
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618250}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618238}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: x
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes: []
+  m_Direction: 1
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618252
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618250}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618238}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: y
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes: []
+  m_Direction: 1
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618253
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618250}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618238}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: z
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes: []
+  m_Direction: 1
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618254
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c499060cea9bbb24b8d723eafa343303, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618238}
+  m_Children:
+  - {fileID: 8926484042661618255}
+  - {fileID: 8926484042661618256}
+  - {fileID: 8926484042661618257}
+  - {fileID: 8926484042661618258}
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618238}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: KernelSize
+    m_serializedType:
+      m_SerializableType: UnityEngine.Vector4, UnityEngine.CoreModule, Version=0.0.0.0,
+        Culture=neutral, PublicKeyToken=null
+    attributes: []
+  m_Direction: 1
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618255
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618254}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618238}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: x
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes: []
+  m_Direction: 1
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618256
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618254}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618238}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: y
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes: []
+  m_Direction: 1
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618257
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618254}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618238}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: z
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes: []
+  m_Direction: 1
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618258
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618254}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618238}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: w
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes: []
+  m_Direction: 1
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618259
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c499060cea9bbb24b8d723eafa343303, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618238}
+  m_Children:
+  - {fileID: 8926484042661618260}
+  - {fileID: 8926484042661618261}
+  - {fileID: 8926484042661618262}
+  - {fileID: 8926484042661618263}
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618238}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: KernelFactors
+    m_serializedType:
+      m_SerializableType: UnityEngine.Vector4, UnityEngine.CoreModule, Version=0.0.0.0,
+        Culture=neutral, PublicKeyToken=null
+    attributes: []
+  m_Direction: 1
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618260
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618259}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618238}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: x
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes: []
+  m_Direction: 1
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618261
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618259}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618238}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: y
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes: []
+  m_Direction: 1
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618262
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618259}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618238}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: z
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes: []
+  m_Direction: 1
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618263
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618259}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618238}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: w
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes: []
+  m_Direction: 1
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618264
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 70a331b1d86cc8d4aa106ccbe0da5852, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618238}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618238}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: Tex
+    m_serializedType:
+      m_SerializableType: UnityEngine.Texture2D, UnityEngine.CoreModule, Version=0.0.0.0,
+        Culture=neutral, PublicKeyToken=null
+    attributes: []
+  m_Direction: 1
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618265
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1b2b751071c7fc14f9fa503163991826, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618238}
+  m_Children:
+  - {fileID: 8926484042661618266}
+  - {fileID: 8926484042661618267}
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618238}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: TexSize
+    m_serializedType:
+      m_SerializableType: UnityEngine.Vector2, UnityEngine.CoreModule, Version=0.0.0.0,
+        Culture=neutral, PublicKeyToken=null
+    attributes: []
+  m_Direction: 1
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618266
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618265}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618238}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: x
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes: []
+  m_Direction: 1
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618267
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618265}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618238}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: y
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes: []
+  m_Direction: 1
   m_LinkedSlots: []

--- a/Editor/Templates/Fluid Particle System.vfx
+++ b/Editor/Templates/Fluid Particle System.vfx
@@ -16,10 +16,10 @@ MonoBehaviour:
   - title: '[FluvioFX] Fluid simulation'
     position:
       serializedVersion: 2
-      x: 830.8771
-      y: -445.97025
+      x: 831
+      y: -446
       width: 1264
-      height: 1704
+      height: 1374
     contents:
     - model: {fileID: 8926484042661618129}
       id: 0
@@ -66,11 +66,17 @@ MonoBehaviour:
     - model: {fileID: 0}
       id: 7
       isStickyNote: 1
+    - model: {fileID: 8926484042661618173}
+      id: 0
+      isStickyNote: 0
+    - model: {fileID: 8926484042661618176}
+      id: 0
+      isStickyNote: 0
   - title: '[FluvioFX] Update and integrate'
     position:
       serializedVersion: 2
-      x: 1325.8771
-      y: 1284.0298
+      x: 514
+      y: 851
       width: 768
       height: 277
     contents:
@@ -80,26 +86,12 @@ MonoBehaviour:
     - model: {fileID: 0}
       id: 8
       isStickyNote: 1
-  - title: '[FluvioFX] Colliders'
-    position:
-      serializedVersion: 2
-      x: 863.8771
-      y: 418.02975
-      width: 426
-      height: 443
-    contents:
-    - model: {fileID: 8926484042661618180}
-      id: 0
-      isStickyNote: 0
-    - model: {fileID: 0}
-      id: 9
-      isStickyNote: 1
   stickyNoteInfos:
   - title: Initialize Solver
     position:
       serializedVersion: 2
-      x: 1760.8771
-      y: 17.029755
+      x: 1761
+      y: 17
       width: 309
       height: 143
     contents: "This block initializes FluvioFX particle attributes and must be in
@@ -109,8 +101,8 @@ MonoBehaviour:
   - title: Space Partitioning
     position:
       serializedVersion: 2
-      x: 1758.8771
-      y: 173.02975
+      x: 1759
+      y: 173
       width: 311
       height: 100
     contents: "First, the simulation area is divided into adjacent spaces. Particles\r
@@ -121,8 +113,8 @@ MonoBehaviour:
   - title: Neighbor search
     position:
       serializedVersion: 2
-      x: 1758.8771
-      y: 295.02975
+      x: 1759
+      y: 295
       width: 311
       height: 100
     contents: "FluvioFX requires neighboring particle information in order to simulate\r
@@ -133,8 +125,8 @@ MonoBehaviour:
   - title: Density and pressure
     position:
       serializedVersion: 2
-      x: 1757.8771
-      y: 420.02975
+      x: 1758
+      y: 420
       width: 312
       height: 100
     contents: Both particle density and pressure are determined here on a per-particle
@@ -144,8 +136,8 @@ MonoBehaviour:
   - title: Surface normal
     position:
       serializedVersion: 2
-      x: 1752.8771
-      y: 853.0298
+      x: 1756
+      y: 547
       width: 314
       height: 100
     contents: "The normal vectors of the fluid surface are calculated based on density\r
@@ -156,10 +148,10 @@ MonoBehaviour:
   - title: Calculate forces
     position:
       serializedVersion: 2
-      x: 1751.8771
-      y: 977.0298
+      x: 1755
+      y: 671
       width: 314
-      height: 223
+      height: 203
     contents: "Here, internal fluid forces (pressure and viscosity), along with external\r
       fluid forces (surface tension, turbulence, and buoyancy) are calculated based\r
       on the information above.\n\nSurface tension, turbulence, gravity, buoyancy
@@ -170,8 +162,8 @@ MonoBehaviour:
   - title: Fluid properties
     position:
       serializedVersion: 2
-      x: 855.8771
-      y: -381.97025
+      x: 856
+      y: -382
       width: 451
       height: 414
     contents: "Physical fluid properties can all be changed or exposed from here.
@@ -184,8 +176,8 @@ MonoBehaviour:
   - title: Why multiple contexts and blocks?
     position:
       serializedVersion: 2
-      x: 1313.8771
-      y: -381.97025
+      x: 1314
+      y: -382
       width: 423
       height: 244
     contents: "FluvioFX requires synchronization steps to ensure correct simulation.\r
@@ -195,33 +187,22 @@ MonoBehaviour:
   - title: 
     position:
       serializedVersion: 2
-      x: 1751.8771
-      y: 1362.0298
+      x: 940
+      y: 929
       width: 317
       height: 136
     contents: "Insert any standard VFX blocks here. The Integrate Particles block\r
       must be the *last* block in this context."
     theme: Classic
     textSize: Medium
-  - title: 
-    position:
-      serializedVersion: 2
-      x: 908.8771
-      y: 482.02975
-      width: 329
-      height: 141
-    contents: Insert any Fluid Collider blocks here. These blocks can be found under
-      FluvioFX > Collision.
-    theme: Classic
-    textSize: Medium
   systemInfos: []
   categories: []
   uiBounds:
     serializedVersion: 2
-    x: 860
-    y: -1384
-    width: 1634
-    height: 3543
+    x: 272
+    y: -950
+    width: 1823
+    height: 2573
 --- !u!114 &114350483966674976
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -243,7 +224,6 @@ MonoBehaviour:
   - {fileID: 8926484042661618171}
   - {fileID: 8926484042661618174}
   - {fileID: 8926484042661618177}
-  - {fileID: 8926484042661618180}
   - {fileID: 8926484042661618182}
   - {fileID: 8926484042661618185}
   - {fileID: 8926484042661618216}
@@ -270,8 +250,13 @@ VisualEffectResource:
       64\n#define VFX_USE_LIFETIME_CURRENT 1\n#define VFX_USE_POSITION_CURRENT 1\n#define
       VFX_USE_FORCE_CURRENT 1\n#define VFX_USE_MASS_CURRENT 1\n#define VFX_USE_OLDPOSITION_CURRENT
       1\n#define VFX_USE_ALIVE_CURRENT 1\n#define VFX_USE_AGE_CURRENT 1\n#define VFX_HAS_INDIRECT_DRAW
-      1\n#define VFX_WORLD_SPACE 1\n\n\nCBUFFER_START(parameters)\n    float3 solverData_Gravity_a;\n
-      \   uint PADDING_0;\nCBUFFER_END\nTexture2D solverData_Tex_a;\nSamplerState
+      1\n#define VFX_WORLD_SPACE 1\n\n\nCBUFFER_START(parameters)\n    float4 solverData_KernelSize_a;\n
+      \   float4 solverData_KernelFactors_a;\n    float3 solverData_Gravity_a;\n    float
+      solverData_Fluid_SmoothingDistance_a;\n    float solverData_Fluid_ParticleMass_a;\n
+      \   float solverData_Fluid_Density_a;\n    float solverData_Fluid_MinimumDensity_a;\n
+      \   float solverData_Fluid_GasConstant_a;\n    float solverData_Fluid_Viscosity_a;\n
+      \   float solverData_Fluid_TurbulenceProbability_a;\n    float solverData_Fluid_SurfaceTension_a;\n
+      \   float solverData_Fluid_BuoyancyCoefficient_a;\nCBUFFER_END\nTexture2D solverData_Tex_a;\nSamplerState
       samplersolverData_Tex_a;\n\n\n#include \"Packages/com.unity.visualeffectgraph/Shaders/Common/VFXCommonCompute.cginc\"\n#include
       \"Packages/com.unity.visualeffectgraph/Shaders/VFXCommon.cginc\"\n#include \"Packages/com.thinksquirrel.fluviofx/Shaders/FluvioCompute.cginc\"\n\n\n\nRWByteAddressBuffer
       attributeBuffer;\n\n#if VFX_USE_ALIVE_CURRENT\nRWStructuredBuffer<uint> deadListOut;\n#endif\n\n#if
@@ -284,12 +269,12 @@ VisualEffectResource:
       solverData_Fluid_TurbulenceProbability, float solverData_Fluid_SurfaceTension,
       float solverData_Fluid_BuoyancyCoefficient, float3 solverData_Gravity, float4
       solverData_KernelSize, float4 solverData_KernelFactors, VFXSampler2D solverData_Tex,
-      float2 solverData_TexSize)\n{\n    \n    // Clear forces\n    force = 0;\n    \n
-      \   #ifdef FLUVIO_INDEX_GRID\n    // Clear grid index\n    gridIndex = 0;\n
-      \   \n    // Clear neighbor count\n    neighborCount = 0;\n    \n    // Set
-      mass\n    mass = solverData_Fluid_ParticleMass;\n    \n    // Set old position\n
-      \   oldPosition = position;\n    \n    #endif\n}\nvoid Reap(float age, float
-      lifetime, inout bool alive)\n{\n    if(age > lifetime) { alive = false; }\n}\n\n\n\n[numthreads(NB_THREADS_PER_GROUP,1,1)]\nvoid
+      float2 solverData_TexSize)\n{\n    \n    // Set old position\n    oldPosition
+      = position;\n    \n    // Clear forces\n    force = 0;\n    \n    // Set mass\n
+      \   mass = solverData_Fluid_ParticleMass;\n    \n    #ifdef FLUVIO_INDEX_GRID\n
+      \   // Clear grid index\n    gridIndex = 0;\n    \n    // Clear neighbor count\n
+      \   neighborCount = 0;\n    #endif\n}\nvoid Reap(float age, float lifetime,
+      inout bool alive)\n{\n    if(age > lifetime) { alive = false; }\n}\n\n\n\n[numthreads(NB_THREADS_PER_GROUP,1,1)]\nvoid
       CSMain(uint3 groupId          : SV_GroupID,\n            uint3 groupThreadId
       \   : SV_GroupThreadID)\n{\n\tuint id = groupThreadId.x + groupId.x * NB_THREADS_PER_GROUP
       + groupId.y * dispatchWidth * NB_THREADS_PER_GROUP;\n\tuint index = id;\n\tif
@@ -303,9 +288,11 @@ VisualEffectResource:
       age = asfloat(attributeBuffer.Load((index * 0x1 + 0xF800) << 2));\n\t\t\t\n\n\t\t\t\n#if
       VFX_USE_OLDPOSITION_CURRENT\n\t\t\toldPosition = position;\n#endif\n\t\t\t\n\t\t\t{\n\t\t\t
       \   InitializeSolver(index, position,  /*inout */force,  /*inout */mass,  /*inout
-      */oldPosition, (float)0.38125, (float)7.625, (float)998.29, (float)9.9829, (float)0.01,
-      (float)0.3, (float)0.2, (float)0.728, (float)0, solverData_Gravity_a, float4(0.38125,0.1453516,0.05541528,0),
-      float4(9206.448,1554.828,43.08061,0), GetVFXSampler(solverData_Tex_a, samplersolverData_Tex_a),
+      */oldPosition, solverData_Fluid_SmoothingDistance_a, solverData_Fluid_ParticleMass_a,
+      solverData_Fluid_Density_a, solverData_Fluid_MinimumDensity_a, solverData_Fluid_GasConstant_a,
+      solverData_Fluid_Viscosity_a, solverData_Fluid_TurbulenceProbability_a, solverData_Fluid_SurfaceTension_a,
+      solverData_Fluid_BuoyancyCoefficient_a, solverData_Gravity_a, solverData_KernelSize_a,
+      solverData_KernelFactors_a, GetVFXSampler(solverData_Tex_a, samplersolverData_Tex_a),
       float2(0,0));\n\t\t\t}\n\t\t\tReap(age, lifetime,  /*inout */alive);\n\t\t\t\n\n\t\t\tif
       (alive)\n\t\t\t{\n\t\t\t\tattributeBuffer.Store3((index * 0x4 + 0x4800) << 2,asuint(force));\n\t\t\t\tattributeBuffer.Store((index
       * 0x1 + 0x6800) << 2,asuint(mass));\n\t\t\t\tattributeBuffer.Store3((index *
@@ -322,23 +309,30 @@ VisualEffectResource:
       + 0xF000) << 2));\n\t\tfloat age = asfloat(attributeBuffer.Load((index * 0x1
       + 0xF800) << 2));\n\t\t\n\n\t\t\n#if VFX_USE_OLDPOSITION_CURRENT\n\t\toldPosition
       = position;\n#endif\n\t\t\n\t\t{\n\t\t    InitializeSolver(index, position,
-      \ /*inout */force,  /*inout */mass,  /*inout */oldPosition, (float)0.38125,
-      (float)7.625, (float)998.29, (float)9.9829, (float)0.01, (float)0.3, (float)0.2,
-      (float)0.728, (float)0, solverData_Gravity_a, float4(0.38125,0.1453516,0.05541528,0),
-      float4(9206.448,1554.828,43.08061,0), GetVFXSampler(solverData_Tex_a, samplersolverData_Tex_a),
-      float2(0,0));\n\t\t}\n\t\tReap(age, lifetime,  /*inout */alive);\n\t\t\n\n\t\tattributeBuffer.Store3((index
-      * 0x4 + 0x4800) << 2,asuint(force));\n\t\tattributeBuffer.Store((index * 0x1
-      + 0x6800) << 2,asuint(mass));\n\t\tattributeBuffer.Store3((index * 0x4 + 0x7000)
-      << 2,asuint(oldPosition));\n\t\tattributeBuffer.Store((index * 0x1 + 0xF000)
-      << 2,uint(alive));\n\t\t\n\n#if VFX_HAS_INDIRECT_DRAW\n        uint indirectIndex
-      = indirectBuffer.IncrementCounter();\n\t\tindirectBuffer[indirectIndex] = index;\n#endif\n#endif\n\t}\n}\n"
+      \ /*inout */force,  /*inout */mass,  /*inout */oldPosition, solverData_Fluid_SmoothingDistance_a,
+      solverData_Fluid_ParticleMass_a, solverData_Fluid_Density_a, solverData_Fluid_MinimumDensity_a,
+      solverData_Fluid_GasConstant_a, solverData_Fluid_Viscosity_a, solverData_Fluid_TurbulenceProbability_a,
+      solverData_Fluid_SurfaceTension_a, solverData_Fluid_BuoyancyCoefficient_a, solverData_Gravity_a,
+      solverData_KernelSize_a, solverData_KernelFactors_a, GetVFXSampler(solverData_Tex_a,
+      samplersolverData_Tex_a), float2(0,0));\n\t\t}\n\t\tReap(age, lifetime,  /*inout
+      */alive);\n\t\t\n\n\t\tattributeBuffer.Store3((index * 0x4 + 0x4800) << 2,asuint(force));\n\t\tattributeBuffer.Store((index
+      * 0x1 + 0x6800) << 2,asuint(mass));\n\t\tattributeBuffer.Store3((index * 0x4
+      + 0x7000) << 2,asuint(oldPosition));\n\t\tattributeBuffer.Store((index * 0x1
+      + 0xF000) << 2,uint(alive));\n\t\t\n\n#if VFX_HAS_INDIRECT_DRAW\n        uint
+      indirectIndex = indirectBuffer.IncrementCounter();\n\t\tindirectBuffer[indirectIndex]
+      = index;\n#endif\n#endif\n\t}\n}\n"
   - compute: 1
     name: '[System 1]B Update'
     source: "#pragma kernel CSMain\n#include \"HLSLSupport.cginc\"\n#define NB_THREADS_PER_GROUP
       64\n#define VFX_USE_LIFETIME_CURRENT 1\n#define VFX_USE_POSITION_CURRENT 1\n#define
       VFX_USE_OLDPOSITION_CURRENT 1\n#define VFX_USE_ALIVE_CURRENT 1\n#define VFX_USE_AGE_CURRENT
       1\n#define VFX_HAS_INDIRECT_DRAW 1\n#define VFX_WORLD_SPACE 1\n\n\nCBUFFER_START(parameters)\n
-      \   float3 solverData_Gravity_a;\n    uint PADDING_0;\nCBUFFER_END\n\n\n#include
+      \   float4 solverData_KernelSize_a;\n    float4 solverData_KernelFactors_a;\n
+      \   float3 solverData_Gravity_a;\n    float solverData_Fluid_SmoothingDistance_a;\n
+      \   float solverData_Fluid_ParticleMass_a;\n    float solverData_Fluid_Density_a;\n
+      \   float solverData_Fluid_MinimumDensity_a;\n    float solverData_Fluid_GasConstant_a;\n
+      \   float solverData_Fluid_Viscosity_a;\n    float solverData_Fluid_TurbulenceProbability_a;\n
+      \   float solverData_Fluid_SurfaceTension_a;\n    float solverData_Fluid_BuoyancyCoefficient_a;\nCBUFFER_END\n\n\n#include
       \"Packages/com.unity.visualeffectgraph/Shaders/Common/VFXCommonCompute.cginc\"\n#include
       \"Packages/com.unity.visualeffectgraph/Shaders/VFXCommon.cginc\"\n#include \"Packages/com.thinksquirrel.fluviofx/Shaders/FluvioCompute.cginc\"\n\n\n\nRWByteAddressBuffer
       attributeBuffer;\n\n#if VFX_USE_ALIVE_CURRENT\nRWStructuredBuffer<uint> deadListOut;\n#endif\n\n#if
@@ -363,13 +357,14 @@ VisualEffectResource:
       = asfloat(attributeBuffer.Load3((index * 0x4 + 0x800) << 2));\n\t\t\tfloat3
       oldPosition = asfloat(attributeBuffer.Load3((index * 0x4 + 0x7000) << 2));\n\t\t\tfloat
       age = asfloat(attributeBuffer.Load((index * 0x1 + 0xF800) << 2));\n\t\t\t\n\n\t\t\t\n#if
-      VFX_USE_OLDPOSITION_CURRENT\n\t\t\toldPosition = position;\n#endif\n\t\t\t\n\t\t\t{\n\t\t\t
-      \   SpacePartitioning(index, position, alive, (float)0.38125, (float)7.625,
-      (float)998.29, (float)9.9829, (float)0.01, (float)0.3, (float)0.2, (float)0.728,
-      (float)0, solverData_Gravity_a, float4(0.38125,0.1453516,0.05541528,0), float4(9206.448,1554.828,43.08061,0));\n\t\t\t}\n\t\t\tReap(age,
-      lifetime,  /*inout */alive);\n\t\t\t\n\n\t\t\tif (alive)\n\t\t\t{\n\t\t\t\tattributeBuffer.Store3((index
-      * 0x4 + 0x7000) << 2,asuint(oldPosition));\n\t\t\t\t\n\n#if VFX_HAS_INDIRECT_DRAW\n
-      \               uint indirectIndex = indirectBuffer.IncrementCounter();\n\t\t\t\tindirectBuffer[indirectIndex]
+      VFX_USE_OLDPOSITION_CURRENT\n\t\t\toldPosition = position;\n#endif\n\t\t\t\n\t\t\tSpacePartitioning(index,
+      position, alive, solverData_Fluid_SmoothingDistance_a, solverData_Fluid_ParticleMass_a,
+      solverData_Fluid_Density_a, solverData_Fluid_MinimumDensity_a, solverData_Fluid_GasConstant_a,
+      solverData_Fluid_Viscosity_a, solverData_Fluid_TurbulenceProbability_a, solverData_Fluid_SurfaceTension_a,
+      solverData_Fluid_BuoyancyCoefficient_a, solverData_Gravity_a, solverData_KernelSize_a,
+      solverData_KernelFactors_a);\n\t\t\tReap(age, lifetime,  /*inout */alive);\n\t\t\t\n\n\t\t\tif
+      (alive)\n\t\t\t{\n\t\t\t\tattributeBuffer.Store3((index * 0x4 + 0x7000) << 2,asuint(oldPosition));\n\t\t\t\t\n\n#if
+      VFX_HAS_INDIRECT_DRAW\n                uint indirectIndex = indirectBuffer.IncrementCounter();\n\t\t\t\tindirectBuffer[indirectIndex]
       = index;\n#endif\n\t\t\t}\n\t\t\telse\n\t\t\t{\n\t\t\t\tattributeBuffer.Store((index
       * 0x1 + 0xF000) << 2,uint(alive));\n\t\t\t\t\n\n\t\t\t\tuint deadIndex = deadListOut.IncrementCounter();\n\t\t\t\tdeadListOut[deadIndex]
       = index;\n\t\t\t}\n\t\t}\n#else\n\t\tfloat lifetime = asfloat(attributeBuffer.Load((index
@@ -378,21 +373,27 @@ VisualEffectResource:
       * 0x4 + 0x7000) << 2));\n\t\tbool alive = (attributeBuffer.Load((index * 0x1
       + 0xF000) << 2));\n\t\tfloat age = asfloat(attributeBuffer.Load((index * 0x1
       + 0xF800) << 2));\n\t\t\n\n\t\t\n#if VFX_USE_OLDPOSITION_CURRENT\n\t\toldPosition
-      = position;\n#endif\n\t\t\n\t\t{\n\t\t    SpacePartitioning(index, position,
-      alive, (float)0.38125, (float)7.625, (float)998.29, (float)9.9829, (float)0.01,
-      (float)0.3, (float)0.2, (float)0.728, (float)0, solverData_Gravity_a, float4(0.38125,0.1453516,0.05541528,0),
-      float4(9206.448,1554.828,43.08061,0));\n\t\t}\n\t\tReap(age, lifetime,  /*inout
-      */alive);\n\t\t\n\n\t\tattributeBuffer.Store3((index * 0x4 + 0x7000) << 2,asuint(oldPosition));\n\t\tattributeBuffer.Store((index
-      * 0x1 + 0xF000) << 2,uint(alive));\n\t\t\n\n#if VFX_HAS_INDIRECT_DRAW\n        uint
-      indirectIndex = indirectBuffer.IncrementCounter();\n\t\tindirectBuffer[indirectIndex]
-      = index;\n#endif\n#endif\n\t}\n}\n"
+      = position;\n#endif\n\t\t\n\t\tSpacePartitioning(index, position, alive, solverData_Fluid_SmoothingDistance_a,
+      solverData_Fluid_ParticleMass_a, solverData_Fluid_Density_a, solverData_Fluid_MinimumDensity_a,
+      solverData_Fluid_GasConstant_a, solverData_Fluid_Viscosity_a, solverData_Fluid_TurbulenceProbability_a,
+      solverData_Fluid_SurfaceTension_a, solverData_Fluid_BuoyancyCoefficient_a, solverData_Gravity_a,
+      solverData_KernelSize_a, solverData_KernelFactors_a);\n\t\tReap(age, lifetime,
+      \ /*inout */alive);\n\t\t\n\n\t\tattributeBuffer.Store3((index * 0x4 + 0x7000)
+      << 2,asuint(oldPosition));\n\t\tattributeBuffer.Store((index * 0x1 + 0xF000)
+      << 2,uint(alive));\n\t\t\n\n#if VFX_HAS_INDIRECT_DRAW\n        uint indirectIndex
+      = indirectBuffer.IncrementCounter();\n\t\tindirectBuffer[indirectIndex] = index;\n#endif\n#endif\n\t}\n}\n"
   - compute: 1
     name: '[System 1]C Update'
     source: "#pragma kernel CSMain\n#include \"HLSLSupport.cginc\"\n#define NB_THREADS_PER_GROUP
       64\n#define VFX_USE_LIFETIME_CURRENT 1\n#define VFX_USE_POSITION_CURRENT 1\n#define
       VFX_USE_OLDPOSITION_CURRENT 1\n#define VFX_USE_ALIVE_CURRENT 1\n#define VFX_USE_AGE_CURRENT
       1\n#define VFX_HAS_INDIRECT_DRAW 1\n#define VFX_WORLD_SPACE 1\n\n\nCBUFFER_START(parameters)\n
-      \   float3 solverData_Gravity_a;\n    uint PADDING_0;\nCBUFFER_END\n\n\n#include
+      \   float4 solverData_KernelSize_a;\n    float4 solverData_KernelFactors_a;\n
+      \   float3 solverData_Gravity_a;\n    float solverData_Fluid_SmoothingDistance_a;\n
+      \   float solverData_Fluid_ParticleMass_a;\n    float solverData_Fluid_Density_a;\n
+      \   float solverData_Fluid_MinimumDensity_a;\n    float solverData_Fluid_GasConstant_a;\n
+      \   float solverData_Fluid_Viscosity_a;\n    float solverData_Fluid_TurbulenceProbability_a;\n
+      \   float solverData_Fluid_SurfaceTension_a;\n    float solverData_Fluid_BuoyancyCoefficient_a;\nCBUFFER_END\n\n\n#include
       \"Packages/com.unity.visualeffectgraph/Shaders/Common/VFXCommonCompute.cginc\"\n#include
       \"Packages/com.unity.visualeffectgraph/Shaders/VFXCommon.cginc\"\n#include \"Packages/com.thinksquirrel.fluviofx/Shaders/FluvioCompute.cginc\"\n\n\n\nRWByteAddressBuffer
       attributeBuffer;\n\n#if VFX_USE_ALIVE_CURRENT\nRWStructuredBuffer<uint> deadListOut;\n#endif\n\n#if
@@ -422,7 +423,7 @@ VisualEffectResource:
       \                   // indices are +1 for GPU grids (0 = not alive)\n                    if
       (candidateGridIndex - 1 == currentGridIndex)\n                    {\n                        float3
       candidatePosition = asfloat(attributeBuffer.Load3((candidate * 0x4 + 0x800)
-      << 2));\n                        dist = candidatePosition - position;\n                        d
+      << 2));\n                        dist = position - candidatePosition;\n                        d
       = dot(dist, dist);\n    \n                        if (d < solverData_KernelSize.y)\n
       \                       {\n                            SetNeighborIndex(solverData_Tex,
       solverData_TexSize, index, nCount++, candidate);\n    \n                            if
@@ -441,11 +442,12 @@ VisualEffectResource:
       * 0x4 + 0x800) << 2));\n\t\t\tfloat3 oldPosition = asfloat(attributeBuffer.Load3((index
       * 0x4 + 0x7000) << 2));\n\t\t\tfloat age = asfloat(attributeBuffer.Load((index
       * 0x1 + 0xF800) << 2));\n\t\t\t\n\n\t\t\t\n#if VFX_USE_OLDPOSITION_CURRENT\n\t\t\toldPosition
-      = position;\n#endif\n\t\t\t\n\t\t\t{\n\t\t\t    NeighborSearch(index, position,
-      alive, (float)0.38125, (float)7.625, (float)998.29, (float)9.9829, (float)0.01,
-      (float)0.3, (float)0.2, (float)0.728, (float)0, solverData_Gravity_a, float4(0.38125,0.1453516,0.05541528,0),
-      float4(9206.448,1554.828,43.08061,0));\n\t\t\t}\n\t\t\tReap(age, lifetime,  /*inout
-      */alive);\n\t\t\t\n\n\t\t\tif (alive)\n\t\t\t{\n\t\t\t\tattributeBuffer.Store3((index
+      = position;\n#endif\n\t\t\t\n\t\t\tNeighborSearch(index, position, alive, solverData_Fluid_SmoothingDistance_a,
+      solverData_Fluid_ParticleMass_a, solverData_Fluid_Density_a, solverData_Fluid_MinimumDensity_a,
+      solverData_Fluid_GasConstant_a, solverData_Fluid_Viscosity_a, solverData_Fluid_TurbulenceProbability_a,
+      solverData_Fluid_SurfaceTension_a, solverData_Fluid_BuoyancyCoefficient_a, solverData_Gravity_a,
+      solverData_KernelSize_a, solverData_KernelFactors_a);\n\t\t\tReap(age, lifetime,
+      \ /*inout */alive);\n\t\t\t\n\n\t\t\tif (alive)\n\t\t\t{\n\t\t\t\tattributeBuffer.Store3((index
       * 0x4 + 0x7000) << 2,asuint(oldPosition));\n\t\t\t\t\n\n#if VFX_HAS_INDIRECT_DRAW\n
       \               uint indirectIndex = indirectBuffer.IncrementCounter();\n\t\t\t\tindirectBuffer[indirectIndex]
       = index;\n#endif\n\t\t\t}\n\t\t\telse\n\t\t\t{\n\t\t\t\tattributeBuffer.Store((index
@@ -456,22 +458,29 @@ VisualEffectResource:
       * 0x4 + 0x7000) << 2));\n\t\tbool alive = (attributeBuffer.Load((index * 0x1
       + 0xF000) << 2));\n\t\tfloat age = asfloat(attributeBuffer.Load((index * 0x1
       + 0xF800) << 2));\n\t\t\n\n\t\t\n#if VFX_USE_OLDPOSITION_CURRENT\n\t\toldPosition
-      = position;\n#endif\n\t\t\n\t\t{\n\t\t    NeighborSearch(index, position, alive,
-      (float)0.38125, (float)7.625, (float)998.29, (float)9.9829, (float)0.01, (float)0.3,
-      (float)0.2, (float)0.728, (float)0, solverData_Gravity_a, float4(0.38125,0.1453516,0.05541528,0),
-      float4(9206.448,1554.828,43.08061,0));\n\t\t}\n\t\tReap(age, lifetime,  /*inout
-      */alive);\n\t\t\n\n\t\tattributeBuffer.Store3((index * 0x4 + 0x7000) << 2,asuint(oldPosition));\n\t\tattributeBuffer.Store((index
-      * 0x1 + 0xF000) << 2,uint(alive));\n\t\t\n\n#if VFX_HAS_INDIRECT_DRAW\n        uint
-      indirectIndex = indirectBuffer.IncrementCounter();\n\t\tindirectBuffer[indirectIndex]
-      = index;\n#endif\n#endif\n\t}\n}\n"
+      = position;\n#endif\n\t\t\n\t\tNeighborSearch(index, position, alive, solverData_Fluid_SmoothingDistance_a,
+      solverData_Fluid_ParticleMass_a, solverData_Fluid_Density_a, solverData_Fluid_MinimumDensity_a,
+      solverData_Fluid_GasConstant_a, solverData_Fluid_Viscosity_a, solverData_Fluid_TurbulenceProbability_a,
+      solverData_Fluid_SurfaceTension_a, solverData_Fluid_BuoyancyCoefficient_a, solverData_Gravity_a,
+      solverData_KernelSize_a, solverData_KernelFactors_a);\n\t\tReap(age, lifetime,
+      \ /*inout */alive);\n\t\t\n\n\t\tattributeBuffer.Store3((index * 0x4 + 0x7000)
+      << 2,asuint(oldPosition));\n\t\tattributeBuffer.Store((index * 0x1 + 0xF000)
+      << 2,uint(alive));\n\t\t\n\n#if VFX_HAS_INDIRECT_DRAW\n        uint indirectIndex
+      = indirectBuffer.IncrementCounter();\n\t\tindirectBuffer[indirectIndex] = index;\n#endif\n#endif\n\t}\n}\n"
   - compute: 1
     name: '[System 1]D Update'
     source: "#pragma kernel CSMain\n#include \"HLSLSupport.cginc\"\n#define NB_THREADS_PER_GROUP
       64\n#define VFX_USE_LIFETIME_CURRENT 1\n#define VFX_USE_POSITION_CURRENT 1\n#define
       VFX_USE_MASS_CURRENT 1\n#define VFX_USE_OLDPOSITION_CURRENT 1\n#define VFX_USE_DENSITYPRESSURE_CURRENT
       1\n#define VFX_USE_ALIVE_CURRENT 1\n#define VFX_USE_AGE_CURRENT 1\n#define VFX_HAS_INDIRECT_DRAW
-      1\n#define VFX_WORLD_SPACE 1\n\n\nCBUFFER_START(parameters)\n    float3 solverData_Gravity_a;\n
-      \   uint PADDING_0;\nCBUFFER_END\n\n\n#include \"Packages/com.unity.visualeffectgraph/Shaders/Common/VFXCommonCompute.cginc\"\n#include
+      1\n#define VFX_WORLD_SPACE 1\n\n\nCBUFFER_START(parameters)\n    float4 solverData_KernelSize_a;\n
+      \   float4 solverData_KernelFactors_a;\n    float3 solverData_Gravity_a;\n    float
+      solverData_Fluid_SmoothingDistance_a;\n    float solverData_Fluid_ParticleMass_a;\n
+      \   float solverData_Fluid_Density_a;\n    float solverData_Fluid_MinimumDensity_a;\n
+      \   float solverData_Fluid_GasConstant_a;\n    float solverData_Fluid_Viscosity_a;\n
+      \   float solverData_Fluid_TurbulenceProbability_a;\n    float solverData_Fluid_SurfaceTension_a;\n
+      \   float solverData_Fluid_BuoyancyCoefficient_a;\nCBUFFER_END\n\n\n#include
+      \"Packages/com.unity.visualeffectgraph/Shaders/Common/VFXCommonCompute.cginc\"\n#include
       \"Packages/com.unity.visualeffectgraph/Shaders/VFXCommon.cginc\"\n#include \"Packages/com.thinksquirrel.fluviofx/Shaders/FluvioCompute.cginc\"\n\n\n\nRWByteAddressBuffer
       attributeBuffer;\n\n#if VFX_USE_ALIVE_CURRENT\nRWStructuredBuffer<uint> deadListOut;\n#endif\n\n#if
       VFX_HAS_INDIRECT_DRAW\nRWStructuredBuffer<uint> indirectBuffer;\n#endif\n\nCBUFFER_START(updateParams)\n
@@ -497,10 +506,10 @@ VisualEffectResource:
       += neighborMass * Poly6Calculate(dist, solverData_KernelFactors.x, solverData_KernelSize.y);\n
       \   }\n    \n    // Write to density/pressure\n    density = max(density, solverData_Fluid_MinimumDensity);\n
       \   pressure = solverData_Fluid_GasConstant * (density - solverData_Fluid_Density);\n
-      \   densityPressure = float4(density, density, pressure, pressure);\n}\nvoid
-      Reap(float age, float lifetime, inout bool alive)\n{\n    if(age > lifetime)
-      { alive = false; }\n}\n\n\n\n[numthreads(NB_THREADS_PER_GROUP,1,1)]\nvoid CSMain(uint3
-      groupId          : SV_GroupID,\n            uint3 groupThreadId    : SV_GroupThreadID)\n{\n\tuint
+      \   densityPressure.xy = float2(density, pressure);\n}\nvoid Reap(float age,
+      float lifetime, inout bool alive)\n{\n    if(age > lifetime) { alive = false;
+      }\n}\n\n\n\n[numthreads(NB_THREADS_PER_GROUP,1,1)]\nvoid CSMain(uint3 groupId
+      \         : SV_GroupID,\n            uint3 groupThreadId    : SV_GroupThreadID)\n{\n\tuint
       id = groupThreadId.x + groupId.x * NB_THREADS_PER_GROUP + groupId.y * dispatchWidth
       * NB_THREADS_PER_GROUP;\n\tuint index = id;\n\tif (id < nbMax)\n\t{\n#if VFX_USE_ALIVE_CURRENT\n\t\tbool
       alive = (attributeBuffer.Load((index * 0x1 + 0xF000) << 2));\n\t\t\n\n\t\tif
@@ -511,12 +520,13 @@ VisualEffectResource:
       * 0x4 + 0x7000) << 2));\n\t\t\tfloat4 densityPressure = asfloat(attributeBuffer.Load4((index
       * 0x4 + 0x9000) << 2));\n\t\t\tfloat age = asfloat(attributeBuffer.Load((index
       * 0x1 + 0xF800) << 2));\n\t\t\t\n\n\t\t\t\n#if VFX_USE_OLDPOSITION_CURRENT\n\t\t\toldPosition
-      = position;\n#endif\n\t\t\t\n\t\t\t{\n\t\t\t    DensityPressure(index, position,
-      alive, mass,  /*inout */densityPressure, (float)0.38125, (float)7.625, (float)998.29,
-      (float)9.9829, (float)0.01, (float)0.3, (float)0.2, (float)0.728, (float)0,
-      solverData_Gravity_a, float4(0.38125,0.1453516,0.05541528,0), float4(9206.448,1554.828,43.08061,0));\n\t\t\t}\n\t\t\tReap(age,
-      lifetime,  /*inout */alive);\n\t\t\t\n\n\t\t\tif (alive)\n\t\t\t{\n\t\t\t\tattributeBuffer.Store3((index
-      * 0x4 + 0x7000) << 2,asuint(oldPosition));\n\t\t\t\tattributeBuffer.Store4((index
+      = position;\n#endif\n\t\t\t\n\t\t\tDensityPressure(index, position, alive, mass,
+      \ /*inout */densityPressure, solverData_Fluid_SmoothingDistance_a, solverData_Fluid_ParticleMass_a,
+      solverData_Fluid_Density_a, solverData_Fluid_MinimumDensity_a, solverData_Fluid_GasConstant_a,
+      solverData_Fluid_Viscosity_a, solverData_Fluid_TurbulenceProbability_a, solverData_Fluid_SurfaceTension_a,
+      solverData_Fluid_BuoyancyCoefficient_a, solverData_Gravity_a, solverData_KernelSize_a,
+      solverData_KernelFactors_a);\n\t\t\tReap(age, lifetime,  /*inout */alive);\n\t\t\t\n\n\t\t\tif
+      (alive)\n\t\t\t{\n\t\t\t\tattributeBuffer.Store3((index * 0x4 + 0x7000) << 2,asuint(oldPosition));\n\t\t\t\tattributeBuffer.Store4((index
       * 0x4 + 0x9000) << 2,asuint(densityPressure));\n\t\t\t\t\n\n#if VFX_HAS_INDIRECT_DRAW\n
       \               uint indirectIndex = indirectBuffer.IncrementCounter();\n\t\t\t\tindirectBuffer[indirectIndex]
       = index;\n#endif\n\t\t\t}\n\t\t\telse\n\t\t\t{\n\t\t\t\tattributeBuffer.Store((index
@@ -529,25 +539,31 @@ VisualEffectResource:
       * 0x4 + 0x9000) << 2));\n\t\tbool alive = (attributeBuffer.Load((index * 0x1
       + 0xF000) << 2));\n\t\tfloat age = asfloat(attributeBuffer.Load((index * 0x1
       + 0xF800) << 2));\n\t\t\n\n\t\t\n#if VFX_USE_OLDPOSITION_CURRENT\n\t\toldPosition
-      = position;\n#endif\n\t\t\n\t\t{\n\t\t    DensityPressure(index, position, alive,
-      mass,  /*inout */densityPressure, (float)0.38125, (float)7.625, (float)998.29,
-      (float)9.9829, (float)0.01, (float)0.3, (float)0.2, (float)0.728, (float)0,
-      solverData_Gravity_a, float4(0.38125,0.1453516,0.05541528,0), float4(9206.448,1554.828,43.08061,0));\n\t\t}\n\t\tReap(age,
-      lifetime,  /*inout */alive);\n\t\t\n\n\t\tattributeBuffer.Store3((index * 0x4
-      + 0x7000) << 2,asuint(oldPosition));\n\t\tattributeBuffer.Store4((index * 0x4
-      + 0x9000) << 2,asuint(densityPressure));\n\t\tattributeBuffer.Store((index *
-      0x1 + 0xF000) << 2,uint(alive));\n\t\t\n\n#if VFX_HAS_INDIRECT_DRAW\n        uint
+      = position;\n#endif\n\t\t\n\t\tDensityPressure(index, position, alive, mass,
+      \ /*inout */densityPressure, solverData_Fluid_SmoothingDistance_a, solverData_Fluid_ParticleMass_a,
+      solverData_Fluid_Density_a, solverData_Fluid_MinimumDensity_a, solverData_Fluid_GasConstant_a,
+      solverData_Fluid_Viscosity_a, solverData_Fluid_TurbulenceProbability_a, solverData_Fluid_SurfaceTension_a,
+      solverData_Fluid_BuoyancyCoefficient_a, solverData_Gravity_a, solverData_KernelSize_a,
+      solverData_KernelFactors_a);\n\t\tReap(age, lifetime,  /*inout */alive);\n\t\t\n\n\t\tattributeBuffer.Store3((index
+      * 0x4 + 0x7000) << 2,asuint(oldPosition));\n\t\tattributeBuffer.Store4((index
+      * 0x4 + 0x9000) << 2,asuint(densityPressure));\n\t\tattributeBuffer.Store((index
+      * 0x1 + 0xF000) << 2,uint(alive));\n\t\t\n\n#if VFX_HAS_INDIRECT_DRAW\n        uint
       indirectIndex = indirectBuffer.IncrementCounter();\n\t\tindirectBuffer[indirectIndex]
       = index;\n#endif\n#endif\n\t}\n}\n"
   - compute: 1
-    name: '[System 1]F Update'
+    name: '[System 1]E Update'
     source: "#pragma kernel CSMain\n#include \"HLSLSupport.cginc\"\n#define NB_THREADS_PER_GROUP
       64\n#define VFX_USE_LIFETIME_CURRENT 1\n#define VFX_USE_POSITION_CURRENT 1\n#define
       VFX_USE_MASS_CURRENT 1\n#define VFX_USE_OLDPOSITION_CURRENT 1\n#define VFX_USE_DENSITYPRESSURE_CURRENT
       1\n#define VFX_USE_NORMAL_CURRENT 1\n#define VFX_USE_ALIVE_CURRENT 1\n#define
       VFX_USE_AGE_CURRENT 1\n#define VFX_HAS_INDIRECT_DRAW 1\n#define VFX_WORLD_SPACE
-      1\n\n\nCBUFFER_START(parameters)\n    float3 solverData_Gravity_a;\n    uint
-      PADDING_0;\nCBUFFER_END\n\n\n#include \"Packages/com.unity.visualeffectgraph/Shaders/Common/VFXCommonCompute.cginc\"\n#include
+      1\n\n\nCBUFFER_START(parameters)\n    float4 solverData_KernelSize_a;\n    float4
+      solverData_KernelFactors_a;\n    float3 solverData_Gravity_a;\n    float solverData_Fluid_SmoothingDistance_a;\n
+      \   float solverData_Fluid_ParticleMass_a;\n    float solverData_Fluid_Density_a;\n
+      \   float solverData_Fluid_MinimumDensity_a;\n    float solverData_Fluid_GasConstant_a;\n
+      \   float solverData_Fluid_Viscosity_a;\n    float solverData_Fluid_TurbulenceProbability_a;\n
+      \   float solverData_Fluid_SurfaceTension_a;\n    float solverData_Fluid_BuoyancyCoefficient_a;\nCBUFFER_END\n\n\n#include
+      \"Packages/com.unity.visualeffectgraph/Shaders/Common/VFXCommonCompute.cginc\"\n#include
       \"Packages/com.unity.visualeffectgraph/Shaders/VFXCommon.cginc\"\n#include \"Packages/com.thinksquirrel.fluviofx/Shaders/FluvioCompute.cginc\"\n\n\n\nRWByteAddressBuffer
       attributeBuffer;\n\n#if VFX_USE_ALIVE_CURRENT\nRWStructuredBuffer<uint> deadListOut;\n#endif\n\n#if
       VFX_HAS_INDIRECT_DRAW\nRWStructuredBuffer<uint> indirectBuffer;\n#endif\n\nCBUFFER_START(updateParams)\n
@@ -571,10 +587,10 @@ VisualEffectResource:
       * 0x4 + 0x9000) << 2));\n    \n        dist = position - neighborPosition;\n
       \   #ifndef FLUVIO_INDEX_GRID\n        distLenSq = dot(dist, dist);\n        if
       (distLenSq >= solverData_KernelSize.y) continue;\n    #endif\n    \n        n
-      += (neighborMass / neighborDensityPressure.y) * Poly6CalculateGradient(dist,
+      += (neighborMass / neighborDensityPressure.x) * Poly6CalculateGradient(dist,
       solverData_KernelFactors.x, solverData_KernelSize.y);\n    }\n    \n    // Write
-      to normal texture\n    float normalLen = length(n);\n    normal = float4(n /
-      normalLen, normalLen);\n}\nvoid Reap(float age, float lifetime, inout bool alive)\n{\n
+      to normal\n    float normalLen = length(n);\n    normal = float4(n / normalLen,
+      normalLen);\n}\nvoid Reap(float age, float lifetime, inout bool alive)\n{\n
       \   if(age > lifetime) { alive = false; }\n}\n\n\n\n[numthreads(NB_THREADS_PER_GROUP,1,1)]\nvoid
       CSMain(uint3 groupId          : SV_GroupID,\n            uint3 groupThreadId
       \   : SV_GroupThreadID)\n{\n\tuint id = groupThreadId.x + groupId.x * NB_THREADS_PER_GROUP
@@ -588,12 +604,13 @@ VisualEffectResource:
       densityPressure = asfloat(attributeBuffer.Load4((index * 0x4 + 0x9000) << 2));\n\t\t\tfloat4
       normal = asfloat(attributeBuffer.Load4((index * 0x4 + 0xB000) << 2));\n\t\t\tfloat
       age = asfloat(attributeBuffer.Load((index * 0x1 + 0xF800) << 2));\n\t\t\t\n\n\t\t\t\n#if
-      VFX_USE_OLDPOSITION_CURRENT\n\t\t\toldPosition = position;\n#endif\n\t\t\t\n\t\t\t{\n\t\t\t
-      \   SurfaceNormal(index, position, alive, mass, densityPressure,  /*inout */normal,
-      (float)0.38125, (float)7.625, (float)998.29, (float)9.9829, (float)0.01, (float)0.3,
-      (float)0.2, (float)0.728, (float)0, solverData_Gravity_a, float4(0.38125,0.1453516,0.05541528,0),
-      float4(9206.448,1554.828,43.08061,0));\n\t\t\t}\n\t\t\tReap(age, lifetime,  /*inout
-      */alive);\n\t\t\t\n\n\t\t\tif (alive)\n\t\t\t{\n\t\t\t\tattributeBuffer.Store3((index
+      VFX_USE_OLDPOSITION_CURRENT\n\t\t\toldPosition = position;\n#endif\n\t\t\t\n\t\t\tSurfaceNormal(index,
+      position, alive, mass, densityPressure,  /*inout */normal, solverData_Fluid_SmoothingDistance_a,
+      solverData_Fluid_ParticleMass_a, solverData_Fluid_Density_a, solverData_Fluid_MinimumDensity_a,
+      solverData_Fluid_GasConstant_a, solverData_Fluid_Viscosity_a, solverData_Fluid_TurbulenceProbability_a,
+      solverData_Fluid_SurfaceTension_a, solverData_Fluid_BuoyancyCoefficient_a, solverData_Gravity_a,
+      solverData_KernelSize_a, solverData_KernelFactors_a);\n\t\t\tReap(age, lifetime,
+      \ /*inout */alive);\n\t\t\t\n\n\t\t\tif (alive)\n\t\t\t{\n\t\t\t\tattributeBuffer.Store3((index
       * 0x4 + 0x7000) << 2,asuint(oldPosition));\n\t\t\t\tattributeBuffer.Store4((index
       * 0x4 + 0xB000) << 2,asuint(normal));\n\t\t\t\t\n\n#if VFX_HAS_INDIRECT_DRAW\n
       \               uint indirectIndex = indirectBuffer.IncrementCounter();\n\t\t\t\tindirectBuffer[indirectIndex]
@@ -608,90 +625,93 @@ VisualEffectResource:
       * 0x4 + 0xB000) << 2));\n\t\tbool alive = (attributeBuffer.Load((index * 0x1
       + 0xF000) << 2));\n\t\tfloat age = asfloat(attributeBuffer.Load((index * 0x1
       + 0xF800) << 2));\n\t\t\n\n\t\t\n#if VFX_USE_OLDPOSITION_CURRENT\n\t\toldPosition
-      = position;\n#endif\n\t\t\n\t\t{\n\t\t    SurfaceNormal(index, position, alive,
-      mass, densityPressure,  /*inout */normal, (float)0.38125, (float)7.625, (float)998.29,
-      (float)9.9829, (float)0.01, (float)0.3, (float)0.2, (float)0.728, (float)0,
-      solverData_Gravity_a, float4(0.38125,0.1453516,0.05541528,0), float4(9206.448,1554.828,43.08061,0));\n\t\t}\n\t\tReap(age,
-      lifetime,  /*inout */alive);\n\t\t\n\n\t\tattributeBuffer.Store3((index * 0x4
-      + 0x7000) << 2,asuint(oldPosition));\n\t\tattributeBuffer.Store4((index * 0x4
-      + 0xB000) << 2,asuint(normal));\n\t\tattributeBuffer.Store((index * 0x1 + 0xF000)
-      << 2,uint(alive));\n\t\t\n\n#if VFX_HAS_INDIRECT_DRAW\n        uint indirectIndex
-      = indirectBuffer.IncrementCounter();\n\t\tindirectBuffer[indirectIndex] = index;\n#endif\n#endif\n\t}\n}\n"
+      = position;\n#endif\n\t\t\n\t\tSurfaceNormal(index, position, alive, mass, densityPressure,
+      \ /*inout */normal, solverData_Fluid_SmoothingDistance_a, solverData_Fluid_ParticleMass_a,
+      solverData_Fluid_Density_a, solverData_Fluid_MinimumDensity_a, solverData_Fluid_GasConstant_a,
+      solverData_Fluid_Viscosity_a, solverData_Fluid_TurbulenceProbability_a, solverData_Fluid_SurfaceTension_a,
+      solverData_Fluid_BuoyancyCoefficient_a, solverData_Gravity_a, solverData_KernelSize_a,
+      solverData_KernelFactors_a);\n\t\tReap(age, lifetime,  /*inout */alive);\n\t\t\n\n\t\tattributeBuffer.Store3((index
+      * 0x4 + 0x7000) << 2,asuint(oldPosition));\n\t\tattributeBuffer.Store4((index
+      * 0x4 + 0xB000) << 2,asuint(normal));\n\t\tattributeBuffer.Store((index * 0x1
+      + 0xF000) << 2,uint(alive));\n\t\t\n\n#if VFX_HAS_INDIRECT_DRAW\n        uint
+      indirectIndex = indirectBuffer.IncrementCounter();\n\t\tindirectBuffer[indirectIndex]
+      = index;\n#endif\n#endif\n\t}\n}\n"
   - compute: 1
-    name: '[System 1]G Update'
+    name: '[System 1]F Update'
     source: "#pragma kernel CSMain\n#include \"HLSLSupport.cginc\"\n#define NB_THREADS_PER_GROUP
       64\n#define VFX_USE_LIFETIME_CURRENT 1\n#define VFX_USE_POSITION_CURRENT 1\n#define
       VFX_USE_VELOCITY_CURRENT 1\n#define VFX_USE_FORCE_CURRENT 1\n#define VFX_USE_MASS_CURRENT
       1\n#define VFX_USE_OLDPOSITION_CURRENT 1\n#define VFX_USE_DENSITYPRESSURE_CURRENT
       1\n#define VFX_USE_NORMAL_CURRENT 1\n#define VFX_USE_VORTICITYTURBULENCE_CURRENT
       1\n#define VFX_USE_ALIVE_CURRENT 1\n#define VFX_USE_AGE_CURRENT 1\n#define VFX_HAS_INDIRECT_DRAW
-      1\n#define VFX_WORLD_SPACE 1\n\n\nCBUFFER_START(parameters)\n    float3 solverData_Gravity_a;\n
-      \   uint PADDING_0;\nCBUFFER_END\n\n\n#include \"Packages/com.unity.visualeffectgraph/Shaders/Common/VFXCommonCompute.cginc\"\n#include
+      1\n#define VFX_WORLD_SPACE 1\n\n\nCBUFFER_START(parameters)\n    float4 solverData_KernelSize_a;\n
+      \   float4 solverData_KernelFactors_a;\n    float3 solverData_Gravity_a;\n    float
+      solverData_Fluid_SmoothingDistance_a;\n    float solverData_Fluid_ParticleMass_a;\n
+      \   float solverData_Fluid_Density_a;\n    float solverData_Fluid_MinimumDensity_a;\n
+      \   float solverData_Fluid_GasConstant_a;\n    float solverData_Fluid_Viscosity_a;\n
+      \   float solverData_Fluid_TurbulenceProbability_a;\n    float solverData_Fluid_SurfaceTension_a;\n
+      \   float solverData_Fluid_BuoyancyCoefficient_a;\nCBUFFER_END\n\n\n#include
+      \"Packages/com.unity.visualeffectgraph/Shaders/Common/VFXCommonCompute.cginc\"\n#include
       \"Packages/com.unity.visualeffectgraph/Shaders/VFXCommon.cginc\"\n#include \"Packages/com.thinksquirrel.fluviofx/Shaders/FluvioCompute.cginc\"\n\n\n\nRWByteAddressBuffer
       attributeBuffer;\n\n#if VFX_USE_ALIVE_CURRENT\nRWStructuredBuffer<uint> deadListOut;\n#endif\n\n#if
       VFX_HAS_INDIRECT_DRAW\nRWStructuredBuffer<uint> indirectBuffer;\n#endif\n\nCBUFFER_START(updateParams)\n
       \   uint nbMax;\n\tuint dispatchWidth;\n\tuint systemSeed;\nCBUFFER_END\n\nvoid
-      CalculateForces_C4E51299(uint index, float3 position, bool alive, float3 velocity,
+      CalculateForces_3B85AF8(uint index, float3 position, bool alive, float3 velocity,
       float mass, float4 densityPressure, float4 normal, inout float4 vorticityTurbulence,
       inout float3 force, float solverData_Fluid_SmoothingDistance, float solverData_Fluid_ParticleMass,
       float solverData_Fluid_Density, float solverData_Fluid_MinimumDensity, float
       solverData_Fluid_GasConstant, float solverData_Fluid_Viscosity, float solverData_Fluid_TurbulenceProbability,
       float solverData_Fluid_SurfaceTension, float solverData_Fluid_BuoyancyCoefficient,
       float3 solverData_Gravity, float4 solverData_KernelSize, float4 solverData_KernelFactors)
-      /*SurfaceTension:True Turbulence:True Gravity:True BuoyancyForce:True Collision:True
-      */\n{\n    \n    #define FLUVIO_SURFACE_TENSION_ENABLED 1\n    #define FLUVIO_TURBULENCE_ENABLED
+      /*SurfaceTension:True Turbulence:True Gravity:True BuoyancyForce:True */\n{\n
+      \   \n    #define FLUVIO_SURFACE_TENSION_ENABLED 1\n    #define FLUVIO_TURBULENCE_ENABLED
       1\n    #define FLUVIO_GRAVITY_ENABLED 1\n    #define FLUVIO_BUOYANCY_FORCE_ENABLED
-      1\n    #define FLUVIO_COLLISION_ENABLED 1\n    float3 dist, f, invNeighborDensity;\n
-      \   float scalar;\n    \n    #ifdef FLUVIO_INDEX_GRID\n    uint neighborIndex;\n
-      \   for (uint j = 0; j < neighborCount; ++j)\n    {\n        neighborIndex =
-      GetNeighborIndex(solverData_Tex, solverData_TexSize, index, j);\n    #else\n
-      \   float distLenSq;\n    for (uint neighborIndex = 0; neighborIndex < nbMax;
-      ++neighborIndex)\n    {\n        if (index == neighborIndex) continue;\n        bool
-      neighborAlive = (attributeBuffer.Load((neighborIndex * 0x1 + 0xF000) << 2));\n
-      \       if (!neighborAlive) continue;\n    #endif\n    \n        float3 neighborPosition
-      = asfloat(attributeBuffer.Load3((neighborIndex * 0x4 + 0x800) << 2));\n        float
-      neighborMass = asfloat(attributeBuffer.Load((neighborIndex * 0x1 + 0x6800) <<
-      2));\n        float3 neighborVelocity = asfloat(attributeBuffer.Load3((neighborIndex
+      1\n    float3 dist, f, invNeighborDensity;\n    float scalar;\n    \n    #ifdef
+      FLUVIO_INDEX_GRID\n    uint neighborIndex;\n    for (uint j = 0; j < neighborCount;
+      ++j)\n    {\n        neighborIndex = GetNeighborIndex(solverData_Tex, solverData_TexSize,
+      index, j);\n    #else\n    float distLenSq;\n    for (uint neighborIndex = 0;
+      neighborIndex < nbMax; ++neighborIndex)\n    {\n        if (index == neighborIndex)
+      continue;\n        bool neighborAlive = (attributeBuffer.Load((neighborIndex
+      * 0x1 + 0xF000) << 2));\n        if (!neighborAlive) continue;\n    #endif\n
+      \   \n        float3 neighborPosition = asfloat(attributeBuffer.Load3((neighborIndex
+      * 0x4 + 0x800) << 2));\n        float neighborMass = asfloat(attributeBuffer.Load((neighborIndex
+      * 0x1 + 0x6800) << 2));\n        float3 neighborVelocity = asfloat(attributeBuffer.Load3((neighborIndex
       * 0x4 + 0x2800) << 2));\n        float4 neighborDensityPressure = asfloat(attributeBuffer.Load4((neighborIndex
       * 0x4 + 0x9000) << 2));\n    \n        dist = position - neighborPosition;\n
       \   #ifndef FLUVIO_INDEX_GRID\n        distLenSq = dot(dist, dist);\n        if
-      (distLenSq >= solverData_KernelSize.y) continue;\n    #endif\n    \n    #ifdef
-      FLUVIO_COLLISION_ENABLED\n        invNeighborDensity = 1.0f / neighborDensityPressure.x;\n
-      \   #else\n        invNeighborDensity = 1.0f / neighborDensityPressure.y;\n
-      \   #endif\n    \n        // Pressure term\n    #ifdef FLUVIO_COLLISION_ENABLED\n
-      \       scalar = neighborMass\n            * (densityPressure.z + neighborDensityPressure.z)
-      / (neighborDensityPressure.x * 2.0f);\n    #else\n        scalar = neighborMass\n
-      \           * (densityPressure.w + neighborDensityPressure.w) / (neighborDensityPressure.y
-      * 2.0f);\n    #endif\n    \n        f = SpikyCalculateGradient(dist, solverData_KernelFactors.y,
-      solverData_KernelSize.x);\n        f *= scalar;\n    \n        force -= f;\n
-      \   \n        // Viscosity term\n        scalar = neighborMass\n            *
-      ViscosityCalculateLaplacian(\n                dist,\n                solverData_KernelFactors.z,\n
-      \               solverData_KernelSize.z,\n                solverData_KernelSize.x)\n
-      \           * invNeighborDensity;\n    \n        f = neighborVelocity - velocity;\n
-      \       f *= scalar * solverData_Fluid_Viscosity;\n    \n        force += f;\n
-      \   \n    #ifdef FLUVIO_SURFACE_TENSION_ENABLED\n        // Surface tension
-      term (external)\n        if (normal.w > FLUVIO_PI && normal.w < FLUVIO_PI *
-      2.0f)\n        {\n            scalar = neighborMass\n                * Poly6CalculateLaplacian(dist,
-      solverData_KernelFactors.x, solverData_KernelSize.y)\n                * solverData_Fluid_SurfaceTension\n
-      \               * 1.0f / neighborDensityPressure.y;\n    \n            f = normal.xyz
-      * scalar;\n    \n            force -= f;\n        }\n    #endif\n    \n    #ifdef
-      FLUVIO_TURBULENCE_ENABLED\n    // Turbulence term (external)\n    float4 neighborVorticityTurbulence
-      = asfloat(attributeBuffer.Load4((neighborIndex * 0x4 + 0xD000) << 2));\n    if
-      (vorticityTurbulence.w >= solverData_Fluid_TurbulenceProbability && neighborVorticityTurbulence.w
-      < solverData_Fluid_TurbulenceProbability)\n    {\n        scalar = neighborMass\n
-      \           * ViscosityCalculateLaplacian(\n                dist,\n                solverData_KernelFactors.z,\n
-      \               solverData_KernelSize.z,\n                solverData_KernelSize.x)\n
-      \           * invNeighborDensity;\n    \n        vorticityTurbulence = scalar
-      * (neighborVorticityTurbulence - vorticityTurbulence);\n        f = clamp_len(FLUVIO_TURBULENCE_CONSTANT
-      * cross(dist, vorticityTurbulence.xyz), FLUVIO_MAX_SQR_VELOCITY_CHANGE * mass);\n
-      \   \n        force += f;\n    }\n    #endif\n    }\n    \n    #ifdef FLUVIO_GRAVITY_ENABLED\n
-      \   // Gravity term (external)\n    force += solverData_Gravity;\n    #endif\n
-      \   \n    #ifdef FLUVIO_BUOYANCY_FORCE_ENABLED\n    // Buoyancy term (external)\n
-      \   #ifdef FLUVIO_COLLISION_ENABLED\n    force += solverData_Gravity * solverData_Fluid_BuoyancyCoefficient
-      * (densityPressure.x - solverData_Fluid_Density);\n    #else\n    force += solverData_Gravity
-      * solverData_Fluid_BuoyancyCoefficient * (densityPressure.y - solverData_Fluid_Density);\n
-      \   #endif\n    #endif\n}\nvoid Reap(float age, float lifetime, inout bool alive)\n{\n
-      \   if(age > lifetime) { alive = false; }\n}\n\n\n\n[numthreads(NB_THREADS_PER_GROUP,1,1)]\nvoid
+      (distLenSq >= solverData_KernelSize.y) continue;\n    #endif\n    \n        //
+      Pressure term\n        scalar = neighborMass\n            * (densityPressure.y
+      + neighborDensityPressure.y) / (neighborDensityPressure.x * 2.0f);\n        f
+      = SpikyCalculateGradient(dist, solverData_KernelFactors.y, solverData_KernelSize.x);\n
+      \       f *= scalar;\n    \n        force -= f;\n    \n        invNeighborDensity
+      = 1.0f / neighborDensityPressure.x;\n    \n        // Viscosity term\n        scalar
+      = neighborMass\n            * ViscosityCalculateLaplacian(\n                dist,\n
+      \               solverData_KernelFactors.z,\n                solverData_KernelSize.z,\n
+      \               solverData_KernelSize.x)\n            * invNeighborDensity;\n
+      \   \n        f = neighborVelocity - velocity;\n        f *= scalar * solverData_Fluid_Viscosity;\n
+      \   \n        force += f;\n    \n    #ifdef FLUVIO_SURFACE_TENSION_ENABLED\n
+      \       // Surface tension term (external)\n        if (normal.w > FLUVIO_PI
+      && normal.w < FLUVIO_TAU)\n        {\n            scalar = neighborMass\n                *
+      Poly6CalculateLaplacian(dist, solverData_KernelFactors.x, solverData_KernelSize.y)\n
+      \               * solverData_Fluid_SurfaceTension\n                * 1.0f /
+      neighborDensityPressure.x;\n    \n            f = normal.xyz * scalar;\n            force
+      -= f;\n        }\n    #endif\n    \n    #ifdef FLUVIO_TURBULENCE_ENABLED\n        //
+      Turbulence term (external)\n        float4 neighborVorticityTurbulence = asfloat(attributeBuffer.Load4((neighborIndex
+      * 0x4 + 0xD000) << 2));\n        if (vorticityTurbulence.w >= solverData_Fluid_TurbulenceProbability
+      && neighborVorticityTurbulence.w < solverData_Fluid_TurbulenceProbability)\n
+      \       {\n            scalar = neighborMass\n                * ViscosityCalculateLaplacian(\n
+      \                   dist,\n                    solverData_KernelFactors.z,\n
+      \                   solverData_KernelSize.z,\n                    solverData_KernelSize.x)\n
+      \               * invNeighborDensity;\n    \n            vorticityTurbulence
+      = scalar * (neighborVorticityTurbulence - vorticityTurbulence);\n            f
+      = clamp_len(FLUVIO_TURBULENCE_CONSTANT * cross(dist, vorticityTurbulence.xyz),
+      FLUVIO_MAX_SQR_VELOCITY_CHANGE * mass);\n    \n            force += f;\n        }\n
+      \   #endif\n    }\n    \n    #ifdef FLUVIO_GRAVITY_ENABLED\n    // Gravity term
+      (external)\n    force += solverData_Gravity * mass;\n    #ifdef FLUVIO_BUOYANCY_FORCE_ENABLED\n
+      \   // Buoyancy term (external)\n    force += solverData_Gravity * solverData_Fluid_BuoyancyCoefficient
+      * (densityPressure.x - solverData_Fluid_Density);\n    #endif\n    #endif\n
+      \   \n}\nvoid Reap(float age, float lifetime, inout bool alive)\n{\n    if(age
+      > lifetime) { alive = false; }\n}\n\n\n\n[numthreads(NB_THREADS_PER_GROUP,1,1)]\nvoid
       CSMain(uint3 groupId          : SV_GroupID,\n            uint3 groupThreadId
       \   : SV_GroupThreadID)\n{\n\tuint id = groupThreadId.x + groupId.x * NB_THREADS_PER_GROUP
       + groupId.y * dispatchWidth * NB_THREADS_PER_GROUP;\n\tuint index = id;\n\tif
@@ -708,13 +728,14 @@ VisualEffectResource:
       vorticityTurbulence = asfloat(attributeBuffer.Load4((index * 0x4 + 0xD000) <<
       2));\n\t\t\tfloat age = asfloat(attributeBuffer.Load((index * 0x1 + 0xF800)
       << 2));\n\t\t\t\n\n\t\t\t\n#if VFX_USE_OLDPOSITION_CURRENT\n\t\t\toldPosition
-      = position;\n#endif\n\t\t\t\n\t\t\t{\n\t\t\t    CalculateForces_C4E51299(index,
-      position, alive, velocity, mass, densityPressure, normal,  /*inout */vorticityTurbulence,
-      \ /*inout */force, (float)0.38125, (float)7.625, (float)998.29, (float)9.9829,
-      (float)0.01, (float)0.3, (float)0.2, (float)0.728, (float)0, solverData_Gravity_a,
-      float4(0.38125,0.1453516,0.05541528,0), float4(9206.448,1554.828,43.08061,0));\n\t\t\t}\n\t\t\tReap(age,
-      lifetime,  /*inout */alive);\n\t\t\t\n\n\t\t\tif (alive)\n\t\t\t{\n\t\t\t\tattributeBuffer.Store3((index
-      * 0x4 + 0x4800) << 2,asuint(force));\n\t\t\t\tattributeBuffer.Store3((index
+      = position;\n#endif\n\t\t\t\n\t\t\tCalculateForces_3B85AF8(index, position,
+      alive, velocity, mass, densityPressure, normal,  /*inout */vorticityTurbulence,
+      \ /*inout */force, solverData_Fluid_SmoothingDistance_a, solverData_Fluid_ParticleMass_a,
+      solverData_Fluid_Density_a, solverData_Fluid_MinimumDensity_a, solverData_Fluid_GasConstant_a,
+      solverData_Fluid_Viscosity_a, solverData_Fluid_TurbulenceProbability_a, solverData_Fluid_SurfaceTension_a,
+      solverData_Fluid_BuoyancyCoefficient_a, solverData_Gravity_a, solverData_KernelSize_a,
+      solverData_KernelFactors_a);\n\t\t\tReap(age, lifetime,  /*inout */alive);\n\t\t\t\n\n\t\t\tif
+      (alive)\n\t\t\t{\n\t\t\t\tattributeBuffer.Store3((index * 0x4 + 0x4800) << 2,asuint(force));\n\t\t\t\tattributeBuffer.Store3((index
       * 0x4 + 0x7000) << 2,asuint(oldPosition));\n\t\t\t\tattributeBuffer.Store4((index
       * 0x4 + 0xD000) << 2,asuint(vorticityTurbulence));\n\t\t\t\t\n\n#if VFX_HAS_INDIRECT_DRAW\n
       \               uint indirectIndex = indirectBuffer.IncrementCounter();\n\t\t\t\tindirectBuffer[indirectIndex]
@@ -732,27 +753,33 @@ VisualEffectResource:
       * 0x4 + 0xD000) << 2));\n\t\tbool alive = (attributeBuffer.Load((index * 0x1
       + 0xF000) << 2));\n\t\tfloat age = asfloat(attributeBuffer.Load((index * 0x1
       + 0xF800) << 2));\n\t\t\n\n\t\t\n#if VFX_USE_OLDPOSITION_CURRENT\n\t\toldPosition
-      = position;\n#endif\n\t\t\n\t\t{\n\t\t    CalculateForces_C4E51299(index, position,
-      alive, velocity, mass, densityPressure, normal,  /*inout */vorticityTurbulence,
-      \ /*inout */force, (float)0.38125, (float)7.625, (float)998.29, (float)9.9829,
-      (float)0.01, (float)0.3, (float)0.2, (float)0.728, (float)0, solverData_Gravity_a,
-      float4(0.38125,0.1453516,0.05541528,0), float4(9206.448,1554.828,43.08061,0));\n\t\t}\n\t\tReap(age,
-      lifetime,  /*inout */alive);\n\t\t\n\n\t\tattributeBuffer.Store3((index * 0x4
-      + 0x4800) << 2,asuint(force));\n\t\tattributeBuffer.Store3((index * 0x4 + 0x7000)
-      << 2,asuint(oldPosition));\n\t\tattributeBuffer.Store4((index * 0x4 + 0xD000)
-      << 2,asuint(vorticityTurbulence));\n\t\tattributeBuffer.Store((index * 0x1 +
-      0xF000) << 2,uint(alive));\n\t\t\n\n#if VFX_HAS_INDIRECT_DRAW\n        uint
+      = position;\n#endif\n\t\t\n\t\tCalculateForces_3B85AF8(index, position, alive,
+      velocity, mass, densityPressure, normal,  /*inout */vorticityTurbulence,  /*inout
+      */force, solverData_Fluid_SmoothingDistance_a, solverData_Fluid_ParticleMass_a,
+      solverData_Fluid_Density_a, solverData_Fluid_MinimumDensity_a, solverData_Fluid_GasConstant_a,
+      solverData_Fluid_Viscosity_a, solverData_Fluid_TurbulenceProbability_a, solverData_Fluid_SurfaceTension_a,
+      solverData_Fluid_BuoyancyCoefficient_a, solverData_Gravity_a, solverData_KernelSize_a,
+      solverData_KernelFactors_a);\n\t\tReap(age, lifetime,  /*inout */alive);\n\t\t\n\n\t\tattributeBuffer.Store3((index
+      * 0x4 + 0x4800) << 2,asuint(force));\n\t\tattributeBuffer.Store3((index * 0x4
+      + 0x7000) << 2,asuint(oldPosition));\n\t\tattributeBuffer.Store4((index * 0x4
+      + 0xD000) << 2,asuint(vorticityTurbulence));\n\t\tattributeBuffer.Store((index
+      * 0x1 + 0xF000) << 2,uint(alive));\n\t\t\n\n#if VFX_HAS_INDIRECT_DRAW\n        uint
       indirectIndex = indirectBuffer.IncrementCounter();\n\t\tindirectBuffer[indirectIndex]
       = index;\n#endif\n#endif\n\t}\n}\n"
   - compute: 1
-    name: '[System 1]H Update'
+    name: '[System 1]G Update'
     source: "#pragma kernel CSMain\n#include \"HLSLSupport.cginc\"\n#define NB_THREADS_PER_GROUP
       64\n#define VFX_USE_LIFETIME_CURRENT 1\n#define VFX_USE_POSITION_CURRENT 1\n#define
       VFX_USE_VELOCITY_CURRENT 1\n#define VFX_USE_FORCE_CURRENT 1\n#define VFX_USE_MASS_CURRENT
       1\n#define VFX_USE_OLDPOSITION_CURRENT 1\n#define VFX_USE_ALIVE_CURRENT 1\n#define
       VFX_USE_AGE_CURRENT 1\n#define VFX_HAS_INDIRECT_DRAW 1\n#define VFX_WORLD_SPACE
-      1\n\n\nCBUFFER_START(parameters)\n    float3 solverData_Gravity_a;\n    float
-      dt_a;\nCBUFFER_END\n\n\n#include \"Packages/com.unity.visualeffectgraph/Shaders/Common/VFXCommonCompute.cginc\"\n#include
+      1\n\n\nCBUFFER_START(parameters)\n    float4 solverData_KernelSize_a;\n    float4
+      solverData_KernelFactors_a;\n    float3 solverData_Gravity_a;\n    float solverData_Fluid_SmoothingDistance_a;\n
+      \   float solverData_Fluid_ParticleMass_a;\n    float solverData_Fluid_Density_a;\n
+      \   float solverData_Fluid_MinimumDensity_a;\n    float solverData_Fluid_GasConstant_a;\n
+      \   float solverData_Fluid_Viscosity_a;\n    float solverData_Fluid_TurbulenceProbability_a;\n
+      \   float solverData_Fluid_SurfaceTension_a;\n    float solverData_Fluid_BuoyancyCoefficient_a;\n
+      \   float dt_a;\n    uint3 PADDING_0;\nCBUFFER_END\n\n\n#include \"Packages/com.unity.visualeffectgraph/Shaders/Common/VFXCommonCompute.cginc\"\n#include
       \"Packages/com.unity.visualeffectgraph/Shaders/VFXCommon.cginc\"\n#include \"Packages/com.thinksquirrel.fluviofx/Shaders/FluvioCompute.cginc\"\n\n\n\nRWByteAddressBuffer
       attributeBuffer;\n\n#if VFX_USE_ALIVE_CURRENT\nRWStructuredBuffer<uint> deadListOut;\n#endif\n\n#if
       VFX_HAS_INDIRECT_DRAW\nRWStructuredBuffer<uint> indirectBuffer;\n#endif\n\nCBUFFER_START(updateParams)\n
@@ -764,34 +791,34 @@ VisualEffectResource:
       solverData_Fluid_TurbulenceProbability, float solverData_Fluid_SurfaceTension,
       float solverData_Fluid_BuoyancyCoefficient, float3 solverData_Gravity, float4
       solverData_KernelSize, float4 solverData_KernelFactors, float dt) /*IntegrationMode:Verlet
-      */\n{\n    \n    position += velocity * dt;\n    \n    float invMass = 1.0f
-      / mass;\n    float3 acceleration = force * invMass;\n    float3 v = dt * acceleration;\n
-      \   \n    // Discard excessive velocities\n    if (any(isnan(v) || isinf(v))
-      || dot(v, v) > FLUVIO_MAX_SQR_VELOCITY_CHANGE)\n    {\n        v = 0;\n    }\n
-      \   \n    \n    float3 x = position;\n    position = (x * 2) - oldPosition +
-      (v * dt);\n    velocity += v;\n    \n}\nvoid Age(inout float age, float deltaTime)\n{\n
-      \   age += deltaTime;\n}\nvoid Reap(float age, float lifetime, inout bool alive)\n{\n
-      \   if(age > lifetime) { alive = false; }\n}\n\n\n\n[numthreads(NB_THREADS_PER_GROUP,1,1)]\nvoid
-      CSMain(uint3 groupId          : SV_GroupID,\n            uint3 groupThreadId
-      \   : SV_GroupThreadID)\n{\n\tuint id = groupThreadId.x + groupId.x * NB_THREADS_PER_GROUP
-      + groupId.y * dispatchWidth * NB_THREADS_PER_GROUP;\n\tuint index = id;\n\tif
-      (id < nbMax)\n\t{\n#if VFX_USE_ALIVE_CURRENT\n\t\tbool alive = (attributeBuffer.Load((index
-      * 0x1 + 0xF000) << 2));\n\t\t\n\n\t\tif (alive)\n\t\t{\n\t\t\tfloat lifetime
-      = asfloat(attributeBuffer.Load((index * 0x1 + 0x0) << 2));\n\t\t\tfloat3 position
-      = asfloat(attributeBuffer.Load3((index * 0x4 + 0x800) << 2));\n\t\t\tfloat3
-      velocity = asfloat(attributeBuffer.Load3((index * 0x4 + 0x2800) << 2));\n\t\t\tfloat3
-      force = asfloat(attributeBuffer.Load3((index * 0x4 + 0x4800) << 2));\n\t\t\tfloat
-      mass = asfloat(attributeBuffer.Load((index * 0x1 + 0x6800) << 2));\n\t\t\tfloat3
-      oldPosition = asfloat(attributeBuffer.Load3((index * 0x4 + 0x7000) << 2));\n\t\t\tfloat
-      age = asfloat(attributeBuffer.Load((index * 0x1 + 0xF800) << 2));\n\t\t\t\n\n\t\t\t\n#if
-      VFX_USE_OLDPOSITION_CURRENT\n\t\t\toldPosition = position;\n#endif\n\t\t\t\n\t\t\t{\n\t\t\t
-      \   IntegrateParticles_0(index,  /*inout */position, alive, mass, force,  /*inout
-      */velocity, oldPosition, (float)0.38125, (float)7.625, (float)998.29, (float)9.9829,
-      (float)0.01, (float)0.3, (float)0.2, (float)0.728, (float)0, solverData_Gravity_a,
-      float4(0.38125,0.1453516,0.05541528,0), float4(9206.448,1554.828,43.08061,0),
-      dt_a);\n\t\t\t}\n\t\t\tAge( /*inout */age, dt_a);\n\t\t\tReap(age, lifetime,
-      \ /*inout */alive);\n\t\t\t\n\n\t\t\tif (alive)\n\t\t\t{\n\t\t\t\tattributeBuffer.Store3((index
-      * 0x4 + 0x800) << 2,asuint(position));\n\t\t\t\tattributeBuffer.Store3((index
+      */\n{\n    \n    float invMass = 1.0f / mass;\n    float3 acceleration = force
+      * invMass;\n    float3 v = dt * acceleration;\n    \n    // Discard excessive
+      velocities\n    if (any(isnan(v) || isinf(v)) || dot(v, v) > FLUVIO_MAX_SQR_VELOCITY_CHANGE)\n
+      \   {\n        v = 0;\n    }\n    \n    \n    float3 x = position;\n    position
+      = (x * 2) - oldPosition + ((v + velocity) * dt);\n    velocity += v;\n}\nvoid
+      Age(inout float age, float deltaTime)\n{\n    age += deltaTime;\n}\nvoid Reap(float
+      age, float lifetime, inout bool alive)\n{\n    if(age > lifetime) { alive =
+      false; }\n}\n\n\n\n[numthreads(NB_THREADS_PER_GROUP,1,1)]\nvoid CSMain(uint3
+      groupId          : SV_GroupID,\n            uint3 groupThreadId    : SV_GroupThreadID)\n{\n\tuint
+      id = groupThreadId.x + groupId.x * NB_THREADS_PER_GROUP + groupId.y * dispatchWidth
+      * NB_THREADS_PER_GROUP;\n\tuint index = id;\n\tif (id < nbMax)\n\t{\n#if VFX_USE_ALIVE_CURRENT\n\t\tbool
+      alive = (attributeBuffer.Load((index * 0x1 + 0xF000) << 2));\n\t\t\n\n\t\tif
+      (alive)\n\t\t{\n\t\t\tfloat lifetime = asfloat(attributeBuffer.Load((index *
+      0x1 + 0x0) << 2));\n\t\t\tfloat3 position = asfloat(attributeBuffer.Load3((index
+      * 0x4 + 0x800) << 2));\n\t\t\tfloat3 velocity = asfloat(attributeBuffer.Load3((index
+      * 0x4 + 0x2800) << 2));\n\t\t\tfloat3 force = asfloat(attributeBuffer.Load3((index
+      * 0x4 + 0x4800) << 2));\n\t\t\tfloat mass = asfloat(attributeBuffer.Load((index
+      * 0x1 + 0x6800) << 2));\n\t\t\tfloat3 oldPosition = asfloat(attributeBuffer.Load3((index
+      * 0x4 + 0x7000) << 2));\n\t\t\tfloat age = asfloat(attributeBuffer.Load((index
+      * 0x1 + 0xF800) << 2));\n\t\t\t\n\n\t\t\t\n#if VFX_USE_OLDPOSITION_CURRENT\n\t\t\toldPosition
+      = position;\n#endif\n\t\t\t\n\t\t\tIntegrateParticles_0(index,  /*inout */position,
+      alive, mass, force,  /*inout */velocity, oldPosition, solverData_Fluid_SmoothingDistance_a,
+      solverData_Fluid_ParticleMass_a, solverData_Fluid_Density_a, solverData_Fluid_MinimumDensity_a,
+      solverData_Fluid_GasConstant_a, solverData_Fluid_Viscosity_a, solverData_Fluid_TurbulenceProbability_a,
+      solverData_Fluid_SurfaceTension_a, solverData_Fluid_BuoyancyCoefficient_a, solverData_Gravity_a,
+      solverData_KernelSize_a, solverData_KernelFactors_a, dt_a);\n\t\t\tAge( /*inout
+      */age, dt_a);\n\t\t\tReap(age, lifetime,  /*inout */alive);\n\t\t\t\n\n\t\t\tif
+      (alive)\n\t\t\t{\n\t\t\t\tattributeBuffer.Store3((index * 0x4 + 0x800) << 2,asuint(position));\n\t\t\t\tattributeBuffer.Store3((index
       * 0x4 + 0x2800) << 2,asuint(velocity));\n\t\t\t\tattributeBuffer.Store3((index
       * 0x4 + 0x7000) << 2,asuint(oldPosition));\n\t\t\t\tattributeBuffer.Store((index
       * 0x1 + 0xF800) << 2,asuint(age));\n\t\t\t\t\n\n#if VFX_HAS_INDIRECT_DRAW\n
@@ -807,45 +834,19 @@ VisualEffectResource:
       * 0x4 + 0x7000) << 2));\n\t\tbool alive = (attributeBuffer.Load((index * 0x1
       + 0xF000) << 2));\n\t\tfloat age = asfloat(attributeBuffer.Load((index * 0x1
       + 0xF800) << 2));\n\t\t\n\n\t\t\n#if VFX_USE_OLDPOSITION_CURRENT\n\t\toldPosition
-      = position;\n#endif\n\t\t\n\t\t{\n\t\t    IntegrateParticles_0(index,  /*inout
-      */position, alive, mass, force,  /*inout */velocity, oldPosition, (float)0.38125,
-      (float)7.625, (float)998.29, (float)9.9829, (float)0.01, (float)0.3, (float)0.2,
-      (float)0.728, (float)0, solverData_Gravity_a, float4(0.38125,0.1453516,0.05541528,0),
-      float4(9206.448,1554.828,43.08061,0), dt_a);\n\t\t}\n\t\tAge( /*inout */age,
-      dt_a);\n\t\tReap(age, lifetime,  /*inout */alive);\n\t\t\n\n\t\tattributeBuffer.Store3((index
+      = position;\n#endif\n\t\t\n\t\tIntegrateParticles_0(index,  /*inout */position,
+      alive, mass, force,  /*inout */velocity, oldPosition, solverData_Fluid_SmoothingDistance_a,
+      solverData_Fluid_ParticleMass_a, solverData_Fluid_Density_a, solverData_Fluid_MinimumDensity_a,
+      solverData_Fluid_GasConstant_a, solverData_Fluid_Viscosity_a, solverData_Fluid_TurbulenceProbability_a,
+      solverData_Fluid_SurfaceTension_a, solverData_Fluid_BuoyancyCoefficient_a, solverData_Gravity_a,
+      solverData_KernelSize_a, solverData_KernelFactors_a, dt_a);\n\t\tAge( /*inout
+      */age, dt_a);\n\t\tReap(age, lifetime,  /*inout */alive);\n\t\t\n\n\t\tattributeBuffer.Store3((index
       * 0x4 + 0x800) << 2,asuint(position));\n\t\tattributeBuffer.Store3((index *
       0x4 + 0x2800) << 2,asuint(velocity));\n\t\tattributeBuffer.Store3((index * 0x4
       + 0x7000) << 2,asuint(oldPosition));\n\t\tattributeBuffer.Store((index * 0x1
       + 0xF000) << 2,uint(alive));\n\t\tattributeBuffer.Store((index * 0x1 + 0xF800)
       << 2,asuint(age));\n\t\t\n\n#if VFX_HAS_INDIRECT_DRAW\n        uint indirectIndex
       = indirectBuffer.IncrementCounter();\n\t\tindirectBuffer[indirectIndex] = index;\n#endif\n#endif\n\t}\n}\n"
-  - compute: 1
-    name: '[System 1]E Update'
-    source: "#pragma kernel CSMain\n#include \"HLSLSupport.cginc\"\n#define NB_THREADS_PER_GROUP
-      64\n#define VFX_USE_POSITION_CURRENT 1\n#define VFX_USE_OLDPOSITION_CURRENT
-      1\n#define VFX_HAS_INDIRECT_DRAW 1\n#define VFX_WORLD_SPACE 1\n\n\n\n#include
-      \"Packages/com.unity.visualeffectgraph/Shaders/Common/VFXCommonCompute.cginc\"\n#include
-      \"Packages/com.unity.visualeffectgraph/Shaders/VFXCommon.cginc\"\n\n\n\nRWByteAddressBuffer
-      attributeBuffer;\n\n#if VFX_USE_ALIVE_CURRENT\nRWStructuredBuffer<uint> deadListOut;\n#endif\n\n#if
-      VFX_HAS_INDIRECT_DRAW\nRWStructuredBuffer<uint> indirectBuffer;\n#endif\n\nCBUFFER_START(updateParams)\n
-      \   uint nbMax;\n\tuint dispatchWidth;\n\tuint systemSeed;\nCBUFFER_END\n\n\n\n[numthreads(NB_THREADS_PER_GROUP,1,1)]\nvoid
-      CSMain(uint3 groupId          : SV_GroupID,\n            uint3 groupThreadId
-      \   : SV_GroupThreadID)\n{\n\tuint id = groupThreadId.x + groupId.x * NB_THREADS_PER_GROUP
-      + groupId.y * dispatchWidth * NB_THREADS_PER_GROUP;\n\tuint index = id;\n\tif
-      (id < nbMax)\n\t{\n#if VFX_USE_ALIVE_CURRENT\n\t\t\n\t\tif (alive)\n\t\t{\n\t\t\tfloat3
-      position = asfloat(attributeBuffer.Load3((index * 0x4 + 0x800) << 2));\n\t\t\tfloat3
-      oldPosition = asfloat(attributeBuffer.Load3((index * 0x4 + 0x7000) << 2));\n\t\t\t\n\n\t\t\t\n#if
-      VFX_USE_OLDPOSITION_CURRENT\n\t\t\toldPosition = position;\n#endif\n\t\t\t\n\t\t\t\n\t\t\tif
-      (alive)\n\t\t\t{\n\t\t\t\tattributeBuffer.Store3((index * 0x4 + 0x7000) << 2,asuint(oldPosition));\n\t\t\t\t\n\n#if
-      VFX_HAS_INDIRECT_DRAW\n                uint indirectIndex = indirectBuffer.IncrementCounter();\n\t\t\t\tindirectBuffer[indirectIndex]
-      = index;\n#endif\n\t\t\t}\n\t\t\telse\n\t\t\t{\n\t\t\t\t\n\t\t\t\tuint deadIndex
-      = deadListOut.IncrementCounter();\n\t\t\t\tdeadListOut[deadIndex] = index;\n\t\t\t}\n\t\t}\n#else\n\t\tfloat3
-      position = asfloat(attributeBuffer.Load3((index * 0x4 + 0x800) << 2));\n\t\tfloat3
-      oldPosition = asfloat(attributeBuffer.Load3((index * 0x4 + 0x7000) << 2));\n\t\t\n\n\t\t\n#if
-      VFX_USE_OLDPOSITION_CURRENT\n\t\toldPosition = position;\n#endif\n\t\t\n\t\t\n\t\tattributeBuffer.Store3((index
-      * 0x4 + 0x7000) << 2,asuint(oldPosition));\n\t\t\n\n#if VFX_HAS_INDIRECT_DRAW\n
-      \       uint indirectIndex = indirectBuffer.IncrementCounter();\n\t\tindirectBuffer[indirectIndex]
-      = index;\n#endif\n#endif\n\t}\n}\n"
   - compute: 1
     name: '[System 1]Initialize'
     source: "#pragma kernel CSMain\n#include \"HLSLSupport.cginc\"\n#define NB_THREADS_PER_GROUP
@@ -855,8 +856,11 @@ VisualEffectResource:
       VFX_USE_OLDPOSITION_CURRENT 1\n#define VFX_USE_DENSITYPRESSURE_CURRENT 1\n#define
       VFX_USE_NORMAL_CURRENT 1\n#define VFX_USE_VORTICITYTURBULENCE_CURRENT 1\n#define
       VFX_USE_ALIVE_CURRENT 1\n#define VFX_USE_AGE_CURRENT 1\n#define VFX_WORLD_SPACE
-      1\n\n\nCBUFFER_START(parameters)\n    float3 Cone_center_b;\n    uint PADDING_0;\n
-      \   float3 Direction_c;\n    uint PADDING_1;\nCBUFFER_END\n\n\n#include \"Packages/com.unity.visualeffectgraph/Shaders/Common/VFXCommonCompute.cginc\"\n#include
+      1\n\n\nCBUFFER_START(parameters)\n    float3 Cone_center_b;\n    float Lifetime_a;\n
+      \   float3 Direction_c;\n    float Cone_radius0_b;\n    float2 sincosSlope_b;\n
+      \   float Cone_radius1_b;\n    float Cone_height_b;\n    float Cone_arc_b;\n
+      \   float fullConeHeight_b;\n    float Speed_c;\n    float DirectionBlend_c;\nCBUFFER_END\n\n\n#include
+      \"Packages/com.unity.visualeffectgraph/Shaders/Common/VFXCommonCompute.cginc\"\n#include
       \"Packages/com.unity.visualeffectgraph/Shaders/VFXCommon.cginc\"\n\n\n\nRWByteAddressBuffer
       attributeBuffer;\nByteAddressBuffer sourceAttributeBuffer;\n\nCBUFFER_START(initParams)\n#if
       !VFX_USE_SPAWNER_FROM_GPU\n    uint nbSpawned;\t\t\t\t\t// Numbers of particle
@@ -911,14 +915,13 @@ VisualEffectResource:
       = float4(0,0,0,0);\n        bool alive = (bool)true;\n        float age = (float)0;\n
       \       \n\n#if VFX_USE_PARTICLEID_CURRENT\n         particleId = particleIndex;\n#endif\n#if
       VFX_USE_SEED_CURRENT\n        seed = WangHash(particleIndex ^ systemSeed);\n#endif\n
-      \       \n        {\n            SetAttribute_F0142CB9( /*inout */lifetime,
-      (float)0.8);\n        }\n        {\n            PositionCone_267A9( /*inout
-      */position,  /*inout */seed,  /*inout */direction, Cone_center_b, (float)0.2,
-      (float)0.3, (float)0.2, (float)6.283185, (float)1, (float)0.6, float2(0.4472136,0.8944272));\n
-      \       }\n        {\n            VelocityDirection_18D( /*inout */velocity,
-      \ /*inout */direction, Direction_c, (float)5, (float)1);\n        }\n        \n\n\n#if
-      VFX_USE_ALIVE_CURRENT\n        if (alive)\n        {\n\t\t\tuint deadIndex =
-      deadListIn.DecrementCounter();\n            uint index = deadListIn[deadIndex];\n
+      \       \n        SetAttribute_F0142CB9( /*inout */lifetime, Lifetime_a);\n
+      \       {\n            PositionCone_267A9( /*inout */position,  /*inout */seed,
+      \ /*inout */direction, Cone_center_b, Cone_radius0_b, Cone_radius1_b, Cone_height_b,
+      Cone_arc_b, (float)1, fullConeHeight_b, sincosSlope_b);\n        }\n        VelocityDirection_18D(
+      /*inout */velocity,  /*inout */direction, Direction_c, Speed_c, DirectionBlend_c);\n
+      \       \n\n\n#if VFX_USE_ALIVE_CURRENT\n        if (alive)\n        {\n\t\t\tuint
+      deadIndex = deadListIn.DecrementCounter();\n            uint index = deadListIn[deadIndex];\n
       \           attributeBuffer.Store((index * 0x1 + 0x0) << 2,asuint(lifetime));\n
       \           attributeBuffer.Store3((index * 0x4 + 0x800) << 2,asuint(position));\n
       \           attributeBuffer.Store3((index * 0x4 + 0x2800) << 2,asuint(velocity));\n
@@ -1094,101 +1097,257 @@ VisualEffectResource:
         data[0]: -1
         data[1]: -1
         data[2]: -1
-        data[3]: 13
+        data[3]: 1
       - op: 1
         valueIndex: 1
         data[0]: -1
         data[1]: -1
         data[2]: -1
-        data[3]: 3
-      - op: 9
+        data[3]: 1
+      - op: 26
+        valueIndex: 2
+        data[0]: 1
+        data[1]: 0
+        data[2]: -1
+        data[3]: 1
+      - op: 1
+        valueIndex: 3
+        data[0]: -1
+        data[1]: -1
+        data[2]: -1
+        data[3]: 1
+      - op: 1
         valueIndex: 4
         data[0]: -1
         data[1]: -1
         data[2]: -1
+        data[3]: 1
+      - op: 1
+        valueIndex: 5
+        data[0]: -1
+        data[1]: -1
+        data[2]: -1
+        data[3]: 1
+      - op: 21
+        valueIndex: 6
+        data[0]: 2
+        data[1]: 2
+        data[2]: -1
+        data[3]: 1
+      - op: 21
+        valueIndex: 7
+        data[0]: 6
+        data[1]: 2
+        data[2]: -1
+        data[3]: 1
+      - op: 3
+        valueIndex: 8
+        data[0]: 3
+        data[1]: 5
+        data[2]: 4
         data[3]: -1
+      - op: 21
+        valueIndex: 11
+        data[0]: 7
+        data[1]: 2
+        data[2]: -1
+        data[3]: 1
+      - op: 21
+        valueIndex: 12
+        data[0]: 8
+        data[1]: 8
+        data[2]: -1
+        data[3]: 3
+      - op: 21
+        valueIndex: 15
+        data[0]: 9
+        data[1]: 2
+        data[2]: -1
+        data[3]: 1
+      - op: 5
+        valueIndex: 16
+        data[0]: 10
+        data[1]: -1
+        data[2]: 1
+        data[3]: 3
+      - op: 5
+        valueIndex: 17
+        data[0]: 10
+        data[1]: -1
+        data[2]: 2
+        data[3]: 3
+      - op: 5
+        valueIndex: 18
+        data[0]: 10
+        data[1]: -1
+        data[2]: 0
+        data[3]: 3
+      - op: 1
+        valueIndex: 19
+        data[0]: -1
+        data[1]: -1
+        data[2]: -1
+        data[3]: 1
       - op: 1
         valueIndex: 20
         data[0]: -1
         data[1]: -1
         data[2]: -1
-        data[3]: 3
+        data[3]: 1
+      - op: 21
+        valueIndex: 21
+        data[0]: 11
+        data[1]: 2
+        data[2]: -1
+        data[3]: 1
+      - op: 23
+        valueIndex: 22
+        data[0]: 13
+        data[1]: 12
+        data[2]: -1
+        data[3]: 1
       - op: 1
         valueIndex: 23
         data[0]: -1
         data[1]: -1
         data[2]: -1
-        data[3]: 3
-      - op: 6
+        data[3]: 1
+      - op: 1
+        valueIndex: 24
+        data[0]: -1
+        data[1]: -1
+        data[2]: -1
+        data[3]: 1
+      - op: 21
+        valueIndex: 25
+        data[0]: 17
+        data[1]: 2
+        data[2]: -1
+        data[3]: 1
+      - op: 1
         valueIndex: 26
         data[0]: -1
         data[1]: -1
         data[2]: -1
-        data[3]: -1
-      - op: 1
+        data[3]: 1
+      - op: 26
         valueIndex: 27
-        data[0]: -1
-        data[1]: -1
+        data[0]: 16
+        data[1]: 15
         data[2]: -1
         data[3]: 1
-      - op: 35
+      - op: 1
         valueIndex: 28
-        data[0]: 2
-        data[1]: 4
+        data[0]: -1
+        data[1]: -1
         data[2]: -1
-        data[3]: -1
+        data[3]: 1
+      - op: 23
+        valueIndex: 29
+        data[0]: 18
+        data[1]: 14
+        data[2]: -1
+        data[3]: 1
       - op: 1
+        valueIndex: 30
+        data[0]: -1
+        data[1]: -1
+        data[2]: -1
+        data[3]: 1
+      - op: 27
         valueIndex: 31
-        data[0]: -1
-        data[1]: -1
+        data[0]: 25
+        data[1]: 24
         data[2]: -1
         data[3]: 1
-      - op: 1
+      - op: 24
         valueIndex: 32
-        data[0]: -1
-        data[1]: -1
+        data[0]: 19
+        data[1]: 22
         data[2]: -1
         data[3]: 1
-      - op: 1
+      - op: 25
         valueIndex: 33
+        data[0]: 23
+        data[1]: 20
+        data[2]: -1
+        data[3]: 1
+      - op: 21
+        valueIndex: 34
+        data[0]: 21
+        data[1]: 2
+        data[2]: -1
+        data[3]: 1
+      - op: 26
+        valueIndex: 35
+        data[0]: 29
+        data[1]: 15
+        data[2]: -1
+        data[3]: 1
+      - op: 1
+        valueIndex: 36
         data[0]: -1
         data[1]: -1
         data[2]: -1
         data[3]: 1
       - op: 1
-        valueIndex: 34
+        valueIndex: 37
         data[0]: -1
         data[1]: -1
         data[2]: -1
-        data[3]: 2
-      - op: 37
-        valueIndex: 36
-        data[0]: 2
-        data[1]: 3
+        data[3]: 1
+      - op: 22
+        valueIndex: 38
+        data[0]: 20
+        data[1]: 27
         data[2]: -1
-        data[3]: -1
+        data[3]: 1
       - op: 1
         valueIndex: 39
         data[0]: -1
         data[1]: -1
         data[2]: -1
         data[3]: 1
-      - op: 44
+      - op: 1
         valueIndex: 40
-        data[0]: 0
+        data[0]: -1
         data[1]: -1
         data[2]: -1
-        data[3]: 0
+        data[3]: 1
+      - op: 22
+        valueIndex: 41
+        data[0]: 28
+        data[1]: 26
+        data[2]: -1
+        data[3]: 1
+      - op: 1
+        valueIndex: 42
+        data[0]: -1
+        data[1]: -1
+        data[2]: -1
+        data[3]: 1
+      - op: 1
+        valueIndex: 43
+        data[0]: -1
+        data[1]: -1
+        data[2]: -1
+        data[3]: 1
       - op: 1
         valueIndex: 44
         data[0]: -1
         data[1]: -1
         data[2]: -1
-        data[3]: 2
+        data[3]: 1
       - op: 1
-        valueIndex: 46
+        valueIndex: 45
         data[0]: -1
         data[1]: -1
+        data[2]: -1
+        data[3]: 1
+      - op: 21
+        valueIndex: 46
+        data[0]: 30
+        data[1]: 2
         data[2]: -1
         data[3]: 1
       - op: 1
@@ -1196,19 +1355,67 @@ VisualEffectResource:
         data[0]: -1
         data[1]: -1
         data[2]: -1
-        data[3]: 4
+        data[3]: 1
+      - op: 1
+        valueIndex: 48
+        data[0]: -1
+        data[1]: -1
+        data[2]: -1
+        data[3]: 1
+      - op: 1
+        valueIndex: 49
+        data[0]: -1
+        data[1]: -1
+        data[2]: -1
+        data[3]: 1
+      - op: 1
+        valueIndex: 50
+        data[0]: -1
+        data[1]: -1
+        data[2]: -1
+        data[3]: 1
       - op: 1
         valueIndex: 51
         data[0]: -1
         data[1]: -1
         data[2]: -1
-        data[3]: 4
-      - op: 36
-        valueIndex: 55
-        data[0]: 2
-        data[1]: 1
+        data[3]: 1
+      - op: 21
+        valueIndex: 52
+        data[0]: 39
+        data[1]: 17
         data[2]: -1
-        data[3]: -1
+        data[3]: 1
+      - op: 1
+        valueIndex: 53
+        data[0]: -1
+        data[1]: -1
+        data[2]: -1
+        data[3]: 1
+      - op: 21
+        valueIndex: 54
+        data[0]: 33
+        data[1]: 7
+        data[2]: -1
+        data[3]: 1
+      - op: 21
+        valueIndex: 55
+        data[0]: 41
+        data[1]: 42
+        data[2]: -1
+        data[3]: 1
+      - op: 26
+        valueIndex: 56
+        data[0]: 44
+        data[1]: 15
+        data[2]: -1
+        data[3]: 1
+      - op: 26
+        valueIndex: 57
+        data[0]: 32
+        data[1]: 15
+        data[2]: -1
+        data[3]: 1
       - op: 1
         valueIndex: 58
         data[0]: -1
@@ -1233,15 +1440,15 @@ VisualEffectResource:
         data[1]: -1
         data[2]: -1
         data[3]: 1
-      - op: 1
+      - op: 26
         valueIndex: 62
-        data[0]: -1
-        data[1]: -1
+        data[0]: 40
+        data[1]: 0
         data[2]: -1
         data[3]: 1
-      - op: 1
+      - op: 16
         valueIndex: 63
-        data[0]: -1
+        data[0]: 37
         data[1]: -1
         data[2]: -1
         data[3]: 1
@@ -1251,38 +1458,380 @@ VisualEffectResource:
         data[1]: -1
         data[2]: -1
         data[3]: 1
-      - op: 1
+      - op: 26
         valueIndex: 65
-        data[0]: -1
-        data[1]: -1
+        data[0]: 36
+        data[1]: 0
         data[2]: -1
         data[3]: 1
-      - op: 1
+      - op: 26
         valueIndex: 66
-        data[0]: -1
-        data[1]: -1
+        data[0]: 35
+        data[1]: 0
         data[2]: -1
         data[3]: 1
-      - op: 1
+      - op: 26
         valueIndex: 67
-        data[0]: -1
-        data[1]: -1
+        data[0]: 43
+        data[1]: 0
         data[2]: -1
-        data[3]: 3
-      - op: 1
-        valueIndex: 70
-        data[0]: -1
-        data[1]: -1
+        data[3]: 1
+      - op: 3
+        valueIndex: 68
+        data[0]: 34
+        data[1]: 34
+        data[2]: 34
+        data[3]: -1
+      - op: 25
+        valueIndex: 71
+        data[0]: 31
+        data[1]: 20
         data[2]: -1
-        data[3]: 3
+        data[3]: 1
+      - op: 26
+        valueIndex: 72
+        data[0]: 38
+        data[1]: 0
+        data[2]: -1
+        data[3]: 1
       - op: 1
         valueIndex: 73
         data[0]: -1
         data[1]: -1
         data[2]: -1
+        data[3]: 1
+      - op: 3
+        valueIndex: 74
+        data[0]: 60
+        data[1]: 57
+        data[2]: 56
+        data[3]: -1
+      - op: 26
+        valueIndex: 77
+        data[0]: 54
+        data[1]: 15
+        data[2]: -1
+        data[3]: 1
+      - op: 22
+        valueIndex: 78
+        data[0]: 67
+        data[1]: 50
+        data[2]: -1
+        data[3]: 1
+      - op: 21
+        valueIndex: 79
+        data[0]: 8
+        data[1]: 64
+        data[2]: -1
+        data[3]: 3
+      - op: 11
+        valueIndex: 82
+        data[0]: 59
+        data[1]: -1
+        data[2]: -1
+        data[3]: 1
+      - op: 12
+        valueIndex: 83
+        data[0]: 59
+        data[1]: -1
+        data[2]: -1
+        data[3]: 1
+      - op: 22
+        valueIndex: 84
+        data[0]: 49
+        data[1]: 51
+        data[2]: -1
+        data[3]: 1
+      - op: 1
+        valueIndex: 85
+        data[0]: -1
+        data[1]: -1
+        data[2]: -1
+        data[3]: 1
+      - op: 1
+        valueIndex: 86
+        data[0]: -1
+        data[1]: -1
+        data[2]: -1
+        data[3]: 1
+      - op: 1
+        valueIndex: 87
+        data[0]: -1
+        data[1]: -1
+        data[2]: -1
+        data[3]: 1
+      - op: 1
+        valueIndex: 88
+        data[0]: -1
+        data[1]: -1
+        data[2]: -1
+        data[3]: 1
+      - op: 1
+        valueIndex: 89
+        data[0]: -1
+        data[1]: -1
+        data[2]: -1
+        data[3]: 1
+      - op: 26
+        valueIndex: 90
+        data[0]: 55
+        data[1]: 15
+        data[2]: -1
+        data[3]: 1
+      - op: 26
+        valueIndex: 91
+        data[0]: 2
+        data[1]: 0
+        data[2]: -1
+        data[3]: 1
+      - op: 22
+        valueIndex: 92
+        data[0]: 67
+        data[1]: 48
+        data[2]: -1
+        data[3]: 1
+      - op: 26
+        valueIndex: 93
+        data[0]: 58
+        data[1]: 0
+        data[2]: -1
+        data[3]: 1
+      - op: 1
+        valueIndex: 94
+        data[0]: -1
+        data[1]: -1
+        data[2]: -1
+        data[3]: 1
+      - op: 1
+        valueIndex: 95
+        data[0]: -1
+        data[1]: -1
+        data[2]: -1
+        data[3]: 1
+      - op: 26
+        valueIndex: 96
+        data[0]: 61
+        data[1]: 0
+        data[2]: -1
+        data[3]: 1
+      - op: 26
+        valueIndex: 97
+        data[0]: 62
+        data[1]: 0
+        data[2]: -1
+        data[3]: 1
+      - op: 26
+        valueIndex: 98
+        data[0]: 63
+        data[1]: 0
+        data[2]: -1
+        data[3]: 1
+      - op: 26
+        valueIndex: 99
+        data[0]: 65
+        data[1]: 15
+        data[2]: -1
+        data[3]: 1
+      - op: 26
+        valueIndex: 100
+        data[0]: 53
+        data[1]: 15
+        data[2]: -1
+        data[3]: 1
+      - op: 26
+        valueIndex: 101
+        data[0]: 52
+        data[1]: 15
+        data[2]: -1
+        data[3]: 1
+      - op: 9
+        valueIndex: 102
+        data[0]: -1
+        data[1]: -1
+        data[2]: -1
+        data[3]: -1
+      - op: 3
+        valueIndex: 118
+        data[0]: 47
+        data[1]: 46
+        data[2]: 45
+        data[3]: -1
+      - op: 1
+        valueIndex: 121
+        data[0]: -1
+        data[1]: -1
+        data[2]: -1
+        data[3]: 13
+      - op: 26
+        valueIndex: 122
+        data[0]: 66
+        data[1]: 0
+        data[2]: -1
+        data[3]: 1
+      - op: 37
+        valueIndex: 123
+        data[0]: 92
+        data[1]: 71
+        data[2]: -1
+        data[3]: -1
+      - op: 25
+        valueIndex: 126
+        data[0]: 80
+        data[1]: 20
+        data[2]: -1
+        data[3]: 1
+      - op: 1
+        valueIndex: 127
+        data[0]: -1
+        data[1]: -1
+        data[2]: -1
+        data[3]: 1
+      - op: 44
+        valueIndex: 128
+        data[0]: 94
+        data[1]: -1
+        data[2]: -1
+        data[3]: 0
+      - op: 26
+        valueIndex: 132
+        data[0]: 85
+        data[1]: 15
+        data[2]: -1
+        data[3]: 1
+      - op: 4
+        valueIndex: 133
+        data[0]: 74
+        data[1]: 82
+        data[2]: 70
+        data[3]: 15
+      - op: 22
+        valueIndex: 137
+        data[0]: 19
+        data[1]: 37
+        data[2]: -1
+        data[3]: 1
+      - op: 3
+        valueIndex: 138
+        data[0]: 84
+        data[1]: 75
+        data[2]: 76
+        data[3]: -1
+      - op: 3
+        valueIndex: 141
+        data[0]: 77
+        data[1]: 78
+        data[2]: 79
+        data[3]: -1
+      - op: 26
+        valueIndex: 144
+        data[0]: 81
+        data[1]: 0
+        data[2]: -1
+        data[3]: 1
+      - op: 26
+        valueIndex: 145
+        data[0]: 83
+        data[1]: 0
+        data[2]: -1
+        data[3]: 1
+      - op: 26
+        valueIndex: 146
+        data[0]: 95
+        data[1]: 0
+        data[2]: -1
+        data[3]: 1
+      - op: 26
+        valueIndex: 147
+        data[0]: 86
+        data[1]: 0
+        data[2]: -1
+        data[3]: 1
+      - op: 26
+        valueIndex: 148
+        data[0]: 87
+        data[1]: 0
+        data[2]: -1
+        data[3]: 1
+      - op: 26
+        valueIndex: 149
+        data[0]: 88
+        data[1]: 0
+        data[2]: -1
+        data[3]: 1
+      - op: 25
+        valueIndex: 150
+        data[0]: 89
+        data[1]: 20
+        data[2]: -1
+        data[3]: 1
+      - op: 26
+        valueIndex: 151
+        data[0]: 90
+        data[1]: 15
+        data[2]: -1
+        data[3]: 1
+      - op: 26
+        valueIndex: 152
+        data[0]: 91
+        data[1]: 15
+        data[2]: -1
+        data[3]: 1
+      - op: 36
+        valueIndex: 153
+        data[0]: 92
+        data[1]: 93
+        data[2]: -1
+        data[3]: -1
+      - op: 4
+        valueIndex: 156
+        data[0]: 2
+        data[1]: 6
+        data[2]: 7
+        data[3]: 15
+      - op: 1
+        valueIndex: 160
+        data[0]: -1
+        data[1]: -1
+        data[2]: -1
         data[3]: 7
       - op: 1
-        valueIndex: 75
+        valueIndex: 162
+        data[0]: -1
+        data[1]: -1
+        data[2]: -1
+        data[3]: 2
+      - op: 6
+        valueIndex: 164
+        data[0]: -1
+        data[1]: -1
+        data[2]: -1
+        data[3]: -1
+      - op: 1
+        valueIndex: 165
+        data[0]: -1
+        data[1]: -1
+        data[2]: -1
+        data[3]: 1
+      - op: 35
+        valueIndex: 166
+        data[0]: 92
+        data[1]: 68
+        data[2]: -1
+        data[3]: -1
+      - op: 25
+        valueIndex: 169
+        data[0]: 69
+        data[1]: 33
+        data[2]: -1
+        data[3]: 1
+      - op: 2
+        valueIndex: 170
+        data[0]: 72
+        data[1]: 73
+        data[2]: -1
+        data[3]: -1
+      - op: 1
+        valueIndex: 172
         data[0]: -1
         data[1]: -1
         data[2]: -1
@@ -1292,60 +1841,96 @@ VisualEffectResource:
     m_PropertySheet:
       m_Float:
         m_Array:
-        - m_ExpressionIndex: 6
-          m_Value: 0.8
-        - m_ExpressionIndex: 8
-          m_Value: 6.2831855
-        - m_ExpressionIndex: 9
-          m_Value: 1
-        - m_ExpressionIndex: 10
-          m_Value: 0.59999996
-        - m_ExpressionIndex: 13
-          m_Value: 5
-        - m_ExpressionIndex: 16
-          m_Value: 2000
-        - m_ExpressionIndex: 20
+        - m_ExpressionIndex: 0
+          m_Value: 9.9999994e-11
+        - m_ExpressionIndex: 1
+          m_Value: 0.38125
+        - m_ExpressionIndex: 3
           m_Value: 0
-        - m_ExpressionIndex: 21
-          m_Value: 0.728
+        - m_ExpressionIndex: 4
+          m_Value: 0
+        - m_ExpressionIndex: 5
+          m_Value: 1
+        - m_ExpressionIndex: 15
+          m_Value: 0
+        - m_ExpressionIndex: 16
+          m_Value: 0.2
+        - m_ExpressionIndex: 19
+          m_Value: 0.3
+        - m_ExpressionIndex: 20
+          m_Value: 1
         - m_ExpressionIndex: 22
           m_Value: 0.2
-        - m_ExpressionIndex: 23
-          m_Value: 0.3
         - m_ExpressionIndex: 24
-          m_Value: 0.01
-        - m_ExpressionIndex: 25
-          m_Value: 9.9829
+          m_Value: 0.5
         - m_ExpressionIndex: 26
+          m_Value: 0.2
+        - m_ExpressionIndex: 32
+          m_Value: 0.728
+        - m_ExpressionIndex: 33
+          m_Value: 6.2831855
+        - m_ExpressionIndex: 35
+          m_Value: 0.01
+        - m_ExpressionIndex: 36
+          m_Value: 9.9829
+        - m_ExpressionIndex: 38
           m_Value: 998.29
-        - m_ExpressionIndex: 27
+        - m_ExpressionIndex: 39
+          m_Value: 3.1415927
+        - m_ExpressionIndex: 40
           m_Value: 7.625
-        - m_ExpressionIndex: 28
-          m_Value: 0.38125
+        - m_ExpressionIndex: 41
+          m_Value: 201.06194
+        - m_ExpressionIndex: 43
+          m_Value: 0.3
+        - m_ExpressionIndex: 44
+          m_Value: 0
+        - m_ExpressionIndex: 45
+          m_Value: 0
+        - m_ExpressionIndex: 46
+          m_Value: -9.81
+        - m_ExpressionIndex: 47
+          m_Value: 0
+        - m_ExpressionIndex: 49
+          m_Value: 315
+        - m_ExpressionIndex: 54
+          m_Value: 6.2831855
+        - m_ExpressionIndex: 55
+          m_Value: 1
+        - m_ExpressionIndex: 56
+          m_Value: 0
+        - m_ExpressionIndex: 57
+          m_Value: -0.24813068
+        - m_ExpressionIndex: 60
+          m_Value: -0.017374076
+        - m_ExpressionIndex: 67
+          m_Value: 15
+        - m_ExpressionIndex: 75
+          m_Value: -0.25
+        - m_ExpressionIndex: 76
+          m_Value: 0
+        - m_ExpressionIndex: 77
+          m_Value: 3
+        - m_ExpressionIndex: 78
+          m_Value: 6.5
+        - m_ExpressionIndex: 79
+          m_Value: 3
+        - m_ExpressionIndex: 84
+          m_Value: 0
+        - m_ExpressionIndex: 85
+          m_Value: 2000
+        - m_ExpressionIndex: 98
+          m_Value: 5
+        - m_ExpressionIndex: 119
+          m_Value: 0.8
       m_Vector2f:
         m_Array:
-        - m_ExpressionIndex: 11
-          m_Value: {x: 0.44721365, y: 0.8944272}
-        - m_ExpressionIndex: 15
+        - m_ExpressionIndex: 117
           m_Value: {x: 0, y: 0}
       m_Vector3f:
-        m_Array:
-        - m_ExpressionIndex: 1
-          m_Value: {x: 0, y: -9.81, z: 0}
-        - m_ExpressionIndex: 3
-          m_Value: {x: 0, y: 1, z: 0}
-        - m_ExpressionIndex: 4
-          m_Value: {x: -0.017374076, y: -0.24813068, z: 0}
-        - m_ExpressionIndex: 29
-          m_Value: {x: 3, y: 6.5, z: 3}
-        - m_ExpressionIndex: 30
-          m_Value: {x: 0, y: -0.25, z: 0}
+        m_Array: []
       m_Vector4f:
-        m_Array:
-        - m_ExpressionIndex: 17
-          m_Value: {x: 9206.448, y: 1554.8279, z: 43.08061, w: 0}
-        - m_ExpressionIndex: 18
-          m_Value: {x: 0.38125, y: 0.14535156, z: 0.05541528, w: 0}
+        m_Array: []
       m_Uint:
         m_Array: []
       m_Int:
@@ -1354,7 +1939,7 @@ VisualEffectResource:
         m_Array: []
       m_AnimationCurve:
         m_Array:
-        - m_ExpressionIndex: 0
+        - m_ExpressionIndex: 94
           m_Value:
             serializedVersion: 2
             m_Curve:
@@ -1410,9 +1995,9 @@ VisualEffectResource:
         m_Array: []
       m_NamedObject:
         m_Array:
-        - m_ExpressionIndex: 31
+        - m_ExpressionIndex: 116
           m_Value: {fileID: 0}
-        - m_ExpressionIndex: 32
+        - m_ExpressionIndex: 123
           m_Value: {fileID: 2800000, guid: 276d9e395ae18fe40a9b4988549f2349, type: 3}
       m_Bool:
         m_Array: []
@@ -1649,7 +2234,7 @@ VisualEffectResource:
       buffers: []
       values:
       - nameId: Rate
-        index: 16
+        index: 100
       params: []
       processor: {fileID: 0}
       shaderSourceIndex: -1
@@ -1676,9 +2261,9 @@ VisualEffectResource:
       index: 7
     values:
     - nameId: bounds_center
-      index: 30
+      index: 103
     - nameId: bounds_size
-      index: 29
+      index: 104
     tasks:
     - type: 536870912
       buffers:
@@ -1691,17 +2276,35 @@ VisualEffectResource:
       - nameId: sourceAttributeBuffer
         index: 2
       values:
+      - nameId: Lifetime_a
+        index: 119
       - nameId: Cone_center_b
-        index: 7
+        index: 120
+      - nameId: Cone_radius0_b
+        index: 22
+      - nameId: Cone_radius1_b
+        index: 19
+      - nameId: Cone_height_b
+        index: 26
+      - nameId: Cone_arc_b
+        index: 121
+      - nameId: fullConeHeight_b
+        index: 102
+      - nameId: sincosSlope_b
+        index: 122
       - nameId: Direction_c
-        index: 12
+        index: 96
+      - nameId: Speed_c
+        index: 98
+      - nameId: DirectionBlend_c
+        index: 97
       params:
       - nameId: bounds_center
-        index: 30
+        index: 103
       - nameId: bounds_size
-        index: 29
+        index: 104
       processor: {fileID: 0}
-      shaderSourceIndex: 8
+      shaderSourceIndex: 7
     - type: 805306368
       buffers:
       - nameId: attributeBuffer
@@ -1711,10 +2314,32 @@ VisualEffectResource:
       - nameId: indirectBuffer
         index: 5
       values:
+      - nameId: solverData_Fluid_SmoothingDistance_a
+        index: 105
+      - nameId: solverData_Fluid_ParticleMass_a
+        index: 106
+      - nameId: solverData_Fluid_Density_a
+        index: 107
+      - nameId: solverData_Fluid_MinimumDensity_a
+        index: 108
+      - nameId: solverData_Fluid_GasConstant_a
+        index: 109
+      - nameId: solverData_Fluid_Viscosity_a
+        index: 110
+      - nameId: solverData_Fluid_TurbulenceProbability_a
+        index: 111
+      - nameId: solverData_Fluid_SurfaceTension_a
+        index: 112
+      - nameId: solverData_Fluid_BuoyancyCoefficient_a
+        index: 113
       - nameId: solverData_Gravity_a
-        index: 19
+        index: 114
+      - nameId: solverData_KernelSize_a
+        index: 115
+      - nameId: solverData_KernelFactors_a
+        index: 101
       - nameId: solverData_Tex_a
-        index: 31
+        index: 116
       params: []
       processor: {fileID: 0}
       shaderSourceIndex: 0
@@ -1727,8 +2352,30 @@ VisualEffectResource:
       - nameId: indirectBuffer
         index: 5
       values:
+      - nameId: solverData_Fluid_SmoothingDistance_a
+        index: 105
+      - nameId: solverData_Fluid_ParticleMass_a
+        index: 106
+      - nameId: solverData_Fluid_Density_a
+        index: 107
+      - nameId: solverData_Fluid_MinimumDensity_a
+        index: 108
+      - nameId: solverData_Fluid_GasConstant_a
+        index: 109
+      - nameId: solverData_Fluid_Viscosity_a
+        index: 110
+      - nameId: solverData_Fluid_TurbulenceProbability_a
+        index: 111
+      - nameId: solverData_Fluid_SurfaceTension_a
+        index: 112
+      - nameId: solverData_Fluid_BuoyancyCoefficient_a
+        index: 113
       - nameId: solverData_Gravity_a
-        index: 19
+        index: 114
+      - nameId: solverData_KernelSize_a
+        index: 115
+      - nameId: solverData_KernelFactors_a
+        index: 101
       params: []
       processor: {fileID: 0}
       shaderSourceIndex: 1
@@ -1741,8 +2388,30 @@ VisualEffectResource:
       - nameId: indirectBuffer
         index: 5
       values:
+      - nameId: solverData_Fluid_SmoothingDistance_a
+        index: 105
+      - nameId: solverData_Fluid_ParticleMass_a
+        index: 106
+      - nameId: solverData_Fluid_Density_a
+        index: 107
+      - nameId: solverData_Fluid_MinimumDensity_a
+        index: 108
+      - nameId: solverData_Fluid_GasConstant_a
+        index: 109
+      - nameId: solverData_Fluid_Viscosity_a
+        index: 110
+      - nameId: solverData_Fluid_TurbulenceProbability_a
+        index: 111
+      - nameId: solverData_Fluid_SurfaceTension_a
+        index: 112
+      - nameId: solverData_Fluid_BuoyancyCoefficient_a
+        index: 113
       - nameId: solverData_Gravity_a
-        index: 19
+        index: 114
+      - nameId: solverData_KernelSize_a
+        index: 115
+      - nameId: solverData_KernelFactors_a
+        index: 101
       params: []
       processor: {fileID: 0}
       shaderSourceIndex: 2
@@ -1755,8 +2424,30 @@ VisualEffectResource:
       - nameId: indirectBuffer
         index: 5
       values:
+      - nameId: solverData_Fluid_SmoothingDistance_a
+        index: 105
+      - nameId: solverData_Fluid_ParticleMass_a
+        index: 106
+      - nameId: solverData_Fluid_Density_a
+        index: 107
+      - nameId: solverData_Fluid_MinimumDensity_a
+        index: 108
+      - nameId: solverData_Fluid_GasConstant_a
+        index: 109
+      - nameId: solverData_Fluid_Viscosity_a
+        index: 110
+      - nameId: solverData_Fluid_TurbulenceProbability_a
+        index: 111
+      - nameId: solverData_Fluid_SurfaceTension_a
+        index: 112
+      - nameId: solverData_Fluid_BuoyancyCoefficient_a
+        index: 113
       - nameId: solverData_Gravity_a
-        index: 19
+        index: 114
+      - nameId: solverData_KernelSize_a
+        index: 115
+      - nameId: solverData_KernelFactors_a
+        index: 101
       params: []
       processor: {fileID: 0}
       shaderSourceIndex: 3
@@ -1768,21 +2459,31 @@ VisualEffectResource:
         index: 3
       - nameId: indirectBuffer
         index: 5
-      values: []
-      params: []
-      processor: {fileID: 0}
-      shaderSourceIndex: 7
-    - type: 805306368
-      buffers:
-      - nameId: attributeBuffer
-        index: 0
-      - nameId: deadListOut
-        index: 3
-      - nameId: indirectBuffer
-        index: 5
       values:
+      - nameId: solverData_Fluid_SmoothingDistance_a
+        index: 105
+      - nameId: solverData_Fluid_ParticleMass_a
+        index: 106
+      - nameId: solverData_Fluid_Density_a
+        index: 107
+      - nameId: solverData_Fluid_MinimumDensity_a
+        index: 108
+      - nameId: solverData_Fluid_GasConstant_a
+        index: 109
+      - nameId: solverData_Fluid_Viscosity_a
+        index: 110
+      - nameId: solverData_Fluid_TurbulenceProbability_a
+        index: 111
+      - nameId: solverData_Fluid_SurfaceTension_a
+        index: 112
+      - nameId: solverData_Fluid_BuoyancyCoefficient_a
+        index: 113
       - nameId: solverData_Gravity_a
-        index: 19
+        index: 114
+      - nameId: solverData_KernelSize_a
+        index: 115
+      - nameId: solverData_KernelFactors_a
+        index: 101
       params: []
       processor: {fileID: 0}
       shaderSourceIndex: 4
@@ -1795,8 +2496,30 @@ VisualEffectResource:
       - nameId: indirectBuffer
         index: 5
       values:
+      - nameId: solverData_Fluid_SmoothingDistance_a
+        index: 105
+      - nameId: solverData_Fluid_ParticleMass_a
+        index: 106
+      - nameId: solverData_Fluid_Density_a
+        index: 107
+      - nameId: solverData_Fluid_MinimumDensity_a
+        index: 108
+      - nameId: solverData_Fluid_GasConstant_a
+        index: 109
+      - nameId: solverData_Fluid_Viscosity_a
+        index: 110
+      - nameId: solverData_Fluid_TurbulenceProbability_a
+        index: 111
+      - nameId: solverData_Fluid_SurfaceTension_a
+        index: 112
+      - nameId: solverData_Fluid_BuoyancyCoefficient_a
+        index: 113
       - nameId: solverData_Gravity_a
-        index: 19
+        index: 114
+      - nameId: solverData_KernelSize_a
+        index: 115
+      - nameId: solverData_KernelFactors_a
+        index: 101
       params: []
       processor: {fileID: 0}
       shaderSourceIndex: 5
@@ -1809,10 +2532,32 @@ VisualEffectResource:
       - nameId: indirectBuffer
         index: 5
       values:
+      - nameId: solverData_Fluid_SmoothingDistance_a
+        index: 105
+      - nameId: solverData_Fluid_ParticleMass_a
+        index: 106
+      - nameId: solverData_Fluid_Density_a
+        index: 107
+      - nameId: solverData_Fluid_MinimumDensity_a
+        index: 108
+      - nameId: solverData_Fluid_GasConstant_a
+        index: 109
+      - nameId: solverData_Fluid_Viscosity_a
+        index: 110
+      - nameId: solverData_Fluid_TurbulenceProbability_a
+        index: 111
+      - nameId: solverData_Fluid_SurfaceTension_a
+        index: 112
+      - nameId: solverData_Fluid_BuoyancyCoefficient_a
+        index: 113
       - nameId: solverData_Gravity_a
-        index: 19
+        index: 114
+      - nameId: solverData_KernelSize_a
+        index: 115
+      - nameId: solverData_KernelFactors_a
+        index: 101
       - nameId: dt_a
-        index: 5
+        index: 118
       params: []
       processor: {fileID: 0}
       shaderSourceIndex: 6
@@ -1829,7 +2574,7 @@ VisualEffectResource:
       values: []
       params: []
       processor: {fileID: 0}
-      shaderSourceIndex: 10
+      shaderSourceIndex: 9
     - type: 1073741826
       buffers:
       - nameId: attributeBuffer
@@ -1840,16 +2585,16 @@ VisualEffectResource:
         index: 4
       values:
       - nameId: Alpha_b
-        index: 14
+        index: 99
       - nameId: mainTexture
-        index: 32
+        index: 123
       params:
       - nameId: sortPriority
         index: 0
       - nameId: indirectDraw
         index: 1
       processor: {fileID: 0}
-      shaderSourceIndex: 9
+      shaderSourceIndex: 8
 --- !u!114 &8926484042661618129
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1865,7 +2610,7 @@ MonoBehaviour:
   m_Parent: {fileID: 114350483966674976}
   m_Children:
   - {fileID: 8926484042661618131}
-  m_UIPosition: {x: 1351.8771, y: 2.0297546}
+  m_UIPosition: {x: 1352, y: 2}
   m_UICollapsed: 0
   m_UISuperCollapsed: 0
   m_InputSlots: []
@@ -3067,7 +3812,7 @@ MonoBehaviour:
   m_Parent: {fileID: 114350483966674976}
   m_Children:
   - {fileID: 8926484042661618164}
-  m_UIPosition: {x: 1351.8771, y: 160.02975}
+  m_UIPosition: {x: 1352, y: 160}
   m_UICollapsed: 0
   m_UISuperCollapsed: 0
   m_InputSlots: []
@@ -3121,7 +3866,7 @@ MonoBehaviour:
   m_Parent: {fileID: 114350483966674976}
   m_Children:
   - {fileID: 8926484042661618167}
-  m_UIPosition: {x: 1351.8771, y: 283.02975}
+  m_UIPosition: {x: 1352, y: 283}
   m_UICollapsed: 0
   m_UISuperCollapsed: 0
   m_InputSlots: []
@@ -3175,7 +3920,7 @@ MonoBehaviour:
   m_Parent: {fileID: 114350483966674976}
   m_Children:
   - {fileID: 8926484042661618170}
-  m_UIPosition: {x: 1351.8771, y: 406.02975}
+  m_UIPosition: {x: 1352, y: 406}
   m_UICollapsed: 0
   m_UISuperCollapsed: 0
   m_InputSlots: []
@@ -3188,7 +3933,7 @@ MonoBehaviour:
       slotIndex: 0
   m_OutputFlowSlot:
   - link:
-    - context: {fileID: 8926484042661618180}
+    - context: {fileID: 8926484042661618171}
       slotIndex: 0
   integration: 1
   angularIntegration: 1
@@ -3229,7 +3974,7 @@ MonoBehaviour:
   m_Parent: {fileID: 114350483966674976}
   m_Children:
   - {fileID: 8926484042661618173}
-  m_UIPosition: {x: 1351.8771, y: 842.0298}
+  m_UIPosition: {x: 1352, y: 532}
   m_UICollapsed: 0
   m_UISuperCollapsed: 0
   m_InputSlots: []
@@ -3238,7 +3983,7 @@ MonoBehaviour:
   m_Data: {fileID: 8926484042661618195}
   m_InputFlowSlot:
   - link:
-    - context: {fileID: 8926484042661618180}
+    - context: {fileID: 8926484042661618168}
       slotIndex: 0
   m_OutputFlowSlot:
   - link:
@@ -3262,7 +4007,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Parent: {fileID: 8926484042661618171}
   m_Children: []
-  m_UIPosition: {x: 1393.8771, y: -356.97025}
+  m_UIPosition: {x: 0, y: 2}
   m_UICollapsed: 1
   m_UISuperCollapsed: 0
   m_InputSlots: []
@@ -3283,7 +4028,7 @@ MonoBehaviour:
   m_Parent: {fileID: 114350483966674976}
   m_Children:
   - {fileID: 8926484042661618176}
-  m_UIPosition: {x: 1351.8771, y: 965.0298}
+  m_UIPosition: {x: 1352, y: 655}
   m_UICollapsed: 0
   m_UISuperCollapsed: 0
   m_InputSlots: []
@@ -3316,7 +4061,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Parent: {fileID: 8926484042661618174}
   m_Children: []
-  m_UIPosition: {x: 1393.8771, y: -356.97025}
+  m_UIPosition: {x: 0, y: 2}
   m_UICollapsed: 0
   m_UISuperCollapsed: 0
   m_InputSlots: []
@@ -3326,7 +4071,6 @@ MonoBehaviour:
   Turbulence: 1
   Gravity: 1
   BuoyancyForce: 1
-  Collision: 1
 --- !u!114 &8926484042661618177
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3342,7 +4086,7 @@ MonoBehaviour:
   m_Parent: {fileID: 114350483966674976}
   m_Children:
   - {fileID: 8926484042661618179}
-  m_UIPosition: {x: 1350.8771, y: 1348.0298}
+  m_UIPosition: {x: 539, y: 915}
   m_UICollapsed: 0
   m_UISuperCollapsed: 0
   m_InputSlots: []
@@ -3375,46 +4119,13 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Parent: {fileID: 8926484042661618177}
   m_Children: []
-  m_UIPosition: {x: 1393.8771, y: -356.97025}
+  m_UIPosition: {x: 0, y: 2}
   m_UICollapsed: 0
   m_UISuperCollapsed: 0
   m_InputSlots: []
   m_OutputSlots: []
   m_Disabled: 0
   IntegrationMode: 0
---- !u!114 &8926484042661618180
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2dc095764ededfa4bb32fa602511ea4b, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 114350483966674976}
-  m_Children: []
-  m_UIPosition: {x: 888.8771, y: 692.0298}
-  m_UICollapsed: 0
-  m_UISuperCollapsed: 0
-  m_InputSlots: []
-  m_OutputSlots: []
-  m_Label: 
-  m_Data: {fileID: 8926484042661618195}
-  m_InputFlowSlot:
-  - link:
-    - context: {fileID: 8926484042661618168}
-      slotIndex: 0
-  m_OutputFlowSlot:
-  - link:
-    - context: {fileID: 8926484042661618171}
-      slotIndex: 0
-  integration: 1
-  angularIntegration: 1
-  ageParticles: 0
-  reapParticles: 0
 --- !u!114 &8926484042661618182
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3430,7 +4141,7 @@ MonoBehaviour:
   m_Parent: {fileID: 114350483966674976}
   m_Children:
   - {fileID: 8926484042661618183}
-  m_UIPosition: {x: 2109.877, y: -1383.9702}
+  m_UIPosition: {x: 264, y: -950}
   m_UICollapsed: 0
   m_UISuperCollapsed: 0
   m_InputSlots: []
@@ -3458,7 +4169,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Parent: {fileID: 8926484042661618182}
   m_Children: []
-  m_UIPosition: {x: 1393.8771, y: -356.97025}
+  m_UIPosition: {x: 0, y: 2}
   m_UICollapsed: 0
   m_UISuperCollapsed: 0
   m_InputSlots:
@@ -3528,7 +4239,7 @@ MonoBehaviour:
   - {fileID: 8926484042661618196}
   - {fileID: 8926484042661618198}
   - {fileID: 8926484042661618208}
-  m_UIPosition: {x: 2109.877, y: -1193.9702}
+  m_UIPosition: {x: 264, y: -760}
   m_UICollapsed: 0
   m_UISuperCollapsed: 0
   m_InputSlots:
@@ -3885,7 +4596,6 @@ MonoBehaviour:
   - {fileID: 8926484042661618162}
   - {fileID: 8926484042661618165}
   - {fileID: 8926484042661618168}
-  - {fileID: 8926484042661618180}
   - {fileID: 8926484042661618171}
   - {fileID: 8926484042661618174}
   - {fileID: 8926484042661618177}
@@ -3906,7 +4616,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Parent: {fileID: 8926484042661618185}
   m_Children: []
-  m_UIPosition: {x: 1393.8771, y: -356.97025}
+  m_UIPosition: {x: 0, y: 2}
   m_UICollapsed: 0
   m_UISuperCollapsed: 0
   m_InputSlots:
@@ -3966,7 +4676,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Parent: {fileID: 8926484042661618185}
   m_Children: []
-  m_UIPosition: {x: 1393.8771, y: -204.97025}
+  m_UIPosition: {x: 0, y: 77}
   m_UICollapsed: 0
   m_UISuperCollapsed: 0
   m_InputSlots:
@@ -4344,7 +5054,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Parent: {fileID: 8926484042661618185}
   m_Children: []
-  m_UIPosition: {x: 1393.8771, y: -281.97025}
+  m_UIPosition: {x: 0, y: 326}
   m_UICollapsed: 0
   m_UISuperCollapsed: 0
   m_InputSlots:
@@ -4640,7 +5350,7 @@ MonoBehaviour:
   m_Children:
   - {fileID: 8926484042661618219}
   - {fileID: 8926484042661618220}
-  m_UIPosition: {x: 2108.877, y: 1774.0298}
+  m_UIPosition: {x: 539, y: 1238}
   m_UICollapsed: 0
   m_UISuperCollapsed: 0
   m_InputSlots:
@@ -4714,7 +5424,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Parent: {fileID: 8926484042661618216}
   m_Children: []
-  m_UIPosition: {x: 1393.8771, y: -356.97025}
+  m_UIPosition: {x: 0, y: 2}
   m_UICollapsed: 0
   m_UISuperCollapsed: 0
   m_InputSlots: []
@@ -4735,7 +5445,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Parent: {fileID: 8926484042661618216}
   m_Children: []
-  m_UIPosition: {x: 1393.8771, y: -358.97025}
+  m_UIPosition: {x: 0, y: 74}
   m_UICollapsed: 0
   m_UISuperCollapsed: 0
   m_InputSlots:
@@ -4797,7 +5507,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Parent: {fileID: 114350483966674976}
   m_Children: []
-  m_UIPosition: {x: 859.8771, y: 66.029755}
+  m_UIPosition: {x: 860, y: 66}
   m_UICollapsed: 0
   m_UISuperCollapsed: 0
   m_InputSlots:

--- a/Editor/Types/Fluid.cs
+++ b/Editor/Types/Fluid.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using UnityEditor.VFX;
 using UnityEngine;
 using UnityEngine.Experimental.VFX;
@@ -56,5 +58,21 @@ namespace Thinksquirrel.FluvioFX.Editor
             SurfaceTension = 0.728f,
             BuoyancyCoefficient = 0.0f,
         };
+
+        internal IEnumerable<VFXNamedExpression> defaultExpressions
+        {
+            get
+            {
+                yield return new VFXNamedExpression(VFXValue.Constant(SmoothingDistance), nameof(SmoothingDistance));
+                yield return new VFXNamedExpression(VFXValue.Constant(ParticleMass), nameof(ParticleMass));
+                yield return new VFXNamedExpression(VFXValue.Constant(Density), nameof(Density));
+                yield return new VFXNamedExpression(VFXValue.Constant(MinimumDensity), nameof(MinimumDensity));
+                yield return new VFXNamedExpression(VFXValue.Constant(GasConstant), nameof(GasConstant));
+                yield return new VFXNamedExpression(VFXValue.Constant(Viscosity), nameof(Viscosity));
+                yield return new VFXNamedExpression(VFXValue.Constant(TurbulenceProbability), nameof(TurbulenceProbability));
+                yield return new VFXNamedExpression(VFXValue.Constant(SurfaceTension), nameof(SurfaceTension));
+                yield return new VFXNamedExpression(VFXValue.Constant(BuoyancyCoefficient), nameof(BuoyancyCoefficient));
+            }
+        }
     }
 }

--- a/Editor/Types/SolverData.cs
+++ b/Editor/Types/SolverData.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using UnityEditor.VFX;
 using UnityEngine;
 using UnityEngine.Experimental.VFX;
@@ -24,5 +26,61 @@ namespace Thinksquirrel.FluvioFX.Editor
             Tex = null,
             TexSize = Vector2.zero,
         };
+
+        internal IEnumerable<VFXNamedExpression> defaultExpressions
+        {
+            get
+            {
+                var fluidExpressions =
+                    Fluid.defaultExpressions.Select((expression) =>
+                    {
+                        expression.name = $"Fluid_{expression.name}";
+                        return expression;
+                    });
+
+                foreach (var exp in fluidExpressions)
+                {
+                    yield return exp;
+                }
+
+                yield return new VFXNamedExpression(
+                    new VFXExpressionCombine(new []
+                    {
+                        VFXValue.Constant(Gravity.vector.x),
+                            VFXValue.Constant(Gravity.vector.y),
+                            VFXValue.Constant(Gravity.vector.z)
+                    }),
+                    nameof(Gravity));
+
+                yield return new VFXNamedExpression(
+                    new VFXExpressionCombine(new []
+                    {
+                        VFXValue.Constant(KernelSize.x),
+                            VFXValue.Constant(KernelSize.y),
+                            VFXValue.Constant(KernelSize.z),
+                            VFXValue.Constant(KernelSize.w),
+                    }),
+                    nameof(KernelSize));
+
+                yield return new VFXNamedExpression(
+                    new VFXExpressionCombine(new []
+                    {
+                        VFXValue.Constant(KernelFactors.x),
+                            VFXValue.Constant(KernelFactors.y),
+                            VFXValue.Constant(KernelFactors.z),
+                            VFXValue.Constant(KernelFactors.w),
+                    }),
+                    nameof(KernelFactors));
+
+                // yield return new VFXNamedExpression(VFXValue.Constant(Tex), nameof(Tex));
+                // yield return new VFXNamedExpression(
+                //     new VFXExpressionCombine(new[]
+                //     {
+                //         VFXValue.Constant(TexSize.x),
+                //         VFXValue.Constant(TexSize.y),
+                //     }),
+                //     nameof(TexSize));
+            }
+        }
     }
 }

--- a/Editor/Utils/FluvioFXAttribute.cs
+++ b/Editor/Utils/FluvioFXAttribute.cs
@@ -13,10 +13,12 @@ namespace Thinksquirrel.FluvioFX.Editor
     {
         public static VFXAttribute DensityPressure => new VFXAttribute("densityPressure", VFXValue.Constant<Vector4>());
         public static VFXAttribute Normal => new VFXAttribute("normal", VFXValue.Constant<Vector4>());
-        public static VFXAttribute VorticityTurbulence => new VFXAttribute("vorticityTurbulence", VFXValue.Constant<Vector4>());
+        public static VFXAttribute VorticityTurbulence =>
+            new VFXAttribute("vorticityTurbulence", VFXValue.Constant<Vector4>());
         public static VFXAttribute Force => new VFXAttribute("force", VFXValue.Constant<Vector3>());
         public static VFXAttribute GridIndex => new VFXAttribute("gridIndex", VFXValue.Constant<uint>());
         public static VFXAttribute NeighborCount => new VFXAttribute("neighborCount", VFXValue.Constant<uint>());
+
         public static string GetLoadAttributeCode(VFXBlock block, VFXAttribute attribute, string name, string index)
         {
             var r = new VFXShaderWriter();

--- a/Editor/Utils/FluvioFXCollisionUtility.cs
+++ b/Editor/Utils/FluvioFXCollisionUtility.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Thinksquirrel.FluvioFX.Editor.Blocks;
+using UnityEditor.VFX;
+using UnityEditor.VFX.Block;
+using UnityEngine;
+
+namespace Thinksquirrel.FluvioFX.Editor
+{
+    internal static class FluvioFXCollisionUtility
+    {
+        public class DensityProperties
+        {
+            [Min(0.0f)]
+            public float ParticleMass = 0.0f;
+
+            [Range(1.0f, 16.0f)]
+            public float Resolution = 4.0f;
+        }
+        public static IEnumerable<VFXPropertyWithValue> GetInputProperties(
+            IEnumerable<VFXPropertyWithValue> baseProperties,
+            bool density)
+        {
+            var properties = baseProperties;
+            if (density)
+            {
+                properties = properties
+                    .Concat(FluvioFXBlock.PropertiesFromType(typeof(DensityProperties)));
+            }
+
+            return properties;
+        }
+
+        public static IEnumerable<VFXNamedExpression> GetParameters(
+            VFXBlock block,
+            IEnumerable<VFXNamedExpression> baseParameters)
+        {
+            var expressions = block.parameters;
+            expressions.Concat(FluvioFXBlock.GetSolverDataExpressions(block));
+            expressions.Concat(FluvioFXBlock.GetExpressionsFromSlots(block));
+            foreach (var exp in expressions)
+            {
+                yield return exp;
+            };
+        }
+
+        public static IEnumerable<VFXAttributeInfo> GetAttributes(IEnumerable<VFXAttributeInfo> baseAttributes)
+        {
+            foreach (var attribute in baseAttributes)
+            {
+                yield return attribute;
+            }
+
+            yield return new VFXAttributeInfo(VFXAttribute.Mass, VFXAttributeMode.Read);
+            yield return new VFXAttributeInfo(FluvioFXAttribute.DensityPressure, VFXAttributeMode.ReadWrite);
+        }
+
+        public static string GetCollisionSource(string originalSource, string collisionResponseSource, bool density)
+        {
+            if (!density)
+            {
+                return originalSource;
+            }
+
+            var densityTestSource = originalSource
+                .Replace("float3 nextPos = position + velocity * deltaTime;", "")
+                .Replace("nextPos", "proxyPosition")
+                .Replace("position", "dummyPosition")
+                .Replace(collisionResponseSource, "    collisionTest = true;");
+
+            var split = densityTestSource.Split(new []
+            {
+                "\r\n",
+                "\r",
+                "\n"
+            }, StringSplitOptions.None);
+            densityTestSource = string.Join("\n            ", split);
+
+            return $@"
+{{
+    float3 offset, proxyPosition, dummyPosition, dist;
+    float density = 0;
+    uint colliderIndex;
+    float pressure, distLenSq;
+    bool collisionTest = false;
+
+    float searchRadius = 2 * solverData_KernelSize.x;
+    float step = solverData_KernelSize.x * (1.0f / Resolution);
+
+    // Density calculation
+    for(float x = -searchRadius; x < searchRadius; x += step)
+    {{
+        for(float y = -searchRadius; y < searchRadius; y += step)
+        {{
+            for(float z = -searchRadius; z < searchRadius; z += step)
+            {{
+                // Get proxy particle position
+                offset = float3(x, y, z);
+                proxyPosition = position + offset;
+                {densityTestSource}
+
+                if (collisionTest)
+                {{
+                    // Range check
+                    dist = position - proxyPosition;
+                    distLenSq = dot(dist, dist);
+                    if (distLenSq < solverData_KernelSize.y && distLenSq > FLUVIO_EPSILON)
+                    {{
+                        // Sum density
+                        density += ParticleMass * Poly6Calculate(dist, solverData_KernelFactors.x, solverData_KernelSize.y);
+                    }}
+                }}
+            }}
+        }}
+    }}
+
+    // Write to density/pressure
+    density = max(densityPressure.x + density, solverData_Fluid_MinimumDensity);
+    pressure = solverData_Fluid_GasConstant * (density - solverData_Fluid_Density);
+    densityPressure = float4(density, densityPressure.y, pressure, densityPressure.w);
+}}
+{originalSource}";
+        }
+    };
+}

--- a/Editor/Utils/FluvioFXCollisionUtility.cs
+++ b/Editor/Utils/FluvioFXCollisionUtility.cs
@@ -18,6 +18,17 @@ namespace Thinksquirrel.FluvioFX.Editor
             [Range(1.0f, 16.0f)]
             public float Resolution = 4.0f;
         }
+
+        public static IEnumerable<string> GetIncludes(
+            IEnumerable<string> baseIncludes)
+        {
+            foreach (var include in baseIncludes)
+            {
+                yield return include;
+            }
+            yield return $"{PackageInfo.assetPackagePath}/Shaders/FluvioCompute.cginc";
+        }
+
         public static IEnumerable<VFXPropertyWithValue> GetInputProperties(
             IEnumerable<VFXPropertyWithValue> baseProperties,
             bool density)
@@ -36,12 +47,12 @@ namespace Thinksquirrel.FluvioFX.Editor
             VFXBlock block,
             IEnumerable<VFXNamedExpression> baseParameters)
         {
-            var expressions = block.parameters;
-            expressions.Concat(FluvioFXBlock.GetSolverDataExpressions(block));
-            expressions.Concat(FluvioFXBlock.GetExpressionsFromSlots(block));
-            foreach (var exp in expressions)
+            var expressions = baseParameters;
+            expressions = expressions.Concat(FluvioFXBlock.GetSolverDataExpressions(block));
+
+            foreach (var expression in expressions)
             {
-                yield return exp;
+                yield return expression;
             };
         }
 
@@ -98,6 +109,9 @@ namespace Thinksquirrel.FluvioFX.Editor
                 // Get proxy particle position
                 offset = float3(x, y, z);
                 proxyPosition = position + offset;
+
+                // Snap to grid to prevent jitter
+                proxyPosition = round(proxyPosition / step) * step;
                 {densityTestSource}
 
                 if (collisionTest)

--- a/Editor/Utils/FluvioFXCollisionUtility.cs
+++ b/Editor/Utils/FluvioFXCollisionUtility.cs
@@ -168,10 +168,7 @@ namespace Thinksquirrel.FluvioFX.Editor
     float searchRadius = solverData_KernelSize.x;
     float step = solverData_KernelSize.x * 0.5f;
 
-    {(settings.RoughSurface ? @"float3 gridJitter = float3(FIXED_RAND3(0x5f7b48e2))
-        * (1.0f / 4294967296.0f)
-        * step
-        * Roughness" : "")};
+    float3 gridJitter = float3(FIXED_RAND3(0x5f7b48e2)) * step;
 
     float x, y, z;
 

--- a/Editor/Utils/FluvioFXCollisionUtility.cs.meta
+++ b/Editor/Utils/FluvioFXCollisionUtility.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 08162818331c7d649b4567157c75ade1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Shaders/FluvioCompute.cginc
+++ b/Shaders/FluvioCompute.cginc
@@ -1,6 +1,7 @@
 #ifndef FLUVIO_COMPUTE_INCLUDED
 #define FLUVIO_COMPUTE_INCLUDED
 #define FLUVIO_PI 3.14159265359f
+#define FLUVIO_TAU 3.14159265359f * 2.0f
 
 // Simulation constants - these cannot be changed at this time
 #define FLUVIO_EPSILON 9.99999944e-11f // FluvioFXSettings.kEpsilon


### PR DESCRIPTION
(resolves #12)

Implements collision, along with some other stability fixes

**Breaking changes:**
- Particles were not correctly being assigned any mass. Setting the fluid's particle mass to 1 should more closely resemble older behavior
- Resolved a bug with verlet integration, where some velocities were applied twice. Fluids may need modification to compensate

**Additions:**
Added fluid collider components for all VFX collider types. These colliders simulate forces against proxy particles as they approach the surface of an object. This leads to more accurate behavior when filling volumes, as fluids no longer overcompress near boundaries.

Fluid colliders can be found under in the blocks menu under _FluvioFX > Collision_.

**Other changes:**
- Automatically fetch solver data from the InitializeSolver node in subsequent nodes. This significantly reduces the number of connectors and cleans up the graph
- The default template now includes information on colliders