### PR TITLE
Unity 2019.2 support

### DIFF
--- a/Editor/Blocks/Solver/FluvioFXBlock.cs
+++ b/Editor/Blocks/Solver/FluvioFXBlock.cs
@@ -20,7 +20,7 @@ namespace Thinksquirrel.FluvioFX.Editor.Blocks
         {
             get
             {
-                return VFXContextType.kUpdate;
+                return VFXContextType.Update;
             }
         }
 
@@ -28,7 +28,7 @@ namespace Thinksquirrel.FluvioFX.Editor.Blocks
         {
             get
             {
-                return VFXDataType.kParticle;
+                return VFXDataType.Particle;
             }
         }
 
@@ -97,7 +97,7 @@ namespace Thinksquirrel.FluvioFX.Editor.Blocks
                 int hash = 0;
                 foreach (var setting in settings)
                 {
-                    var value = setting.GetValue(this);
+                    var value = setting.value;
                     hash = (hash * 397) ^ value.GetHashCode();
                 }
                 return string.Format("{0}_{1}", GetType().Name, hash.ToString("X"));

--- a/Editor/Templates/Fluid Particle System.vfx
+++ b/Editor/Templates/Fluid Particle System.vfx
@@ -16,10 +16,10 @@ MonoBehaviour:
   - title: '[FluvioFX] Fluid simulation'
     position:
       serializedVersion: 2
-      x: 991
-      y: -60
-      width: 1103
-      height: 1037
+      x: 982
+      y: -58
+      width: 1112
+      height: 1004
     contents:
     - model: {fileID: 8926484042661618129}
       id: 0
@@ -66,22 +66,7 @@ MonoBehaviour:
     - model: {fileID: 8926484042661618440}
       id: 0
       isStickyNote: 0
-    - model: {fileID: 8926484042661618458}
-      id: 0
-      isStickyNote: 0
-    - model: {fileID: 8926484042661618435}
-      id: 0
-      isStickyNote: 0
-    - model: {fileID: 8926484042661618436}
-      id: 0
-      isStickyNote: 0
-    - model: {fileID: 8926484042661618437}
-      id: 0
-      isStickyNote: 0
-    - model: {fileID: 8926484042661618438}
-      id: 0
-      isStickyNote: 0
-    - model: {fileID: 8926484042661618455}
+    - model: {fileID: 8926484042661618597}
       id: 0
       isStickyNote: 0
   - title: '[FluvioFX] Update and integrate'
@@ -98,22 +83,7 @@ MonoBehaviour:
     - model: {fileID: 0}
       id: 8
       isStickyNote: 1
-    - model: {fileID: 8926484042661618179}
-      id: 0
-      isStickyNote: 0
     - model: {fileID: 8926484042661618543}
-      id: 0
-      isStickyNote: 0
-    - model: {fileID: 8926484042661618557}
-      id: 0
-      isStickyNote: 0
-    - model: {fileID: 8926484042661618549}
-      id: 0
-      isStickyNote: 0
-    - model: {fileID: 8926484042661618563}
-      id: 0
-      isStickyNote: 0
-    - model: {fileID: 8926484042661618552}
       id: 0
       isStickyNote: 0
   stickyNoteInfos:
@@ -193,7 +163,7 @@ MonoBehaviour:
   - title: Fluid properties
     position:
       serializedVersion: 2
-      x: 1052
+      x: 1050
       y: 258
       width: 281
       height: 161
@@ -206,8 +176,8 @@ MonoBehaviour:
   - title: Gravity
     position:
       serializedVersion: 2
-      x: 1131
-      y: 559
+      x: 1126
+      y: 561
       width: 202
       height: 100
     contents: The gravity vector for simulation can be changed here. In addition to
@@ -229,10 +199,10 @@ MonoBehaviour:
   categories: []
   uiBounds:
     serializedVersion: 2
-    x: 257
+    x: 505
     y: -912
-    width: 1837
-    height: 2670
+    width: 1589
+    height: 2733
 --- !u!114 &114350483966674976
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -257,16 +227,17 @@ MonoBehaviour:
   - {fileID: 8926484042661618182}
   - {fileID: 8926484042661618185}
   - {fileID: 8926484042661618440}
-  - {fileID: 8926484042661618458}
   - {fileID: 8926484042661618543}
-  - {fileID: 8926484042661618552}
+  - {fileID: 8926484042661618597}
   m_UIPosition: {x: 0, y: 0}
   m_UICollapsed: 1
   m_UISuperCollapsed: 0
   m_UIInfos: {fileID: 114340500867371532}
   m_ParameterInfo: []
-  m_GraphVersion: 1
+  m_GraphVersion: 2
   m_saved: 1
+  m_SubgraphDependencies: []
+  m_CategoryPath: 
 --- !u!2058629511 &8926484042661614527
 VisualEffectResource:
   m_ObjectHideFlags: 0
@@ -281,11 +252,12 @@ VisualEffectResource:
     source: "\r\n// FluvioFX simulation constants\r\n#define FLUVIO_EPSILON 9.999999E-11\r\n#define
       FLUVIO_MAX_SQR_VELOCITY_CHANGE 10000\r\n#define FLUVIO_MAX_BUCKET_COUNT 32\r\n#define
       FLUVIO_MAX_NEIGHBOR_COUNT 863\r\n#define FLUVIO_AUTO_PARTICLE_SIZE_FACTOR 0.25\r\n#define
-      FLUVIO_MAX_GRID_SIZE 21\r\n\r\n#pragma kernel CSMain\n#include \"HLSLSupport.cginc\"\n#define
-      NB_THREADS_PER_GROUP 64\n#define VFX_USE_LIFETIME_CURRENT 1\n#define VFX_USE_FORCE_CURRENT
-      1\n#define VFX_USE_MASS_CURRENT 1\n#define VFX_USE_SIZE_CURRENT 1\n#define VFX_USE_ALIVE_CURRENT
+      FLUVIO_MAX_GRID_SIZE 21\r\n\r\n#pragma kernel CSMain\n#define NB_THREADS_PER_GROUP
+      64\n#define VFX_USE_LIFETIME_CURRENT 1\n#define VFX_USE_FORCE_CURRENT 1\n#define
+      VFX_USE_MASS_CURRENT 1\n#define VFX_USE_SIZE_CURRENT 1\n#define VFX_USE_ALIVE_CURRENT
       1\n#define VFX_USE_AGE_CURRENT 1\n#define VFX_HAS_INDIRECT_DRAW 1\n#define VFX_WORLD_SPACE
-      1\n\n\n\n#include \"Packages/com.unity.visualeffectgraph/Shaders/Common/VFXCommonCompute.cginc\"\n#include
+      1\n#include \"Packages/com.unity.visualeffectgraph/Shaders/RenderPipeline/HDRP/VFXDefines.hlsl\"\n\n\n\n#include
+      \"Packages/com.unity.visualeffectgraph/Shaders/Common/VFXCommonCompute.cginc\"\n#include
       \"Packages/com.unity.visualeffectgraph/Shaders/VFXCommon.cginc\"\n#include \"Packages/com.thinksquirrel.fluviofx/Shaders/FluvioCompute.cginc\"\n\n\n\nRWByteAddressBuffer
       attributeBuffer;\n\n#if VFX_USE_ALIVE_CURRENT\nRWStructuredBuffer<uint> deadListOut;\n#endif\n\n#if
       VFX_HAS_INDIRECT_DRAW\nRWStructuredBuffer<uint> indirectBuffer;\n#endif\n\nCBUFFER_START(updateParams)\n
@@ -329,9 +301,10 @@ VisualEffectResource:
     source: "\r\n// FluvioFX simulation constants\r\n#define FLUVIO_EPSILON 9.999999E-11\r\n#define
       FLUVIO_MAX_SQR_VELOCITY_CHANGE 10000\r\n#define FLUVIO_MAX_BUCKET_COUNT 32\r\n#define
       FLUVIO_MAX_NEIGHBOR_COUNT 863\r\n#define FLUVIO_AUTO_PARTICLE_SIZE_FACTOR 0.25\r\n#define
-      FLUVIO_MAX_GRID_SIZE 21\r\n\r\n#pragma kernel CSMain\n#include \"HLSLSupport.cginc\"\n#define
-      NB_THREADS_PER_GROUP 64\n#define VFX_USE_POSITION_CURRENT 1\n#define VFX_HAS_INDIRECT_DRAW
-      1\n#define VFX_WORLD_SPACE 1\n\n\n\n#include \"Packages/com.unity.visualeffectgraph/Shaders/Common/VFXCommonCompute.cginc\"\n#include
+      FLUVIO_MAX_GRID_SIZE 21\r\n\r\n#pragma kernel CSMain\n#define NB_THREADS_PER_GROUP
+      64\n#define VFX_USE_POSITION_CURRENT 1\n#define VFX_HAS_INDIRECT_DRAW 1\n#define
+      VFX_WORLD_SPACE 1\n#include \"Packages/com.unity.visualeffectgraph/Shaders/RenderPipeline/HDRP/VFXDefines.hlsl\"\n\n\n\n#include
+      \"Packages/com.unity.visualeffectgraph/Shaders/Common/VFXCommonCompute.cginc\"\n#include
       \"Packages/com.unity.visualeffectgraph/Shaders/VFXCommon.cginc\"\n#include \"Packages/com.thinksquirrel.fluviofx/Shaders/FluvioCompute.cginc\"\n\n\n\nRWByteAddressBuffer
       attributeBuffer;\n\n#if VFX_USE_ALIVE_CURRENT\nRWStructuredBuffer<uint> deadListOut;\n#endif\n\n#if
       VFX_HAS_INDIRECT_DRAW\nRWStructuredBuffer<uint> indirectBuffer;\n#endif\n\nCBUFFER_START(updateParams)\n
@@ -365,9 +338,9 @@ VisualEffectResource:
     source: "\r\n// FluvioFX simulation constants\r\n#define FLUVIO_EPSILON 9.999999E-11\r\n#define
       FLUVIO_MAX_SQR_VELOCITY_CHANGE 10000\r\n#define FLUVIO_MAX_BUCKET_COUNT 32\r\n#define
       FLUVIO_MAX_NEIGHBOR_COUNT 863\r\n#define FLUVIO_AUTO_PARTICLE_SIZE_FACTOR 0.25\r\n#define
-      FLUVIO_MAX_GRID_SIZE 21\r\n\r\n#pragma kernel CSMain\n#include \"HLSLSupport.cginc\"\n#define
-      NB_THREADS_PER_GROUP 64\n#define VFX_USE_POSITION_CURRENT 1\n#define VFX_USE_NEIGHBORCOUNT_CURRENT
-      1\n#define VFX_HAS_INDIRECT_DRAW 1\n#define VFX_WORLD_SPACE 1\n\n\n\n#include
+      FLUVIO_MAX_GRID_SIZE 21\r\n\r\n#pragma kernel CSMain\n#define NB_THREADS_PER_GROUP
+      64\n#define VFX_USE_POSITION_CURRENT 1\n#define VFX_USE_NEIGHBORCOUNT_CURRENT
+      1\n#define VFX_HAS_INDIRECT_DRAW 1\n#define VFX_WORLD_SPACE 1\n#include \"Packages/com.unity.visualeffectgraph/Shaders/RenderPipeline/HDRP/VFXDefines.hlsl\"\n\n\n\n#include
       \"Packages/com.unity.visualeffectgraph/Shaders/Common/VFXCommonCompute.cginc\"\n#include
       \"Packages/com.unity.visualeffectgraph/Shaders/VFXCommon.cginc\"\n#include \"Packages/com.thinksquirrel.fluviofx/Shaders/FluvioCompute.cginc\"\n\n\n\nRWByteAddressBuffer
       attributeBuffer;\n\n#if VFX_USE_ALIVE_CURRENT\nRWStructuredBuffer<uint> deadListOut;\n#endif\n\n#if
@@ -419,10 +392,10 @@ VisualEffectResource:
     source: "\r\n// FluvioFX simulation constants\r\n#define FLUVIO_EPSILON 9.999999E-11\r\n#define
       FLUVIO_MAX_SQR_VELOCITY_CHANGE 10000\r\n#define FLUVIO_MAX_BUCKET_COUNT 32\r\n#define
       FLUVIO_MAX_NEIGHBOR_COUNT 863\r\n#define FLUVIO_AUTO_PARTICLE_SIZE_FACTOR 0.25\r\n#define
-      FLUVIO_MAX_GRID_SIZE 21\r\n\r\n#pragma kernel CSMain\n#include \"HLSLSupport.cginc\"\n#define
-      NB_THREADS_PER_GROUP 64\n#define VFX_USE_POSITION_CURRENT 1\n#define VFX_USE_MASS_CURRENT
-      1\n#define VFX_USE_NEIGHBORCOUNT_CURRENT 1\n#define VFX_USE_DENSITYPRESSURE_CURRENT
-      1\n#define VFX_HAS_INDIRECT_DRAW 1\n#define VFX_WORLD_SPACE 1\n\n\n\n#include
+      FLUVIO_MAX_GRID_SIZE 21\r\n\r\n#pragma kernel CSMain\n#define NB_THREADS_PER_GROUP
+      64\n#define VFX_USE_POSITION_CURRENT 1\n#define VFX_USE_MASS_CURRENT 1\n#define
+      VFX_USE_NEIGHBORCOUNT_CURRENT 1\n#define VFX_USE_DENSITYPRESSURE_CURRENT 1\n#define
+      VFX_HAS_INDIRECT_DRAW 1\n#define VFX_WORLD_SPACE 1\n#include \"Packages/com.unity.visualeffectgraph/Shaders/RenderPipeline/HDRP/VFXDefines.hlsl\"\n\n\n\n#include
       \"Packages/com.unity.visualeffectgraph/Shaders/Common/VFXCommonCompute.cginc\"\n#include
       \"Packages/com.unity.visualeffectgraph/Shaders/VFXCommon.cginc\"\n#include \"Packages/com.thinksquirrel.fluviofx/Shaders/FluvioCompute.cginc\"\n\n\n\nRWByteAddressBuffer
       attributeBuffer;\n\n#if VFX_USE_ALIVE_CURRENT\nRWStructuredBuffer<uint> deadListOut;\n#endif\n\n#if
@@ -476,11 +449,12 @@ VisualEffectResource:
     source: "\r\n// FluvioFX simulation constants\r\n#define FLUVIO_EPSILON 9.999999E-11\r\n#define
       FLUVIO_MAX_SQR_VELOCITY_CHANGE 10000\r\n#define FLUVIO_MAX_BUCKET_COUNT 32\r\n#define
       FLUVIO_MAX_NEIGHBOR_COUNT 863\r\n#define FLUVIO_AUTO_PARTICLE_SIZE_FACTOR 0.25\r\n#define
-      FLUVIO_MAX_GRID_SIZE 21\r\n\r\n#pragma kernel CSMain\n#include \"HLSLSupport.cginc\"\n#define
-      NB_THREADS_PER_GROUP 64\n#define VFX_USE_POSITION_CURRENT 1\n#define VFX_USE_MASS_CURRENT
-      1\n#define VFX_USE_NEIGHBORCOUNT_CURRENT 1\n#define VFX_USE_DENSITYPRESSURE_CURRENT
-      1\n#define VFX_USE_NORMAL_CURRENT 1\n#define VFX_HAS_INDIRECT_DRAW 1\n#define
-      VFX_WORLD_SPACE 1\n\n\n\n#include \"Packages/com.unity.visualeffectgraph/Shaders/Common/VFXCommonCompute.cginc\"\n#include
+      FLUVIO_MAX_GRID_SIZE 21\r\n\r\n#pragma kernel CSMain\n#define NB_THREADS_PER_GROUP
+      64\n#define VFX_USE_POSITION_CURRENT 1\n#define VFX_USE_MASS_CURRENT 1\n#define
+      VFX_USE_NEIGHBORCOUNT_CURRENT 1\n#define VFX_USE_DENSITYPRESSURE_CURRENT 1\n#define
+      VFX_USE_NORMAL_CURRENT 1\n#define VFX_HAS_INDIRECT_DRAW 1\n#define VFX_WORLD_SPACE
+      1\n#include \"Packages/com.unity.visualeffectgraph/Shaders/RenderPipeline/HDRP/VFXDefines.hlsl\"\n\n\n\n#include
+      \"Packages/com.unity.visualeffectgraph/Shaders/Common/VFXCommonCompute.cginc\"\n#include
       \"Packages/com.unity.visualeffectgraph/Shaders/VFXCommon.cginc\"\n#include \"Packages/com.thinksquirrel.fluviofx/Shaders/FluvioCompute.cginc\"\n\n\n\nRWByteAddressBuffer
       attributeBuffer;\n\n#if VFX_USE_ALIVE_CURRENT\nRWStructuredBuffer<uint> deadListOut;\n#endif\n\n#if
       VFX_HAS_INDIRECT_DRAW\nRWStructuredBuffer<uint> indirectBuffer;\n#endif\n\nCBUFFER_START(updateParams)\n
@@ -533,13 +507,12 @@ VisualEffectResource:
     source: "\r\n// FluvioFX simulation constants\r\n#define FLUVIO_EPSILON 9.999999E-11\r\n#define
       FLUVIO_MAX_SQR_VELOCITY_CHANGE 10000\r\n#define FLUVIO_MAX_BUCKET_COUNT 32\r\n#define
       FLUVIO_MAX_NEIGHBOR_COUNT 863\r\n#define FLUVIO_AUTO_PARTICLE_SIZE_FACTOR 0.25\r\n#define
-      FLUVIO_MAX_GRID_SIZE 21\r\n\r\n#pragma kernel CSMain\n#include \"HLSLSupport.cginc\"\n#define
-      NB_THREADS_PER_GROUP 64\n#define VFX_USE_POSITION_CURRENT 1\n#define VFX_USE_VELOCITY_CURRENT
-      1\n#define VFX_USE_FORCE_CURRENT 1\n#define VFX_USE_MASS_CURRENT 1\n#define
-      VFX_USE_NEIGHBORCOUNT_CURRENT 1\n#define VFX_USE_DENSITYPRESSURE_CURRENT 1\n#define
-      VFX_USE_NORMAL_CURRENT 1\n#define VFX_HAS_INDIRECT_DRAW 1\n#define VFX_WORLD_SPACE
-      1\n\n\nCBUFFER_START(parameters)\n    float3 solverData_Gravity_a;\n    uint
-      PADDING_0;\nCBUFFER_END\n\n\n#include \"Packages/com.unity.visualeffectgraph/Shaders/Common/VFXCommonCompute.cginc\"\n#include
+      FLUVIO_MAX_GRID_SIZE 21\r\n\r\n#pragma kernel CSMain\n#define NB_THREADS_PER_GROUP
+      64\n#define VFX_USE_POSITION_CURRENT 1\n#define VFX_USE_VELOCITY_CURRENT 1\n#define
+      VFX_USE_FORCE_CURRENT 1\n#define VFX_USE_MASS_CURRENT 1\n#define VFX_USE_NEIGHBORCOUNT_CURRENT
+      1\n#define VFX_USE_DENSITYPRESSURE_CURRENT 1\n#define VFX_USE_NORMAL_CURRENT
+      1\n#define VFX_HAS_INDIRECT_DRAW 1\n#define VFX_WORLD_SPACE 1\n#include \"Packages/com.unity.visualeffectgraph/Shaders/RenderPipeline/HDRP/VFXDefines.hlsl\"\n\n\n\n#include
+      \"Packages/com.unity.visualeffectgraph/Shaders/Common/VFXCommonCompute.cginc\"\n#include
       \"Packages/com.unity.visualeffectgraph/Shaders/VFXCommon.cginc\"\n#include \"Packages/com.thinksquirrel.fluviofx/Shaders/FluvioCompute.cginc\"\n\n\n\nRWByteAddressBuffer
       attributeBuffer;\n\n#if VFX_USE_ALIVE_CURRENT\nRWStructuredBuffer<uint> deadListOut;\n#endif\n\n#if
       VFX_HAS_INDIRECT_DRAW\nRWStructuredBuffer<uint> indirectBuffer;\n#endif\n\nCBUFFER_START(updateParams)\n
@@ -550,32 +523,36 @@ VisualEffectResource:
       float solverData_Fluid_BuoyancyCoefficient, float4 solverData_KernelSize, float3
       solverData_KernelFactors, float3 solverData_Gravity) /*SurfaceTension:True Gravity:True
       BuoyancyForce:True */\n{\n    bool isAlive = (attributeBuffer.Load((index *
-      0x1 + 0x8D83C0) << 2));\n    if (!isAlive) return;\n    \n    float3 dist, f,
-      invNeighborDensity;\n    float lenSq, len, len3, diffSq, diff, scalar;\n    for
-      (uint j = 0; j < neighborCount; ++j)\n    {\n        uint neighborIndex = (attributeBuffer.Load((index
-      * 0x35F + 0x75C00 + (j)) << 2));\n    \n        float3 neighborPosition = asfloat(attributeBuffer.Load3((neighborIndex
-      * 0x4 + 0x2740) << 2));\n        float neighborMass = asfloat(attributeBuffer.Load((neighborIndex
-      * 0x1 + 0x1FE40) << 2));\n        float3 neighborVelocity = asfloat(attributeBuffer.Load3((neighborIndex
-      * 0x4 + 0xC440) << 2));\n        float4 neighborDensityPressure = asfloat(attributeBuffer.Load4((neighborIndex
-      * 0x4 + 0x8BACC0) << 2));\n    \n        dist = position - neighborPosition;\n
-      \   \n        // For kernels\n        lenSq = dot(dist, dist);\n        len
-      = sqrt(lenSq);\n        len3 = len * len * len;\n        diffSq = solverData_KernelSize.y
-      - lenSq;\n        diff = solverData_KernelSize.x - len;\n    \n        // Pressure
-      term\n        scalar = neighborMass\n            * (densityPressure.y + neighborDensityPressure.y)
-      / (neighborDensityPressure.x * 2.0f);\n        f = SpikyCalculateGradient(dist,
-      diff, len, solverData_KernelFactors.y);\n        f *= scalar;\n    \n        force
-      -= f;\n    \n        invNeighborDensity = 1.0f / neighborDensityPressure.x;\n
-      \   \n        // Viscosity term\n        scalar = neighborMass\n            *
-      ViscosityCalculateLaplacian(diff, solverData_KernelSize.z, solverData_KernelFactors.z)\n
-      \           * invNeighborDensity;\n    \n        f = neighborVelocity - velocity;\n
-      \       f *= scalar * solverData_Fluid_Viscosity;\n    \n        force += f;\n
-      \   \n    // Surface tension term (external)\n        if (normal.w > FLUVIO_PI
-      && normal.w < FLUVIO_TAU)\n        {\n            scalar = neighborMass\n                *
-      Poly6CalculateLaplacian(lenSq, diffSq, solverData_KernelFactors.x)\n                *
-      solverData_Fluid_SurfaceTension\n                * 1.0f / neighborDensityPressure.x;\n
-      \   \n            f = normal.xyz * scalar;\n            force -= f;\n        }\n
-      \   }\n    \n    // Gravity term (external)\n    force += solverData_Gravity
-      * mass;\n    \n    // Buoyancy term (external)\n    force += solverData_Gravity
+      0x1 + 0x8D83C0) << 2));\n    if (!isAlive) return;\n    \n            float3
+      dist, f;\n            float invNeighborDensity, lenSq, len, len3, diff, diffSq,
+      scalar;\n            for (uint j = 0; j < neighborCount; ++j)\n            {\n
+      \               uint neighborIndex = (attributeBuffer.Load((index * 0x35F +
+      0x75C00 + (j)) << 2));\n    \n                float3 neighborPosition = asfloat(attributeBuffer.Load3((neighborIndex
+      * 0x4 + 0x2740) << 2));\n                float neighborMass = asfloat(attributeBuffer.Load((neighborIndex
+      * 0x1 + 0x1FE40) << 2));\n                float3 neighborVelocity = asfloat(attributeBuffer.Load3((neighborIndex
+      * 0x4 + 0xC440) << 2));\n                float4 neighborDensityPressure = asfloat(attributeBuffer.Load4((neighborIndex
+      * 0x4 + 0x8BACC0) << 2));\n    \n                dist = position - neighborPosition;\n
+      \   \n                // For kernels\n                lenSq = dot(dist, dist);\n
+      \               len = sqrt(lenSq);\n                len3 = len * len * len;\n
+      \               diffSq = solverData_KernelSize.y - lenSq;\n                diff
+      = solverData_KernelSize.x - len;\n    \n                // Pressure term\n                scalar
+      = neighborMass\n                    * (densityPressure.y + neighborDensityPressure.y)
+      / (neighborDensityPressure.x * 2.0f);\n                f = SpikyCalculateGradient(dist,
+      diff, len, solverData_KernelFactors.y);\n                f *= scalar;\n    \n
+      \               force -= f;\n    \n                invNeighborDensity = 1.0f
+      / neighborDensityPressure.x;\n    \n                // Viscosity term\n                scalar
+      = neighborMass\n                    * ViscosityCalculateLaplacian(diff, solverData_KernelSize.z,
+      solverData_KernelFactors.z)\n                    * invNeighborDensity;\n    \n
+      \               f = neighborVelocity - velocity;\n                f *= scalar
+      * solverData_Fluid_Viscosity;\n    \n                force += f;\n    \n                //
+      Surface tension term (external)\n                if (normal.w > FLUVIO_PI &&
+      normal.w < FLUVIO_TAU)\n                {\n                    scalar = neighborMass\n
+      \                       * Poly6CalculateLaplacian(lenSq, diffSq, solverData_KernelFactors.x)\n
+      \                       * solverData_Fluid_SurfaceTension\n                        *
+      1.0f / neighborDensityPressure.x;\n    \n                    f = normal.xyz
+      * scalar;\n                    force -= f;\n                }\n            }\n
+      \   \n            // Gravity term (external)\n            force += solverData_Gravity
+      * mass;\n            // Buoyancy term (external)\n            force += solverData_Gravity
       * solverData_Fluid_BuoyancyCoefficient * (densityPressure.x - solverData_Fluid_Density);\n}\n\n\n\n[numthreads(NB_THREADS_PER_GROUP,1,1)]\nvoid
       CSMain(uint3 groupId          : SV_GroupID,\n            uint3 groupThreadId
       \   : SV_GroupThreadID)\n{\n\tuint id = groupThreadId.x + groupId.x * NB_THREADS_PER_GROUP
@@ -592,7 +569,7 @@ VisualEffectResource:
       = position;\n#endif\n\t\t\t\n\t\t\t{\n\t\t\t    CalculateForces_2661D(index,
       neighborCount, position, velocity, mass, densityPressure, normal,  /*inout */force,
       (float)998.29, (float)0.03, (float)0.728, (float)0, float4(0.190625,0.03633789,0.00692691,0.0953125),
-      float3(4713702,99508.98,344.6449), solverData_Gravity_a);\n\t\t\t}\n\t\t\t\n\n\t\t\tif
+      float3(4713702,99508.98,344.6449), float3(0,-9.81,0));\n\t\t\t}\n\t\t\t\n\n\t\t\tif
       (alive)\n\t\t\t{\n\t\t\t\tattributeBuffer.Store3((index * 0x4 + 0x16140) <<
       2,asuint(force));\n\t\t\t\t\n\n#if VFX_HAS_INDIRECT_DRAW\n                uint
       indirectIndex = indirectBuffer.IncrementCounter();\n\t\t\t\tindirectBuffer[indirectIndex]
@@ -609,7 +586,7 @@ VisualEffectResource:
       \   CalculateForces_2661D(index, neighborCount, position, velocity, mass, densityPressure,
       normal,  /*inout */force, (float)998.29, (float)0.03, (float)0.728, (float)0,
       float4(0.190625,0.03633789,0.00692691,0.0953125), float3(4713702,99508.98,344.6449),
-      solverData_Gravity_a);\n\t\t}\n\t\t\n\n\t\tattributeBuffer.Store3((index * 0x4
+      float3(0,-9.81,0));\n\t\t}\n\t\t\n\n\t\tattributeBuffer.Store3((index * 0x4
       + 0x16140) << 2,asuint(force));\n\t\t\n\n#if VFX_HAS_INDIRECT_DRAW\n        uint
       indirectIndex = indirectBuffer.IncrementCounter();\n\t\tindirectBuffer[indirectIndex]
       = index;\n#endif\n#endif\n\t}\n}\n"
@@ -618,13 +595,13 @@ VisualEffectResource:
     source: "\r\n// FluvioFX simulation constants\r\n#define FLUVIO_EPSILON 9.999999E-11\r\n#define
       FLUVIO_MAX_SQR_VELOCITY_CHANGE 10000\r\n#define FLUVIO_MAX_BUCKET_COUNT 32\r\n#define
       FLUVIO_MAX_NEIGHBOR_COUNT 863\r\n#define FLUVIO_AUTO_PARTICLE_SIZE_FACTOR 0.25\r\n#define
-      FLUVIO_MAX_GRID_SIZE 21\r\n\r\n#pragma kernel CSMain\n#include \"HLSLSupport.cginc\"\n#define
-      NB_THREADS_PER_GROUP 64\n#define VFX_USE_LIFETIME_CURRENT 1\n#define VFX_USE_POSITION_CURRENT
-      1\n#define VFX_USE_VELOCITY_CURRENT 1\n#define VFX_USE_FORCE_CURRENT 1\n#define
-      VFX_USE_MASS_CURRENT 1\n#define VFX_USE_PREVIOUSPOSITION_CURRENT 1\n#define
-      VFX_USE_ALIVE_CURRENT 1\n#define VFX_USE_AGE_CURRENT 1\n#define VFX_HAS_INDIRECT_DRAW
-      1\n#define VFX_WORLD_SPACE 1\n\n\nCBUFFER_START(parameters)\n    float dt_a;\n
-      \   uint3 PADDING_0;\nCBUFFER_END\n\n\n#include \"Packages/com.unity.visualeffectgraph/Shaders/Common/VFXCommonCompute.cginc\"\n#include
+      FLUVIO_MAX_GRID_SIZE 21\r\n\r\n#pragma kernel CSMain\n#define NB_THREADS_PER_GROUP
+      64\n#define VFX_USE_LIFETIME_CURRENT 1\n#define VFX_USE_POSITION_CURRENT 1\n#define
+      VFX_USE_VELOCITY_CURRENT 1\n#define VFX_USE_FORCE_CURRENT 1\n#define VFX_USE_MASS_CURRENT
+      1\n#define VFX_USE_PREVIOUSPOSITION_CURRENT 1\n#define VFX_USE_ALIVE_CURRENT
+      1\n#define VFX_USE_AGE_CURRENT 1\n#define VFX_HAS_INDIRECT_DRAW 1\n#define VFX_WORLD_SPACE
+      1\n#include \"Packages/com.unity.visualeffectgraph/Shaders/RenderPipeline/HDRP/VFXDefines.hlsl\"\n\n\nCBUFFER_START(parameters)\n
+      \   float dt_a;\n    uint3 PADDING_0;\nCBUFFER_END\n\n\n#include \"Packages/com.unity.visualeffectgraph/Shaders/Common/VFXCommonCompute.cginc\"\n#include
       \"Packages/com.unity.visualeffectgraph/Shaders/VFXCommon.cginc\"\n#include \"Packages/com.thinksquirrel.fluviofx/Shaders/FluvioCompute.cginc\"\n\n\n\nRWByteAddressBuffer
       attributeBuffer;\n\n#if VFX_USE_ALIVE_CURRENT\nRWStructuredBuffer<uint> deadListOut;\n#endif\n\n#if
       VFX_HAS_INDIRECT_DRAW\nRWStructuredBuffer<uint> indirectBuffer;\n#endif\n\nCBUFFER_START(updateParams)\n
@@ -684,460 +661,460 @@ VisualEffectResource:
       = index;\n#endif\n#endif\n\t}\n}\n"
   - compute: 1
     name: '[System 1]Initialize'
-    source: "#pragma kernel CSMain\n#include \"HLSLSupport.cginc\"\n#define NB_THREADS_PER_GROUP
-      64\n#define VFX_USE_LIFETIME_CURRENT 1\n#define VFX_USE_POSITION_CURRENT 1\n#define
-      VFX_USE_SEED_CURRENT 1\n#define VFX_USE_DIRECTION_CURRENT 1\n#define VFX_USE_VELOCITY_CURRENT
-      1\n#define VFX_USE_FORCE_CURRENT 1\n#define VFX_USE_MASS_CURRENT 1\n#define
-      VFX_USE_SIZE_CURRENT 1\n#define VFX_USE_BUCKETS_0_CURRENT 1\n#define VFX_USE_BUCKETS_1_CURRENT
-      1\n#define VFX_USE_BUCKETS_2_CURRENT 1\n#define VFX_USE_BUCKETS_3_CURRENT 1\n#define
-      VFX_USE_BUCKETS_4_CURRENT 1\n#define VFX_USE_BUCKETS_5_CURRENT 1\n#define VFX_USE_BUCKETS_6_CURRENT
-      1\n#define VFX_USE_BUCKETS_7_CURRENT 1\n#define VFX_USE_BUCKETS_8_CURRENT 1\n#define
-      VFX_USE_BUCKETS_9_CURRENT 1\n#define VFX_USE_BUCKETS_10_CURRENT 1\n#define VFX_USE_BUCKETS_11_CURRENT
-      1\n#define VFX_USE_BUCKETS_12_CURRENT 1\n#define VFX_USE_BUCKETS_13_CURRENT
-      1\n#define VFX_USE_BUCKETS_14_CURRENT 1\n#define VFX_USE_BUCKETS_15_CURRENT
-      1\n#define VFX_USE_BUCKETS_16_CURRENT 1\n#define VFX_USE_BUCKETS_17_CURRENT
-      1\n#define VFX_USE_BUCKETS_18_CURRENT 1\n#define VFX_USE_BUCKETS_19_CURRENT
-      1\n#define VFX_USE_BUCKETS_20_CURRENT 1\n#define VFX_USE_BUCKETS_21_CURRENT
-      1\n#define VFX_USE_BUCKETS_22_CURRENT 1\n#define VFX_USE_BUCKETS_23_CURRENT
-      1\n#define VFX_USE_BUCKETS_24_CURRENT 1\n#define VFX_USE_BUCKETS_25_CURRENT
-      1\n#define VFX_USE_BUCKETS_26_CURRENT 1\n#define VFX_USE_BUCKETS_27_CURRENT
-      1\n#define VFX_USE_BUCKETS_28_CURRENT 1\n#define VFX_USE_BUCKETS_29_CURRENT
-      1\n#define VFX_USE_BUCKETS_30_CURRENT 1\n#define VFX_USE_BUCKETS_31_CURRENT
-      1\n#define VFX_USE_NEIGHBORCOUNT_CURRENT 1\n#define VFX_USE_NEIGHBORS_0_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_1_CURRENT 1\n#define VFX_USE_NEIGHBORS_2_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_3_CURRENT 1\n#define VFX_USE_NEIGHBORS_4_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_5_CURRENT 1\n#define VFX_USE_NEIGHBORS_6_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_7_CURRENT 1\n#define VFX_USE_NEIGHBORS_8_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_9_CURRENT 1\n#define VFX_USE_NEIGHBORS_10_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_11_CURRENT 1\n#define VFX_USE_NEIGHBORS_12_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_13_CURRENT 1\n#define VFX_USE_NEIGHBORS_14_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_15_CURRENT 1\n#define VFX_USE_NEIGHBORS_16_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_17_CURRENT 1\n#define VFX_USE_NEIGHBORS_18_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_19_CURRENT 1\n#define VFX_USE_NEIGHBORS_20_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_21_CURRENT 1\n#define VFX_USE_NEIGHBORS_22_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_23_CURRENT 1\n#define VFX_USE_NEIGHBORS_24_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_25_CURRENT 1\n#define VFX_USE_NEIGHBORS_26_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_27_CURRENT 1\n#define VFX_USE_NEIGHBORS_28_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_29_CURRENT 1\n#define VFX_USE_NEIGHBORS_30_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_31_CURRENT 1\n#define VFX_USE_NEIGHBORS_32_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_33_CURRENT 1\n#define VFX_USE_NEIGHBORS_34_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_35_CURRENT 1\n#define VFX_USE_NEIGHBORS_36_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_37_CURRENT 1\n#define VFX_USE_NEIGHBORS_38_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_39_CURRENT 1\n#define VFX_USE_NEIGHBORS_40_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_41_CURRENT 1\n#define VFX_USE_NEIGHBORS_42_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_43_CURRENT 1\n#define VFX_USE_NEIGHBORS_44_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_45_CURRENT 1\n#define VFX_USE_NEIGHBORS_46_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_47_CURRENT 1\n#define VFX_USE_NEIGHBORS_48_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_49_CURRENT 1\n#define VFX_USE_NEIGHBORS_50_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_51_CURRENT 1\n#define VFX_USE_NEIGHBORS_52_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_53_CURRENT 1\n#define VFX_USE_NEIGHBORS_54_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_55_CURRENT 1\n#define VFX_USE_NEIGHBORS_56_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_57_CURRENT 1\n#define VFX_USE_NEIGHBORS_58_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_59_CURRENT 1\n#define VFX_USE_NEIGHBORS_60_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_61_CURRENT 1\n#define VFX_USE_NEIGHBORS_62_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_63_CURRENT 1\n#define VFX_USE_NEIGHBORS_64_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_65_CURRENT 1\n#define VFX_USE_NEIGHBORS_66_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_67_CURRENT 1\n#define VFX_USE_NEIGHBORS_68_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_69_CURRENT 1\n#define VFX_USE_NEIGHBORS_70_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_71_CURRENT 1\n#define VFX_USE_NEIGHBORS_72_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_73_CURRENT 1\n#define VFX_USE_NEIGHBORS_74_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_75_CURRENT 1\n#define VFX_USE_NEIGHBORS_76_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_77_CURRENT 1\n#define VFX_USE_NEIGHBORS_78_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_79_CURRENT 1\n#define VFX_USE_NEIGHBORS_80_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_81_CURRENT 1\n#define VFX_USE_NEIGHBORS_82_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_83_CURRENT 1\n#define VFX_USE_NEIGHBORS_84_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_85_CURRENT 1\n#define VFX_USE_NEIGHBORS_86_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_87_CURRENT 1\n#define VFX_USE_NEIGHBORS_88_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_89_CURRENT 1\n#define VFX_USE_NEIGHBORS_90_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_91_CURRENT 1\n#define VFX_USE_NEIGHBORS_92_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_93_CURRENT 1\n#define VFX_USE_NEIGHBORS_94_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_95_CURRENT 1\n#define VFX_USE_NEIGHBORS_96_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_97_CURRENT 1\n#define VFX_USE_NEIGHBORS_98_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_99_CURRENT 1\n#define VFX_USE_NEIGHBORS_100_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_101_CURRENT 1\n#define VFX_USE_NEIGHBORS_102_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_103_CURRENT 1\n#define VFX_USE_NEIGHBORS_104_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_105_CURRENT 1\n#define VFX_USE_NEIGHBORS_106_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_107_CURRENT 1\n#define VFX_USE_NEIGHBORS_108_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_109_CURRENT 1\n#define VFX_USE_NEIGHBORS_110_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_111_CURRENT 1\n#define VFX_USE_NEIGHBORS_112_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_113_CURRENT 1\n#define VFX_USE_NEIGHBORS_114_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_115_CURRENT 1\n#define VFX_USE_NEIGHBORS_116_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_117_CURRENT 1\n#define VFX_USE_NEIGHBORS_118_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_119_CURRENT 1\n#define VFX_USE_NEIGHBORS_120_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_121_CURRENT 1\n#define VFX_USE_NEIGHBORS_122_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_123_CURRENT 1\n#define VFX_USE_NEIGHBORS_124_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_125_CURRENT 1\n#define VFX_USE_NEIGHBORS_126_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_127_CURRENT 1\n#define VFX_USE_NEIGHBORS_128_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_129_CURRENT 1\n#define VFX_USE_NEIGHBORS_130_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_131_CURRENT 1\n#define VFX_USE_NEIGHBORS_132_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_133_CURRENT 1\n#define VFX_USE_NEIGHBORS_134_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_135_CURRENT 1\n#define VFX_USE_NEIGHBORS_136_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_137_CURRENT 1\n#define VFX_USE_NEIGHBORS_138_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_139_CURRENT 1\n#define VFX_USE_NEIGHBORS_140_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_141_CURRENT 1\n#define VFX_USE_NEIGHBORS_142_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_143_CURRENT 1\n#define VFX_USE_NEIGHBORS_144_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_145_CURRENT 1\n#define VFX_USE_NEIGHBORS_146_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_147_CURRENT 1\n#define VFX_USE_NEIGHBORS_148_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_149_CURRENT 1\n#define VFX_USE_NEIGHBORS_150_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_151_CURRENT 1\n#define VFX_USE_NEIGHBORS_152_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_153_CURRENT 1\n#define VFX_USE_NEIGHBORS_154_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_155_CURRENT 1\n#define VFX_USE_NEIGHBORS_156_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_157_CURRENT 1\n#define VFX_USE_NEIGHBORS_158_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_159_CURRENT 1\n#define VFX_USE_NEIGHBORS_160_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_161_CURRENT 1\n#define VFX_USE_NEIGHBORS_162_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_163_CURRENT 1\n#define VFX_USE_NEIGHBORS_164_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_165_CURRENT 1\n#define VFX_USE_NEIGHBORS_166_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_167_CURRENT 1\n#define VFX_USE_NEIGHBORS_168_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_169_CURRENT 1\n#define VFX_USE_NEIGHBORS_170_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_171_CURRENT 1\n#define VFX_USE_NEIGHBORS_172_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_173_CURRENT 1\n#define VFX_USE_NEIGHBORS_174_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_175_CURRENT 1\n#define VFX_USE_NEIGHBORS_176_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_177_CURRENT 1\n#define VFX_USE_NEIGHBORS_178_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_179_CURRENT 1\n#define VFX_USE_NEIGHBORS_180_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_181_CURRENT 1\n#define VFX_USE_NEIGHBORS_182_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_183_CURRENT 1\n#define VFX_USE_NEIGHBORS_184_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_185_CURRENT 1\n#define VFX_USE_NEIGHBORS_186_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_187_CURRENT 1\n#define VFX_USE_NEIGHBORS_188_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_189_CURRENT 1\n#define VFX_USE_NEIGHBORS_190_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_191_CURRENT 1\n#define VFX_USE_NEIGHBORS_192_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_193_CURRENT 1\n#define VFX_USE_NEIGHBORS_194_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_195_CURRENT 1\n#define VFX_USE_NEIGHBORS_196_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_197_CURRENT 1\n#define VFX_USE_NEIGHBORS_198_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_199_CURRENT 1\n#define VFX_USE_NEIGHBORS_200_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_201_CURRENT 1\n#define VFX_USE_NEIGHBORS_202_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_203_CURRENT 1\n#define VFX_USE_NEIGHBORS_204_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_205_CURRENT 1\n#define VFX_USE_NEIGHBORS_206_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_207_CURRENT 1\n#define VFX_USE_NEIGHBORS_208_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_209_CURRENT 1\n#define VFX_USE_NEIGHBORS_210_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_211_CURRENT 1\n#define VFX_USE_NEIGHBORS_212_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_213_CURRENT 1\n#define VFX_USE_NEIGHBORS_214_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_215_CURRENT 1\n#define VFX_USE_NEIGHBORS_216_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_217_CURRENT 1\n#define VFX_USE_NEIGHBORS_218_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_219_CURRENT 1\n#define VFX_USE_NEIGHBORS_220_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_221_CURRENT 1\n#define VFX_USE_NEIGHBORS_222_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_223_CURRENT 1\n#define VFX_USE_NEIGHBORS_224_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_225_CURRENT 1\n#define VFX_USE_NEIGHBORS_226_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_227_CURRENT 1\n#define VFX_USE_NEIGHBORS_228_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_229_CURRENT 1\n#define VFX_USE_NEIGHBORS_230_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_231_CURRENT 1\n#define VFX_USE_NEIGHBORS_232_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_233_CURRENT 1\n#define VFX_USE_NEIGHBORS_234_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_235_CURRENT 1\n#define VFX_USE_NEIGHBORS_236_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_237_CURRENT 1\n#define VFX_USE_NEIGHBORS_238_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_239_CURRENT 1\n#define VFX_USE_NEIGHBORS_240_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_241_CURRENT 1\n#define VFX_USE_NEIGHBORS_242_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_243_CURRENT 1\n#define VFX_USE_NEIGHBORS_244_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_245_CURRENT 1\n#define VFX_USE_NEIGHBORS_246_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_247_CURRENT 1\n#define VFX_USE_NEIGHBORS_248_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_249_CURRENT 1\n#define VFX_USE_NEIGHBORS_250_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_251_CURRENT 1\n#define VFX_USE_NEIGHBORS_252_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_253_CURRENT 1\n#define VFX_USE_NEIGHBORS_254_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_255_CURRENT 1\n#define VFX_USE_NEIGHBORS_256_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_257_CURRENT 1\n#define VFX_USE_NEIGHBORS_258_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_259_CURRENT 1\n#define VFX_USE_NEIGHBORS_260_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_261_CURRENT 1\n#define VFX_USE_NEIGHBORS_262_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_263_CURRENT 1\n#define VFX_USE_NEIGHBORS_264_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_265_CURRENT 1\n#define VFX_USE_NEIGHBORS_266_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_267_CURRENT 1\n#define VFX_USE_NEIGHBORS_268_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_269_CURRENT 1\n#define VFX_USE_NEIGHBORS_270_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_271_CURRENT 1\n#define VFX_USE_NEIGHBORS_272_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_273_CURRENT 1\n#define VFX_USE_NEIGHBORS_274_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_275_CURRENT 1\n#define VFX_USE_NEIGHBORS_276_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_277_CURRENT 1\n#define VFX_USE_NEIGHBORS_278_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_279_CURRENT 1\n#define VFX_USE_NEIGHBORS_280_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_281_CURRENT 1\n#define VFX_USE_NEIGHBORS_282_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_283_CURRENT 1\n#define VFX_USE_NEIGHBORS_284_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_285_CURRENT 1\n#define VFX_USE_NEIGHBORS_286_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_287_CURRENT 1\n#define VFX_USE_NEIGHBORS_288_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_289_CURRENT 1\n#define VFX_USE_NEIGHBORS_290_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_291_CURRENT 1\n#define VFX_USE_NEIGHBORS_292_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_293_CURRENT 1\n#define VFX_USE_NEIGHBORS_294_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_295_CURRENT 1\n#define VFX_USE_NEIGHBORS_296_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_297_CURRENT 1\n#define VFX_USE_NEIGHBORS_298_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_299_CURRENT 1\n#define VFX_USE_NEIGHBORS_300_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_301_CURRENT 1\n#define VFX_USE_NEIGHBORS_302_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_303_CURRENT 1\n#define VFX_USE_NEIGHBORS_304_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_305_CURRENT 1\n#define VFX_USE_NEIGHBORS_306_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_307_CURRENT 1\n#define VFX_USE_NEIGHBORS_308_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_309_CURRENT 1\n#define VFX_USE_NEIGHBORS_310_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_311_CURRENT 1\n#define VFX_USE_NEIGHBORS_312_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_313_CURRENT 1\n#define VFX_USE_NEIGHBORS_314_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_315_CURRENT 1\n#define VFX_USE_NEIGHBORS_316_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_317_CURRENT 1\n#define VFX_USE_NEIGHBORS_318_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_319_CURRENT 1\n#define VFX_USE_NEIGHBORS_320_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_321_CURRENT 1\n#define VFX_USE_NEIGHBORS_322_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_323_CURRENT 1\n#define VFX_USE_NEIGHBORS_324_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_325_CURRENT 1\n#define VFX_USE_NEIGHBORS_326_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_327_CURRENT 1\n#define VFX_USE_NEIGHBORS_328_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_329_CURRENT 1\n#define VFX_USE_NEIGHBORS_330_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_331_CURRENT 1\n#define VFX_USE_NEIGHBORS_332_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_333_CURRENT 1\n#define VFX_USE_NEIGHBORS_334_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_335_CURRENT 1\n#define VFX_USE_NEIGHBORS_336_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_337_CURRENT 1\n#define VFX_USE_NEIGHBORS_338_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_339_CURRENT 1\n#define VFX_USE_NEIGHBORS_340_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_341_CURRENT 1\n#define VFX_USE_NEIGHBORS_342_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_343_CURRENT 1\n#define VFX_USE_NEIGHBORS_344_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_345_CURRENT 1\n#define VFX_USE_NEIGHBORS_346_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_347_CURRENT 1\n#define VFX_USE_NEIGHBORS_348_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_349_CURRENT 1\n#define VFX_USE_NEIGHBORS_350_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_351_CURRENT 1\n#define VFX_USE_NEIGHBORS_352_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_353_CURRENT 1\n#define VFX_USE_NEIGHBORS_354_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_355_CURRENT 1\n#define VFX_USE_NEIGHBORS_356_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_357_CURRENT 1\n#define VFX_USE_NEIGHBORS_358_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_359_CURRENT 1\n#define VFX_USE_NEIGHBORS_360_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_361_CURRENT 1\n#define VFX_USE_NEIGHBORS_362_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_363_CURRENT 1\n#define VFX_USE_NEIGHBORS_364_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_365_CURRENT 1\n#define VFX_USE_NEIGHBORS_366_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_367_CURRENT 1\n#define VFX_USE_NEIGHBORS_368_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_369_CURRENT 1\n#define VFX_USE_NEIGHBORS_370_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_371_CURRENT 1\n#define VFX_USE_NEIGHBORS_372_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_373_CURRENT 1\n#define VFX_USE_NEIGHBORS_374_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_375_CURRENT 1\n#define VFX_USE_NEIGHBORS_376_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_377_CURRENT 1\n#define VFX_USE_NEIGHBORS_378_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_379_CURRENT 1\n#define VFX_USE_NEIGHBORS_380_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_381_CURRENT 1\n#define VFX_USE_NEIGHBORS_382_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_383_CURRENT 1\n#define VFX_USE_NEIGHBORS_384_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_385_CURRENT 1\n#define VFX_USE_NEIGHBORS_386_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_387_CURRENT 1\n#define VFX_USE_NEIGHBORS_388_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_389_CURRENT 1\n#define VFX_USE_NEIGHBORS_390_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_391_CURRENT 1\n#define VFX_USE_NEIGHBORS_392_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_393_CURRENT 1\n#define VFX_USE_NEIGHBORS_394_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_395_CURRENT 1\n#define VFX_USE_NEIGHBORS_396_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_397_CURRENT 1\n#define VFX_USE_NEIGHBORS_398_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_399_CURRENT 1\n#define VFX_USE_NEIGHBORS_400_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_401_CURRENT 1\n#define VFX_USE_NEIGHBORS_402_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_403_CURRENT 1\n#define VFX_USE_NEIGHBORS_404_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_405_CURRENT 1\n#define VFX_USE_NEIGHBORS_406_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_407_CURRENT 1\n#define VFX_USE_NEIGHBORS_408_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_409_CURRENT 1\n#define VFX_USE_NEIGHBORS_410_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_411_CURRENT 1\n#define VFX_USE_NEIGHBORS_412_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_413_CURRENT 1\n#define VFX_USE_NEIGHBORS_414_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_415_CURRENT 1\n#define VFX_USE_NEIGHBORS_416_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_417_CURRENT 1\n#define VFX_USE_NEIGHBORS_418_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_419_CURRENT 1\n#define VFX_USE_NEIGHBORS_420_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_421_CURRENT 1\n#define VFX_USE_NEIGHBORS_422_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_423_CURRENT 1\n#define VFX_USE_NEIGHBORS_424_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_425_CURRENT 1\n#define VFX_USE_NEIGHBORS_426_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_427_CURRENT 1\n#define VFX_USE_NEIGHBORS_428_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_429_CURRENT 1\n#define VFX_USE_NEIGHBORS_430_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_431_CURRENT 1\n#define VFX_USE_NEIGHBORS_432_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_433_CURRENT 1\n#define VFX_USE_NEIGHBORS_434_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_435_CURRENT 1\n#define VFX_USE_NEIGHBORS_436_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_437_CURRENT 1\n#define VFX_USE_NEIGHBORS_438_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_439_CURRENT 1\n#define VFX_USE_NEIGHBORS_440_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_441_CURRENT 1\n#define VFX_USE_NEIGHBORS_442_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_443_CURRENT 1\n#define VFX_USE_NEIGHBORS_444_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_445_CURRENT 1\n#define VFX_USE_NEIGHBORS_446_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_447_CURRENT 1\n#define VFX_USE_NEIGHBORS_448_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_449_CURRENT 1\n#define VFX_USE_NEIGHBORS_450_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_451_CURRENT 1\n#define VFX_USE_NEIGHBORS_452_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_453_CURRENT 1\n#define VFX_USE_NEIGHBORS_454_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_455_CURRENT 1\n#define VFX_USE_NEIGHBORS_456_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_457_CURRENT 1\n#define VFX_USE_NEIGHBORS_458_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_459_CURRENT 1\n#define VFX_USE_NEIGHBORS_460_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_461_CURRENT 1\n#define VFX_USE_NEIGHBORS_462_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_463_CURRENT 1\n#define VFX_USE_NEIGHBORS_464_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_465_CURRENT 1\n#define VFX_USE_NEIGHBORS_466_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_467_CURRENT 1\n#define VFX_USE_NEIGHBORS_468_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_469_CURRENT 1\n#define VFX_USE_NEIGHBORS_470_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_471_CURRENT 1\n#define VFX_USE_NEIGHBORS_472_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_473_CURRENT 1\n#define VFX_USE_NEIGHBORS_474_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_475_CURRENT 1\n#define VFX_USE_NEIGHBORS_476_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_477_CURRENT 1\n#define VFX_USE_NEIGHBORS_478_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_479_CURRENT 1\n#define VFX_USE_NEIGHBORS_480_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_481_CURRENT 1\n#define VFX_USE_NEIGHBORS_482_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_483_CURRENT 1\n#define VFX_USE_NEIGHBORS_484_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_485_CURRENT 1\n#define VFX_USE_NEIGHBORS_486_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_487_CURRENT 1\n#define VFX_USE_NEIGHBORS_488_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_489_CURRENT 1\n#define VFX_USE_NEIGHBORS_490_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_491_CURRENT 1\n#define VFX_USE_NEIGHBORS_492_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_493_CURRENT 1\n#define VFX_USE_NEIGHBORS_494_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_495_CURRENT 1\n#define VFX_USE_NEIGHBORS_496_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_497_CURRENT 1\n#define VFX_USE_NEIGHBORS_498_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_499_CURRENT 1\n#define VFX_USE_NEIGHBORS_500_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_501_CURRENT 1\n#define VFX_USE_NEIGHBORS_502_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_503_CURRENT 1\n#define VFX_USE_NEIGHBORS_504_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_505_CURRENT 1\n#define VFX_USE_NEIGHBORS_506_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_507_CURRENT 1\n#define VFX_USE_NEIGHBORS_508_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_509_CURRENT 1\n#define VFX_USE_NEIGHBORS_510_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_511_CURRENT 1\n#define VFX_USE_NEIGHBORS_512_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_513_CURRENT 1\n#define VFX_USE_NEIGHBORS_514_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_515_CURRENT 1\n#define VFX_USE_NEIGHBORS_516_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_517_CURRENT 1\n#define VFX_USE_NEIGHBORS_518_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_519_CURRENT 1\n#define VFX_USE_NEIGHBORS_520_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_521_CURRENT 1\n#define VFX_USE_NEIGHBORS_522_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_523_CURRENT 1\n#define VFX_USE_NEIGHBORS_524_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_525_CURRENT 1\n#define VFX_USE_NEIGHBORS_526_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_527_CURRENT 1\n#define VFX_USE_NEIGHBORS_528_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_529_CURRENT 1\n#define VFX_USE_NEIGHBORS_530_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_531_CURRENT 1\n#define VFX_USE_NEIGHBORS_532_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_533_CURRENT 1\n#define VFX_USE_NEIGHBORS_534_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_535_CURRENT 1\n#define VFX_USE_NEIGHBORS_536_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_537_CURRENT 1\n#define VFX_USE_NEIGHBORS_538_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_539_CURRENT 1\n#define VFX_USE_NEIGHBORS_540_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_541_CURRENT 1\n#define VFX_USE_NEIGHBORS_542_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_543_CURRENT 1\n#define VFX_USE_NEIGHBORS_544_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_545_CURRENT 1\n#define VFX_USE_NEIGHBORS_546_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_547_CURRENT 1\n#define VFX_USE_NEIGHBORS_548_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_549_CURRENT 1\n#define VFX_USE_NEIGHBORS_550_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_551_CURRENT 1\n#define VFX_USE_NEIGHBORS_552_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_553_CURRENT 1\n#define VFX_USE_NEIGHBORS_554_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_555_CURRENT 1\n#define VFX_USE_NEIGHBORS_556_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_557_CURRENT 1\n#define VFX_USE_NEIGHBORS_558_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_559_CURRENT 1\n#define VFX_USE_NEIGHBORS_560_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_561_CURRENT 1\n#define VFX_USE_NEIGHBORS_562_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_563_CURRENT 1\n#define VFX_USE_NEIGHBORS_564_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_565_CURRENT 1\n#define VFX_USE_NEIGHBORS_566_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_567_CURRENT 1\n#define VFX_USE_NEIGHBORS_568_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_569_CURRENT 1\n#define VFX_USE_NEIGHBORS_570_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_571_CURRENT 1\n#define VFX_USE_NEIGHBORS_572_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_573_CURRENT 1\n#define VFX_USE_NEIGHBORS_574_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_575_CURRENT 1\n#define VFX_USE_NEIGHBORS_576_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_577_CURRENT 1\n#define VFX_USE_NEIGHBORS_578_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_579_CURRENT 1\n#define VFX_USE_NEIGHBORS_580_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_581_CURRENT 1\n#define VFX_USE_NEIGHBORS_582_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_583_CURRENT 1\n#define VFX_USE_NEIGHBORS_584_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_585_CURRENT 1\n#define VFX_USE_NEIGHBORS_586_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_587_CURRENT 1\n#define VFX_USE_NEIGHBORS_588_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_589_CURRENT 1\n#define VFX_USE_NEIGHBORS_590_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_591_CURRENT 1\n#define VFX_USE_NEIGHBORS_592_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_593_CURRENT 1\n#define VFX_USE_NEIGHBORS_594_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_595_CURRENT 1\n#define VFX_USE_NEIGHBORS_596_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_597_CURRENT 1\n#define VFX_USE_NEIGHBORS_598_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_599_CURRENT 1\n#define VFX_USE_NEIGHBORS_600_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_601_CURRENT 1\n#define VFX_USE_NEIGHBORS_602_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_603_CURRENT 1\n#define VFX_USE_NEIGHBORS_604_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_605_CURRENT 1\n#define VFX_USE_NEIGHBORS_606_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_607_CURRENT 1\n#define VFX_USE_NEIGHBORS_608_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_609_CURRENT 1\n#define VFX_USE_NEIGHBORS_610_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_611_CURRENT 1\n#define VFX_USE_NEIGHBORS_612_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_613_CURRENT 1\n#define VFX_USE_NEIGHBORS_614_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_615_CURRENT 1\n#define VFX_USE_NEIGHBORS_616_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_617_CURRENT 1\n#define VFX_USE_NEIGHBORS_618_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_619_CURRENT 1\n#define VFX_USE_NEIGHBORS_620_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_621_CURRENT 1\n#define VFX_USE_NEIGHBORS_622_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_623_CURRENT 1\n#define VFX_USE_NEIGHBORS_624_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_625_CURRENT 1\n#define VFX_USE_NEIGHBORS_626_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_627_CURRENT 1\n#define VFX_USE_NEIGHBORS_628_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_629_CURRENT 1\n#define VFX_USE_NEIGHBORS_630_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_631_CURRENT 1\n#define VFX_USE_NEIGHBORS_632_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_633_CURRENT 1\n#define VFX_USE_NEIGHBORS_634_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_635_CURRENT 1\n#define VFX_USE_NEIGHBORS_636_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_637_CURRENT 1\n#define VFX_USE_NEIGHBORS_638_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_639_CURRENT 1\n#define VFX_USE_NEIGHBORS_640_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_641_CURRENT 1\n#define VFX_USE_NEIGHBORS_642_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_643_CURRENT 1\n#define VFX_USE_NEIGHBORS_644_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_645_CURRENT 1\n#define VFX_USE_NEIGHBORS_646_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_647_CURRENT 1\n#define VFX_USE_NEIGHBORS_648_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_649_CURRENT 1\n#define VFX_USE_NEIGHBORS_650_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_651_CURRENT 1\n#define VFX_USE_NEIGHBORS_652_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_653_CURRENT 1\n#define VFX_USE_NEIGHBORS_654_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_655_CURRENT 1\n#define VFX_USE_NEIGHBORS_656_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_657_CURRENT 1\n#define VFX_USE_NEIGHBORS_658_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_659_CURRENT 1\n#define VFX_USE_NEIGHBORS_660_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_661_CURRENT 1\n#define VFX_USE_NEIGHBORS_662_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_663_CURRENT 1\n#define VFX_USE_NEIGHBORS_664_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_665_CURRENT 1\n#define VFX_USE_NEIGHBORS_666_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_667_CURRENT 1\n#define VFX_USE_NEIGHBORS_668_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_669_CURRENT 1\n#define VFX_USE_NEIGHBORS_670_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_671_CURRENT 1\n#define VFX_USE_NEIGHBORS_672_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_673_CURRENT 1\n#define VFX_USE_NEIGHBORS_674_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_675_CURRENT 1\n#define VFX_USE_NEIGHBORS_676_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_677_CURRENT 1\n#define VFX_USE_NEIGHBORS_678_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_679_CURRENT 1\n#define VFX_USE_NEIGHBORS_680_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_681_CURRENT 1\n#define VFX_USE_NEIGHBORS_682_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_683_CURRENT 1\n#define VFX_USE_NEIGHBORS_684_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_685_CURRENT 1\n#define VFX_USE_NEIGHBORS_686_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_687_CURRENT 1\n#define VFX_USE_NEIGHBORS_688_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_689_CURRENT 1\n#define VFX_USE_NEIGHBORS_690_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_691_CURRENT 1\n#define VFX_USE_NEIGHBORS_692_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_693_CURRENT 1\n#define VFX_USE_NEIGHBORS_694_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_695_CURRENT 1\n#define VFX_USE_NEIGHBORS_696_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_697_CURRENT 1\n#define VFX_USE_NEIGHBORS_698_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_699_CURRENT 1\n#define VFX_USE_NEIGHBORS_700_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_701_CURRENT 1\n#define VFX_USE_NEIGHBORS_702_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_703_CURRENT 1\n#define VFX_USE_NEIGHBORS_704_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_705_CURRENT 1\n#define VFX_USE_NEIGHBORS_706_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_707_CURRENT 1\n#define VFX_USE_NEIGHBORS_708_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_709_CURRENT 1\n#define VFX_USE_NEIGHBORS_710_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_711_CURRENT 1\n#define VFX_USE_NEIGHBORS_712_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_713_CURRENT 1\n#define VFX_USE_NEIGHBORS_714_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_715_CURRENT 1\n#define VFX_USE_NEIGHBORS_716_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_717_CURRENT 1\n#define VFX_USE_NEIGHBORS_718_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_719_CURRENT 1\n#define VFX_USE_NEIGHBORS_720_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_721_CURRENT 1\n#define VFX_USE_NEIGHBORS_722_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_723_CURRENT 1\n#define VFX_USE_NEIGHBORS_724_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_725_CURRENT 1\n#define VFX_USE_NEIGHBORS_726_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_727_CURRENT 1\n#define VFX_USE_NEIGHBORS_728_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_729_CURRENT 1\n#define VFX_USE_NEIGHBORS_730_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_731_CURRENT 1\n#define VFX_USE_NEIGHBORS_732_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_733_CURRENT 1\n#define VFX_USE_NEIGHBORS_734_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_735_CURRENT 1\n#define VFX_USE_NEIGHBORS_736_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_737_CURRENT 1\n#define VFX_USE_NEIGHBORS_738_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_739_CURRENT 1\n#define VFX_USE_NEIGHBORS_740_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_741_CURRENT 1\n#define VFX_USE_NEIGHBORS_742_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_743_CURRENT 1\n#define VFX_USE_NEIGHBORS_744_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_745_CURRENT 1\n#define VFX_USE_NEIGHBORS_746_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_747_CURRENT 1\n#define VFX_USE_NEIGHBORS_748_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_749_CURRENT 1\n#define VFX_USE_NEIGHBORS_750_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_751_CURRENT 1\n#define VFX_USE_NEIGHBORS_752_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_753_CURRENT 1\n#define VFX_USE_NEIGHBORS_754_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_755_CURRENT 1\n#define VFX_USE_NEIGHBORS_756_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_757_CURRENT 1\n#define VFX_USE_NEIGHBORS_758_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_759_CURRENT 1\n#define VFX_USE_NEIGHBORS_760_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_761_CURRENT 1\n#define VFX_USE_NEIGHBORS_762_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_763_CURRENT 1\n#define VFX_USE_NEIGHBORS_764_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_765_CURRENT 1\n#define VFX_USE_NEIGHBORS_766_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_767_CURRENT 1\n#define VFX_USE_NEIGHBORS_768_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_769_CURRENT 1\n#define VFX_USE_NEIGHBORS_770_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_771_CURRENT 1\n#define VFX_USE_NEIGHBORS_772_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_773_CURRENT 1\n#define VFX_USE_NEIGHBORS_774_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_775_CURRENT 1\n#define VFX_USE_NEIGHBORS_776_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_777_CURRENT 1\n#define VFX_USE_NEIGHBORS_778_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_779_CURRENT 1\n#define VFX_USE_NEIGHBORS_780_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_781_CURRENT 1\n#define VFX_USE_NEIGHBORS_782_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_783_CURRENT 1\n#define VFX_USE_NEIGHBORS_784_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_785_CURRENT 1\n#define VFX_USE_NEIGHBORS_786_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_787_CURRENT 1\n#define VFX_USE_NEIGHBORS_788_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_789_CURRENT 1\n#define VFX_USE_NEIGHBORS_790_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_791_CURRENT 1\n#define VFX_USE_NEIGHBORS_792_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_793_CURRENT 1\n#define VFX_USE_NEIGHBORS_794_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_795_CURRENT 1\n#define VFX_USE_NEIGHBORS_796_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_797_CURRENT 1\n#define VFX_USE_NEIGHBORS_798_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_799_CURRENT 1\n#define VFX_USE_NEIGHBORS_800_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_801_CURRENT 1\n#define VFX_USE_NEIGHBORS_802_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_803_CURRENT 1\n#define VFX_USE_NEIGHBORS_804_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_805_CURRENT 1\n#define VFX_USE_NEIGHBORS_806_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_807_CURRENT 1\n#define VFX_USE_NEIGHBORS_808_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_809_CURRENT 1\n#define VFX_USE_NEIGHBORS_810_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_811_CURRENT 1\n#define VFX_USE_NEIGHBORS_812_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_813_CURRENT 1\n#define VFX_USE_NEIGHBORS_814_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_815_CURRENT 1\n#define VFX_USE_NEIGHBORS_816_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_817_CURRENT 1\n#define VFX_USE_NEIGHBORS_818_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_819_CURRENT 1\n#define VFX_USE_NEIGHBORS_820_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_821_CURRENT 1\n#define VFX_USE_NEIGHBORS_822_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_823_CURRENT 1\n#define VFX_USE_NEIGHBORS_824_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_825_CURRENT 1\n#define VFX_USE_NEIGHBORS_826_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_827_CURRENT 1\n#define VFX_USE_NEIGHBORS_828_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_829_CURRENT 1\n#define VFX_USE_NEIGHBORS_830_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_831_CURRENT 1\n#define VFX_USE_NEIGHBORS_832_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_833_CURRENT 1\n#define VFX_USE_NEIGHBORS_834_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_835_CURRENT 1\n#define VFX_USE_NEIGHBORS_836_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_837_CURRENT 1\n#define VFX_USE_NEIGHBORS_838_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_839_CURRENT 1\n#define VFX_USE_NEIGHBORS_840_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_841_CURRENT 1\n#define VFX_USE_NEIGHBORS_842_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_843_CURRENT 1\n#define VFX_USE_NEIGHBORS_844_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_845_CURRENT 1\n#define VFX_USE_NEIGHBORS_846_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_847_CURRENT 1\n#define VFX_USE_NEIGHBORS_848_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_849_CURRENT 1\n#define VFX_USE_NEIGHBORS_850_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_851_CURRENT 1\n#define VFX_USE_NEIGHBORS_852_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_853_CURRENT 1\n#define VFX_USE_NEIGHBORS_854_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_855_CURRENT 1\n#define VFX_USE_NEIGHBORS_856_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_857_CURRENT 1\n#define VFX_USE_NEIGHBORS_858_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_859_CURRENT 1\n#define VFX_USE_NEIGHBORS_860_CURRENT
-      1\n#define VFX_USE_NEIGHBORS_861_CURRENT 1\n#define VFX_USE_NEIGHBORS_862_CURRENT
-      1\n#define VFX_USE_DENSITYPRESSURE_CURRENT 1\n#define VFX_USE_NORMAL_CURRENT
-      1\n#define VFX_USE_PREVIOUSPOSITION_CURRENT 1\n#define VFX_USE_ALIVE_CURRENT
-      1\n#define VFX_USE_AGE_CURRENT 1\n#define VFX_WORLD_SPACE 1\n\n\nCBUFFER_START(parameters)\n
+    source: "#pragma kernel CSMain\n#define NB_THREADS_PER_GROUP 64\n#define VFX_USE_LIFETIME_CURRENT
+      1\n#define VFX_USE_POSITION_CURRENT 1\n#define VFX_USE_SEED_CURRENT 1\n#define
+      VFX_USE_DIRECTION_CURRENT 1\n#define VFX_USE_VELOCITY_CURRENT 1\n#define VFX_USE_FORCE_CURRENT
+      1\n#define VFX_USE_MASS_CURRENT 1\n#define VFX_USE_SIZE_CURRENT 1\n#define VFX_USE_BUCKETS_0_CURRENT
+      1\n#define VFX_USE_BUCKETS_1_CURRENT 1\n#define VFX_USE_BUCKETS_2_CURRENT 1\n#define
+      VFX_USE_BUCKETS_3_CURRENT 1\n#define VFX_USE_BUCKETS_4_CURRENT 1\n#define VFX_USE_BUCKETS_5_CURRENT
+      1\n#define VFX_USE_BUCKETS_6_CURRENT 1\n#define VFX_USE_BUCKETS_7_CURRENT 1\n#define
+      VFX_USE_BUCKETS_8_CURRENT 1\n#define VFX_USE_BUCKETS_9_CURRENT 1\n#define VFX_USE_BUCKETS_10_CURRENT
+      1\n#define VFX_USE_BUCKETS_11_CURRENT 1\n#define VFX_USE_BUCKETS_12_CURRENT
+      1\n#define VFX_USE_BUCKETS_13_CURRENT 1\n#define VFX_USE_BUCKETS_14_CURRENT
+      1\n#define VFX_USE_BUCKETS_15_CURRENT 1\n#define VFX_USE_BUCKETS_16_CURRENT
+      1\n#define VFX_USE_BUCKETS_17_CURRENT 1\n#define VFX_USE_BUCKETS_18_CURRENT
+      1\n#define VFX_USE_BUCKETS_19_CURRENT 1\n#define VFX_USE_BUCKETS_20_CURRENT
+      1\n#define VFX_USE_BUCKETS_21_CURRENT 1\n#define VFX_USE_BUCKETS_22_CURRENT
+      1\n#define VFX_USE_BUCKETS_23_CURRENT 1\n#define VFX_USE_BUCKETS_24_CURRENT
+      1\n#define VFX_USE_BUCKETS_25_CURRENT 1\n#define VFX_USE_BUCKETS_26_CURRENT
+      1\n#define VFX_USE_BUCKETS_27_CURRENT 1\n#define VFX_USE_BUCKETS_28_CURRENT
+      1\n#define VFX_USE_BUCKETS_29_CURRENT 1\n#define VFX_USE_BUCKETS_30_CURRENT
+      1\n#define VFX_USE_BUCKETS_31_CURRENT 1\n#define VFX_USE_NEIGHBORCOUNT_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_0_CURRENT 1\n#define VFX_USE_NEIGHBORS_1_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_2_CURRENT 1\n#define VFX_USE_NEIGHBORS_3_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_4_CURRENT 1\n#define VFX_USE_NEIGHBORS_5_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_6_CURRENT 1\n#define VFX_USE_NEIGHBORS_7_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_8_CURRENT 1\n#define VFX_USE_NEIGHBORS_9_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_10_CURRENT 1\n#define VFX_USE_NEIGHBORS_11_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_12_CURRENT 1\n#define VFX_USE_NEIGHBORS_13_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_14_CURRENT 1\n#define VFX_USE_NEIGHBORS_15_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_16_CURRENT 1\n#define VFX_USE_NEIGHBORS_17_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_18_CURRENT 1\n#define VFX_USE_NEIGHBORS_19_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_20_CURRENT 1\n#define VFX_USE_NEIGHBORS_21_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_22_CURRENT 1\n#define VFX_USE_NEIGHBORS_23_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_24_CURRENT 1\n#define VFX_USE_NEIGHBORS_25_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_26_CURRENT 1\n#define VFX_USE_NEIGHBORS_27_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_28_CURRENT 1\n#define VFX_USE_NEIGHBORS_29_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_30_CURRENT 1\n#define VFX_USE_NEIGHBORS_31_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_32_CURRENT 1\n#define VFX_USE_NEIGHBORS_33_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_34_CURRENT 1\n#define VFX_USE_NEIGHBORS_35_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_36_CURRENT 1\n#define VFX_USE_NEIGHBORS_37_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_38_CURRENT 1\n#define VFX_USE_NEIGHBORS_39_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_40_CURRENT 1\n#define VFX_USE_NEIGHBORS_41_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_42_CURRENT 1\n#define VFX_USE_NEIGHBORS_43_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_44_CURRENT 1\n#define VFX_USE_NEIGHBORS_45_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_46_CURRENT 1\n#define VFX_USE_NEIGHBORS_47_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_48_CURRENT 1\n#define VFX_USE_NEIGHBORS_49_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_50_CURRENT 1\n#define VFX_USE_NEIGHBORS_51_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_52_CURRENT 1\n#define VFX_USE_NEIGHBORS_53_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_54_CURRENT 1\n#define VFX_USE_NEIGHBORS_55_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_56_CURRENT 1\n#define VFX_USE_NEIGHBORS_57_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_58_CURRENT 1\n#define VFX_USE_NEIGHBORS_59_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_60_CURRENT 1\n#define VFX_USE_NEIGHBORS_61_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_62_CURRENT 1\n#define VFX_USE_NEIGHBORS_63_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_64_CURRENT 1\n#define VFX_USE_NEIGHBORS_65_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_66_CURRENT 1\n#define VFX_USE_NEIGHBORS_67_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_68_CURRENT 1\n#define VFX_USE_NEIGHBORS_69_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_70_CURRENT 1\n#define VFX_USE_NEIGHBORS_71_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_72_CURRENT 1\n#define VFX_USE_NEIGHBORS_73_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_74_CURRENT 1\n#define VFX_USE_NEIGHBORS_75_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_76_CURRENT 1\n#define VFX_USE_NEIGHBORS_77_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_78_CURRENT 1\n#define VFX_USE_NEIGHBORS_79_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_80_CURRENT 1\n#define VFX_USE_NEIGHBORS_81_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_82_CURRENT 1\n#define VFX_USE_NEIGHBORS_83_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_84_CURRENT 1\n#define VFX_USE_NEIGHBORS_85_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_86_CURRENT 1\n#define VFX_USE_NEIGHBORS_87_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_88_CURRENT 1\n#define VFX_USE_NEIGHBORS_89_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_90_CURRENT 1\n#define VFX_USE_NEIGHBORS_91_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_92_CURRENT 1\n#define VFX_USE_NEIGHBORS_93_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_94_CURRENT 1\n#define VFX_USE_NEIGHBORS_95_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_96_CURRENT 1\n#define VFX_USE_NEIGHBORS_97_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_98_CURRENT 1\n#define VFX_USE_NEIGHBORS_99_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_100_CURRENT 1\n#define VFX_USE_NEIGHBORS_101_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_102_CURRENT 1\n#define VFX_USE_NEIGHBORS_103_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_104_CURRENT 1\n#define VFX_USE_NEIGHBORS_105_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_106_CURRENT 1\n#define VFX_USE_NEIGHBORS_107_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_108_CURRENT 1\n#define VFX_USE_NEIGHBORS_109_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_110_CURRENT 1\n#define VFX_USE_NEIGHBORS_111_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_112_CURRENT 1\n#define VFX_USE_NEIGHBORS_113_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_114_CURRENT 1\n#define VFX_USE_NEIGHBORS_115_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_116_CURRENT 1\n#define VFX_USE_NEIGHBORS_117_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_118_CURRENT 1\n#define VFX_USE_NEIGHBORS_119_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_120_CURRENT 1\n#define VFX_USE_NEIGHBORS_121_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_122_CURRENT 1\n#define VFX_USE_NEIGHBORS_123_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_124_CURRENT 1\n#define VFX_USE_NEIGHBORS_125_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_126_CURRENT 1\n#define VFX_USE_NEIGHBORS_127_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_128_CURRENT 1\n#define VFX_USE_NEIGHBORS_129_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_130_CURRENT 1\n#define VFX_USE_NEIGHBORS_131_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_132_CURRENT 1\n#define VFX_USE_NEIGHBORS_133_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_134_CURRENT 1\n#define VFX_USE_NEIGHBORS_135_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_136_CURRENT 1\n#define VFX_USE_NEIGHBORS_137_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_138_CURRENT 1\n#define VFX_USE_NEIGHBORS_139_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_140_CURRENT 1\n#define VFX_USE_NEIGHBORS_141_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_142_CURRENT 1\n#define VFX_USE_NEIGHBORS_143_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_144_CURRENT 1\n#define VFX_USE_NEIGHBORS_145_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_146_CURRENT 1\n#define VFX_USE_NEIGHBORS_147_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_148_CURRENT 1\n#define VFX_USE_NEIGHBORS_149_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_150_CURRENT 1\n#define VFX_USE_NEIGHBORS_151_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_152_CURRENT 1\n#define VFX_USE_NEIGHBORS_153_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_154_CURRENT 1\n#define VFX_USE_NEIGHBORS_155_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_156_CURRENT 1\n#define VFX_USE_NEIGHBORS_157_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_158_CURRENT 1\n#define VFX_USE_NEIGHBORS_159_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_160_CURRENT 1\n#define VFX_USE_NEIGHBORS_161_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_162_CURRENT 1\n#define VFX_USE_NEIGHBORS_163_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_164_CURRENT 1\n#define VFX_USE_NEIGHBORS_165_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_166_CURRENT 1\n#define VFX_USE_NEIGHBORS_167_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_168_CURRENT 1\n#define VFX_USE_NEIGHBORS_169_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_170_CURRENT 1\n#define VFX_USE_NEIGHBORS_171_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_172_CURRENT 1\n#define VFX_USE_NEIGHBORS_173_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_174_CURRENT 1\n#define VFX_USE_NEIGHBORS_175_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_176_CURRENT 1\n#define VFX_USE_NEIGHBORS_177_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_178_CURRENT 1\n#define VFX_USE_NEIGHBORS_179_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_180_CURRENT 1\n#define VFX_USE_NEIGHBORS_181_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_182_CURRENT 1\n#define VFX_USE_NEIGHBORS_183_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_184_CURRENT 1\n#define VFX_USE_NEIGHBORS_185_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_186_CURRENT 1\n#define VFX_USE_NEIGHBORS_187_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_188_CURRENT 1\n#define VFX_USE_NEIGHBORS_189_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_190_CURRENT 1\n#define VFX_USE_NEIGHBORS_191_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_192_CURRENT 1\n#define VFX_USE_NEIGHBORS_193_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_194_CURRENT 1\n#define VFX_USE_NEIGHBORS_195_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_196_CURRENT 1\n#define VFX_USE_NEIGHBORS_197_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_198_CURRENT 1\n#define VFX_USE_NEIGHBORS_199_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_200_CURRENT 1\n#define VFX_USE_NEIGHBORS_201_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_202_CURRENT 1\n#define VFX_USE_NEIGHBORS_203_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_204_CURRENT 1\n#define VFX_USE_NEIGHBORS_205_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_206_CURRENT 1\n#define VFX_USE_NEIGHBORS_207_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_208_CURRENT 1\n#define VFX_USE_NEIGHBORS_209_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_210_CURRENT 1\n#define VFX_USE_NEIGHBORS_211_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_212_CURRENT 1\n#define VFX_USE_NEIGHBORS_213_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_214_CURRENT 1\n#define VFX_USE_NEIGHBORS_215_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_216_CURRENT 1\n#define VFX_USE_NEIGHBORS_217_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_218_CURRENT 1\n#define VFX_USE_NEIGHBORS_219_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_220_CURRENT 1\n#define VFX_USE_NEIGHBORS_221_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_222_CURRENT 1\n#define VFX_USE_NEIGHBORS_223_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_224_CURRENT 1\n#define VFX_USE_NEIGHBORS_225_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_226_CURRENT 1\n#define VFX_USE_NEIGHBORS_227_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_228_CURRENT 1\n#define VFX_USE_NEIGHBORS_229_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_230_CURRENT 1\n#define VFX_USE_NEIGHBORS_231_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_232_CURRENT 1\n#define VFX_USE_NEIGHBORS_233_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_234_CURRENT 1\n#define VFX_USE_NEIGHBORS_235_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_236_CURRENT 1\n#define VFX_USE_NEIGHBORS_237_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_238_CURRENT 1\n#define VFX_USE_NEIGHBORS_239_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_240_CURRENT 1\n#define VFX_USE_NEIGHBORS_241_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_242_CURRENT 1\n#define VFX_USE_NEIGHBORS_243_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_244_CURRENT 1\n#define VFX_USE_NEIGHBORS_245_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_246_CURRENT 1\n#define VFX_USE_NEIGHBORS_247_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_248_CURRENT 1\n#define VFX_USE_NEIGHBORS_249_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_250_CURRENT 1\n#define VFX_USE_NEIGHBORS_251_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_252_CURRENT 1\n#define VFX_USE_NEIGHBORS_253_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_254_CURRENT 1\n#define VFX_USE_NEIGHBORS_255_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_256_CURRENT 1\n#define VFX_USE_NEIGHBORS_257_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_258_CURRENT 1\n#define VFX_USE_NEIGHBORS_259_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_260_CURRENT 1\n#define VFX_USE_NEIGHBORS_261_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_262_CURRENT 1\n#define VFX_USE_NEIGHBORS_263_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_264_CURRENT 1\n#define VFX_USE_NEIGHBORS_265_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_266_CURRENT 1\n#define VFX_USE_NEIGHBORS_267_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_268_CURRENT 1\n#define VFX_USE_NEIGHBORS_269_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_270_CURRENT 1\n#define VFX_USE_NEIGHBORS_271_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_272_CURRENT 1\n#define VFX_USE_NEIGHBORS_273_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_274_CURRENT 1\n#define VFX_USE_NEIGHBORS_275_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_276_CURRENT 1\n#define VFX_USE_NEIGHBORS_277_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_278_CURRENT 1\n#define VFX_USE_NEIGHBORS_279_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_280_CURRENT 1\n#define VFX_USE_NEIGHBORS_281_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_282_CURRENT 1\n#define VFX_USE_NEIGHBORS_283_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_284_CURRENT 1\n#define VFX_USE_NEIGHBORS_285_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_286_CURRENT 1\n#define VFX_USE_NEIGHBORS_287_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_288_CURRENT 1\n#define VFX_USE_NEIGHBORS_289_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_290_CURRENT 1\n#define VFX_USE_NEIGHBORS_291_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_292_CURRENT 1\n#define VFX_USE_NEIGHBORS_293_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_294_CURRENT 1\n#define VFX_USE_NEIGHBORS_295_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_296_CURRENT 1\n#define VFX_USE_NEIGHBORS_297_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_298_CURRENT 1\n#define VFX_USE_NEIGHBORS_299_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_300_CURRENT 1\n#define VFX_USE_NEIGHBORS_301_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_302_CURRENT 1\n#define VFX_USE_NEIGHBORS_303_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_304_CURRENT 1\n#define VFX_USE_NEIGHBORS_305_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_306_CURRENT 1\n#define VFX_USE_NEIGHBORS_307_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_308_CURRENT 1\n#define VFX_USE_NEIGHBORS_309_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_310_CURRENT 1\n#define VFX_USE_NEIGHBORS_311_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_312_CURRENT 1\n#define VFX_USE_NEIGHBORS_313_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_314_CURRENT 1\n#define VFX_USE_NEIGHBORS_315_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_316_CURRENT 1\n#define VFX_USE_NEIGHBORS_317_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_318_CURRENT 1\n#define VFX_USE_NEIGHBORS_319_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_320_CURRENT 1\n#define VFX_USE_NEIGHBORS_321_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_322_CURRENT 1\n#define VFX_USE_NEIGHBORS_323_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_324_CURRENT 1\n#define VFX_USE_NEIGHBORS_325_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_326_CURRENT 1\n#define VFX_USE_NEIGHBORS_327_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_328_CURRENT 1\n#define VFX_USE_NEIGHBORS_329_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_330_CURRENT 1\n#define VFX_USE_NEIGHBORS_331_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_332_CURRENT 1\n#define VFX_USE_NEIGHBORS_333_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_334_CURRENT 1\n#define VFX_USE_NEIGHBORS_335_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_336_CURRENT 1\n#define VFX_USE_NEIGHBORS_337_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_338_CURRENT 1\n#define VFX_USE_NEIGHBORS_339_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_340_CURRENT 1\n#define VFX_USE_NEIGHBORS_341_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_342_CURRENT 1\n#define VFX_USE_NEIGHBORS_343_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_344_CURRENT 1\n#define VFX_USE_NEIGHBORS_345_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_346_CURRENT 1\n#define VFX_USE_NEIGHBORS_347_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_348_CURRENT 1\n#define VFX_USE_NEIGHBORS_349_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_350_CURRENT 1\n#define VFX_USE_NEIGHBORS_351_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_352_CURRENT 1\n#define VFX_USE_NEIGHBORS_353_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_354_CURRENT 1\n#define VFX_USE_NEIGHBORS_355_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_356_CURRENT 1\n#define VFX_USE_NEIGHBORS_357_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_358_CURRENT 1\n#define VFX_USE_NEIGHBORS_359_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_360_CURRENT 1\n#define VFX_USE_NEIGHBORS_361_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_362_CURRENT 1\n#define VFX_USE_NEIGHBORS_363_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_364_CURRENT 1\n#define VFX_USE_NEIGHBORS_365_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_366_CURRENT 1\n#define VFX_USE_NEIGHBORS_367_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_368_CURRENT 1\n#define VFX_USE_NEIGHBORS_369_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_370_CURRENT 1\n#define VFX_USE_NEIGHBORS_371_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_372_CURRENT 1\n#define VFX_USE_NEIGHBORS_373_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_374_CURRENT 1\n#define VFX_USE_NEIGHBORS_375_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_376_CURRENT 1\n#define VFX_USE_NEIGHBORS_377_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_378_CURRENT 1\n#define VFX_USE_NEIGHBORS_379_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_380_CURRENT 1\n#define VFX_USE_NEIGHBORS_381_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_382_CURRENT 1\n#define VFX_USE_NEIGHBORS_383_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_384_CURRENT 1\n#define VFX_USE_NEIGHBORS_385_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_386_CURRENT 1\n#define VFX_USE_NEIGHBORS_387_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_388_CURRENT 1\n#define VFX_USE_NEIGHBORS_389_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_390_CURRENT 1\n#define VFX_USE_NEIGHBORS_391_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_392_CURRENT 1\n#define VFX_USE_NEIGHBORS_393_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_394_CURRENT 1\n#define VFX_USE_NEIGHBORS_395_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_396_CURRENT 1\n#define VFX_USE_NEIGHBORS_397_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_398_CURRENT 1\n#define VFX_USE_NEIGHBORS_399_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_400_CURRENT 1\n#define VFX_USE_NEIGHBORS_401_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_402_CURRENT 1\n#define VFX_USE_NEIGHBORS_403_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_404_CURRENT 1\n#define VFX_USE_NEIGHBORS_405_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_406_CURRENT 1\n#define VFX_USE_NEIGHBORS_407_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_408_CURRENT 1\n#define VFX_USE_NEIGHBORS_409_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_410_CURRENT 1\n#define VFX_USE_NEIGHBORS_411_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_412_CURRENT 1\n#define VFX_USE_NEIGHBORS_413_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_414_CURRENT 1\n#define VFX_USE_NEIGHBORS_415_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_416_CURRENT 1\n#define VFX_USE_NEIGHBORS_417_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_418_CURRENT 1\n#define VFX_USE_NEIGHBORS_419_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_420_CURRENT 1\n#define VFX_USE_NEIGHBORS_421_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_422_CURRENT 1\n#define VFX_USE_NEIGHBORS_423_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_424_CURRENT 1\n#define VFX_USE_NEIGHBORS_425_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_426_CURRENT 1\n#define VFX_USE_NEIGHBORS_427_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_428_CURRENT 1\n#define VFX_USE_NEIGHBORS_429_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_430_CURRENT 1\n#define VFX_USE_NEIGHBORS_431_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_432_CURRENT 1\n#define VFX_USE_NEIGHBORS_433_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_434_CURRENT 1\n#define VFX_USE_NEIGHBORS_435_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_436_CURRENT 1\n#define VFX_USE_NEIGHBORS_437_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_438_CURRENT 1\n#define VFX_USE_NEIGHBORS_439_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_440_CURRENT 1\n#define VFX_USE_NEIGHBORS_441_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_442_CURRENT 1\n#define VFX_USE_NEIGHBORS_443_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_444_CURRENT 1\n#define VFX_USE_NEIGHBORS_445_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_446_CURRENT 1\n#define VFX_USE_NEIGHBORS_447_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_448_CURRENT 1\n#define VFX_USE_NEIGHBORS_449_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_450_CURRENT 1\n#define VFX_USE_NEIGHBORS_451_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_452_CURRENT 1\n#define VFX_USE_NEIGHBORS_453_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_454_CURRENT 1\n#define VFX_USE_NEIGHBORS_455_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_456_CURRENT 1\n#define VFX_USE_NEIGHBORS_457_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_458_CURRENT 1\n#define VFX_USE_NEIGHBORS_459_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_460_CURRENT 1\n#define VFX_USE_NEIGHBORS_461_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_462_CURRENT 1\n#define VFX_USE_NEIGHBORS_463_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_464_CURRENT 1\n#define VFX_USE_NEIGHBORS_465_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_466_CURRENT 1\n#define VFX_USE_NEIGHBORS_467_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_468_CURRENT 1\n#define VFX_USE_NEIGHBORS_469_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_470_CURRENT 1\n#define VFX_USE_NEIGHBORS_471_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_472_CURRENT 1\n#define VFX_USE_NEIGHBORS_473_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_474_CURRENT 1\n#define VFX_USE_NEIGHBORS_475_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_476_CURRENT 1\n#define VFX_USE_NEIGHBORS_477_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_478_CURRENT 1\n#define VFX_USE_NEIGHBORS_479_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_480_CURRENT 1\n#define VFX_USE_NEIGHBORS_481_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_482_CURRENT 1\n#define VFX_USE_NEIGHBORS_483_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_484_CURRENT 1\n#define VFX_USE_NEIGHBORS_485_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_486_CURRENT 1\n#define VFX_USE_NEIGHBORS_487_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_488_CURRENT 1\n#define VFX_USE_NEIGHBORS_489_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_490_CURRENT 1\n#define VFX_USE_NEIGHBORS_491_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_492_CURRENT 1\n#define VFX_USE_NEIGHBORS_493_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_494_CURRENT 1\n#define VFX_USE_NEIGHBORS_495_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_496_CURRENT 1\n#define VFX_USE_NEIGHBORS_497_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_498_CURRENT 1\n#define VFX_USE_NEIGHBORS_499_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_500_CURRENT 1\n#define VFX_USE_NEIGHBORS_501_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_502_CURRENT 1\n#define VFX_USE_NEIGHBORS_503_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_504_CURRENT 1\n#define VFX_USE_NEIGHBORS_505_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_506_CURRENT 1\n#define VFX_USE_NEIGHBORS_507_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_508_CURRENT 1\n#define VFX_USE_NEIGHBORS_509_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_510_CURRENT 1\n#define VFX_USE_NEIGHBORS_511_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_512_CURRENT 1\n#define VFX_USE_NEIGHBORS_513_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_514_CURRENT 1\n#define VFX_USE_NEIGHBORS_515_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_516_CURRENT 1\n#define VFX_USE_NEIGHBORS_517_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_518_CURRENT 1\n#define VFX_USE_NEIGHBORS_519_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_520_CURRENT 1\n#define VFX_USE_NEIGHBORS_521_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_522_CURRENT 1\n#define VFX_USE_NEIGHBORS_523_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_524_CURRENT 1\n#define VFX_USE_NEIGHBORS_525_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_526_CURRENT 1\n#define VFX_USE_NEIGHBORS_527_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_528_CURRENT 1\n#define VFX_USE_NEIGHBORS_529_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_530_CURRENT 1\n#define VFX_USE_NEIGHBORS_531_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_532_CURRENT 1\n#define VFX_USE_NEIGHBORS_533_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_534_CURRENT 1\n#define VFX_USE_NEIGHBORS_535_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_536_CURRENT 1\n#define VFX_USE_NEIGHBORS_537_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_538_CURRENT 1\n#define VFX_USE_NEIGHBORS_539_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_540_CURRENT 1\n#define VFX_USE_NEIGHBORS_541_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_542_CURRENT 1\n#define VFX_USE_NEIGHBORS_543_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_544_CURRENT 1\n#define VFX_USE_NEIGHBORS_545_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_546_CURRENT 1\n#define VFX_USE_NEIGHBORS_547_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_548_CURRENT 1\n#define VFX_USE_NEIGHBORS_549_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_550_CURRENT 1\n#define VFX_USE_NEIGHBORS_551_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_552_CURRENT 1\n#define VFX_USE_NEIGHBORS_553_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_554_CURRENT 1\n#define VFX_USE_NEIGHBORS_555_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_556_CURRENT 1\n#define VFX_USE_NEIGHBORS_557_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_558_CURRENT 1\n#define VFX_USE_NEIGHBORS_559_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_560_CURRENT 1\n#define VFX_USE_NEIGHBORS_561_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_562_CURRENT 1\n#define VFX_USE_NEIGHBORS_563_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_564_CURRENT 1\n#define VFX_USE_NEIGHBORS_565_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_566_CURRENT 1\n#define VFX_USE_NEIGHBORS_567_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_568_CURRENT 1\n#define VFX_USE_NEIGHBORS_569_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_570_CURRENT 1\n#define VFX_USE_NEIGHBORS_571_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_572_CURRENT 1\n#define VFX_USE_NEIGHBORS_573_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_574_CURRENT 1\n#define VFX_USE_NEIGHBORS_575_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_576_CURRENT 1\n#define VFX_USE_NEIGHBORS_577_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_578_CURRENT 1\n#define VFX_USE_NEIGHBORS_579_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_580_CURRENT 1\n#define VFX_USE_NEIGHBORS_581_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_582_CURRENT 1\n#define VFX_USE_NEIGHBORS_583_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_584_CURRENT 1\n#define VFX_USE_NEIGHBORS_585_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_586_CURRENT 1\n#define VFX_USE_NEIGHBORS_587_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_588_CURRENT 1\n#define VFX_USE_NEIGHBORS_589_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_590_CURRENT 1\n#define VFX_USE_NEIGHBORS_591_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_592_CURRENT 1\n#define VFX_USE_NEIGHBORS_593_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_594_CURRENT 1\n#define VFX_USE_NEIGHBORS_595_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_596_CURRENT 1\n#define VFX_USE_NEIGHBORS_597_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_598_CURRENT 1\n#define VFX_USE_NEIGHBORS_599_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_600_CURRENT 1\n#define VFX_USE_NEIGHBORS_601_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_602_CURRENT 1\n#define VFX_USE_NEIGHBORS_603_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_604_CURRENT 1\n#define VFX_USE_NEIGHBORS_605_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_606_CURRENT 1\n#define VFX_USE_NEIGHBORS_607_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_608_CURRENT 1\n#define VFX_USE_NEIGHBORS_609_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_610_CURRENT 1\n#define VFX_USE_NEIGHBORS_611_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_612_CURRENT 1\n#define VFX_USE_NEIGHBORS_613_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_614_CURRENT 1\n#define VFX_USE_NEIGHBORS_615_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_616_CURRENT 1\n#define VFX_USE_NEIGHBORS_617_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_618_CURRENT 1\n#define VFX_USE_NEIGHBORS_619_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_620_CURRENT 1\n#define VFX_USE_NEIGHBORS_621_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_622_CURRENT 1\n#define VFX_USE_NEIGHBORS_623_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_624_CURRENT 1\n#define VFX_USE_NEIGHBORS_625_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_626_CURRENT 1\n#define VFX_USE_NEIGHBORS_627_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_628_CURRENT 1\n#define VFX_USE_NEIGHBORS_629_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_630_CURRENT 1\n#define VFX_USE_NEIGHBORS_631_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_632_CURRENT 1\n#define VFX_USE_NEIGHBORS_633_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_634_CURRENT 1\n#define VFX_USE_NEIGHBORS_635_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_636_CURRENT 1\n#define VFX_USE_NEIGHBORS_637_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_638_CURRENT 1\n#define VFX_USE_NEIGHBORS_639_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_640_CURRENT 1\n#define VFX_USE_NEIGHBORS_641_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_642_CURRENT 1\n#define VFX_USE_NEIGHBORS_643_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_644_CURRENT 1\n#define VFX_USE_NEIGHBORS_645_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_646_CURRENT 1\n#define VFX_USE_NEIGHBORS_647_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_648_CURRENT 1\n#define VFX_USE_NEIGHBORS_649_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_650_CURRENT 1\n#define VFX_USE_NEIGHBORS_651_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_652_CURRENT 1\n#define VFX_USE_NEIGHBORS_653_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_654_CURRENT 1\n#define VFX_USE_NEIGHBORS_655_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_656_CURRENT 1\n#define VFX_USE_NEIGHBORS_657_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_658_CURRENT 1\n#define VFX_USE_NEIGHBORS_659_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_660_CURRENT 1\n#define VFX_USE_NEIGHBORS_661_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_662_CURRENT 1\n#define VFX_USE_NEIGHBORS_663_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_664_CURRENT 1\n#define VFX_USE_NEIGHBORS_665_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_666_CURRENT 1\n#define VFX_USE_NEIGHBORS_667_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_668_CURRENT 1\n#define VFX_USE_NEIGHBORS_669_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_670_CURRENT 1\n#define VFX_USE_NEIGHBORS_671_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_672_CURRENT 1\n#define VFX_USE_NEIGHBORS_673_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_674_CURRENT 1\n#define VFX_USE_NEIGHBORS_675_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_676_CURRENT 1\n#define VFX_USE_NEIGHBORS_677_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_678_CURRENT 1\n#define VFX_USE_NEIGHBORS_679_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_680_CURRENT 1\n#define VFX_USE_NEIGHBORS_681_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_682_CURRENT 1\n#define VFX_USE_NEIGHBORS_683_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_684_CURRENT 1\n#define VFX_USE_NEIGHBORS_685_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_686_CURRENT 1\n#define VFX_USE_NEIGHBORS_687_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_688_CURRENT 1\n#define VFX_USE_NEIGHBORS_689_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_690_CURRENT 1\n#define VFX_USE_NEIGHBORS_691_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_692_CURRENT 1\n#define VFX_USE_NEIGHBORS_693_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_694_CURRENT 1\n#define VFX_USE_NEIGHBORS_695_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_696_CURRENT 1\n#define VFX_USE_NEIGHBORS_697_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_698_CURRENT 1\n#define VFX_USE_NEIGHBORS_699_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_700_CURRENT 1\n#define VFX_USE_NEIGHBORS_701_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_702_CURRENT 1\n#define VFX_USE_NEIGHBORS_703_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_704_CURRENT 1\n#define VFX_USE_NEIGHBORS_705_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_706_CURRENT 1\n#define VFX_USE_NEIGHBORS_707_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_708_CURRENT 1\n#define VFX_USE_NEIGHBORS_709_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_710_CURRENT 1\n#define VFX_USE_NEIGHBORS_711_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_712_CURRENT 1\n#define VFX_USE_NEIGHBORS_713_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_714_CURRENT 1\n#define VFX_USE_NEIGHBORS_715_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_716_CURRENT 1\n#define VFX_USE_NEIGHBORS_717_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_718_CURRENT 1\n#define VFX_USE_NEIGHBORS_719_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_720_CURRENT 1\n#define VFX_USE_NEIGHBORS_721_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_722_CURRENT 1\n#define VFX_USE_NEIGHBORS_723_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_724_CURRENT 1\n#define VFX_USE_NEIGHBORS_725_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_726_CURRENT 1\n#define VFX_USE_NEIGHBORS_727_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_728_CURRENT 1\n#define VFX_USE_NEIGHBORS_729_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_730_CURRENT 1\n#define VFX_USE_NEIGHBORS_731_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_732_CURRENT 1\n#define VFX_USE_NEIGHBORS_733_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_734_CURRENT 1\n#define VFX_USE_NEIGHBORS_735_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_736_CURRENT 1\n#define VFX_USE_NEIGHBORS_737_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_738_CURRENT 1\n#define VFX_USE_NEIGHBORS_739_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_740_CURRENT 1\n#define VFX_USE_NEIGHBORS_741_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_742_CURRENT 1\n#define VFX_USE_NEIGHBORS_743_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_744_CURRENT 1\n#define VFX_USE_NEIGHBORS_745_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_746_CURRENT 1\n#define VFX_USE_NEIGHBORS_747_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_748_CURRENT 1\n#define VFX_USE_NEIGHBORS_749_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_750_CURRENT 1\n#define VFX_USE_NEIGHBORS_751_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_752_CURRENT 1\n#define VFX_USE_NEIGHBORS_753_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_754_CURRENT 1\n#define VFX_USE_NEIGHBORS_755_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_756_CURRENT 1\n#define VFX_USE_NEIGHBORS_757_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_758_CURRENT 1\n#define VFX_USE_NEIGHBORS_759_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_760_CURRENT 1\n#define VFX_USE_NEIGHBORS_761_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_762_CURRENT 1\n#define VFX_USE_NEIGHBORS_763_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_764_CURRENT 1\n#define VFX_USE_NEIGHBORS_765_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_766_CURRENT 1\n#define VFX_USE_NEIGHBORS_767_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_768_CURRENT 1\n#define VFX_USE_NEIGHBORS_769_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_770_CURRENT 1\n#define VFX_USE_NEIGHBORS_771_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_772_CURRENT 1\n#define VFX_USE_NEIGHBORS_773_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_774_CURRENT 1\n#define VFX_USE_NEIGHBORS_775_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_776_CURRENT 1\n#define VFX_USE_NEIGHBORS_777_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_778_CURRENT 1\n#define VFX_USE_NEIGHBORS_779_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_780_CURRENT 1\n#define VFX_USE_NEIGHBORS_781_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_782_CURRENT 1\n#define VFX_USE_NEIGHBORS_783_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_784_CURRENT 1\n#define VFX_USE_NEIGHBORS_785_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_786_CURRENT 1\n#define VFX_USE_NEIGHBORS_787_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_788_CURRENT 1\n#define VFX_USE_NEIGHBORS_789_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_790_CURRENT 1\n#define VFX_USE_NEIGHBORS_791_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_792_CURRENT 1\n#define VFX_USE_NEIGHBORS_793_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_794_CURRENT 1\n#define VFX_USE_NEIGHBORS_795_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_796_CURRENT 1\n#define VFX_USE_NEIGHBORS_797_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_798_CURRENT 1\n#define VFX_USE_NEIGHBORS_799_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_800_CURRENT 1\n#define VFX_USE_NEIGHBORS_801_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_802_CURRENT 1\n#define VFX_USE_NEIGHBORS_803_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_804_CURRENT 1\n#define VFX_USE_NEIGHBORS_805_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_806_CURRENT 1\n#define VFX_USE_NEIGHBORS_807_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_808_CURRENT 1\n#define VFX_USE_NEIGHBORS_809_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_810_CURRENT 1\n#define VFX_USE_NEIGHBORS_811_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_812_CURRENT 1\n#define VFX_USE_NEIGHBORS_813_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_814_CURRENT 1\n#define VFX_USE_NEIGHBORS_815_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_816_CURRENT 1\n#define VFX_USE_NEIGHBORS_817_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_818_CURRENT 1\n#define VFX_USE_NEIGHBORS_819_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_820_CURRENT 1\n#define VFX_USE_NEIGHBORS_821_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_822_CURRENT 1\n#define VFX_USE_NEIGHBORS_823_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_824_CURRENT 1\n#define VFX_USE_NEIGHBORS_825_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_826_CURRENT 1\n#define VFX_USE_NEIGHBORS_827_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_828_CURRENT 1\n#define VFX_USE_NEIGHBORS_829_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_830_CURRENT 1\n#define VFX_USE_NEIGHBORS_831_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_832_CURRENT 1\n#define VFX_USE_NEIGHBORS_833_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_834_CURRENT 1\n#define VFX_USE_NEIGHBORS_835_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_836_CURRENT 1\n#define VFX_USE_NEIGHBORS_837_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_838_CURRENT 1\n#define VFX_USE_NEIGHBORS_839_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_840_CURRENT 1\n#define VFX_USE_NEIGHBORS_841_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_842_CURRENT 1\n#define VFX_USE_NEIGHBORS_843_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_844_CURRENT 1\n#define VFX_USE_NEIGHBORS_845_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_846_CURRENT 1\n#define VFX_USE_NEIGHBORS_847_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_848_CURRENT 1\n#define VFX_USE_NEIGHBORS_849_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_850_CURRENT 1\n#define VFX_USE_NEIGHBORS_851_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_852_CURRENT 1\n#define VFX_USE_NEIGHBORS_853_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_854_CURRENT 1\n#define VFX_USE_NEIGHBORS_855_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_856_CURRENT 1\n#define VFX_USE_NEIGHBORS_857_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_858_CURRENT 1\n#define VFX_USE_NEIGHBORS_859_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_860_CURRENT 1\n#define VFX_USE_NEIGHBORS_861_CURRENT
+      1\n#define VFX_USE_NEIGHBORS_862_CURRENT 1\n#define VFX_USE_DENSITYPRESSURE_CURRENT
+      1\n#define VFX_USE_NORMAL_CURRENT 1\n#define VFX_USE_PREVIOUSPOSITION_CURRENT
+      1\n#define VFX_USE_ALIVE_CURRENT 1\n#define VFX_USE_AGE_CURRENT 1\n#define VFX_WORLD_SPACE
+      1\n#include \"Packages/com.unity.visualeffectgraph/Shaders/RenderPipeline/HDRP/VFXDefines.hlsl\"\n\n\nCBUFFER_START(parameters)\n
       \   float3 Cone_center_b;\n    uint PADDING_0;\nCBUFFER_END\n\n\n#include \"Packages/com.unity.visualeffectgraph/Shaders/Common/VFXCommonCompute.cginc\"\n#include
       \"Packages/com.unity.visualeffectgraph/Shaders/VFXCommon.cginc\"\n\n\n\nRWByteAddressBuffer
       attributeBuffer;\nByteAddressBuffer sourceAttributeBuffer;\n\nCBUFFER_START(initParams)\n#if
@@ -1183,7 +1160,7 @@ VisualEffectResource:
       += uint(asfloat(sourceAttributeBuffer.Load((sourceIndex * 0x1 + 0x0) << 2)));\n
       \           if (id < currentSumSpawnCount)\n            {\n                break;\n
       \           }\n        }\n        */\n        \n\n#endif\n        float lifetime
-      = (float)0;\n        float3 position = float3(0,0,0);\n        uint seed = (uint)0;\n
+      = (float)1;\n        float3 position = float3(0,0,0);\n        uint seed = (uint)0;\n
       \       float3 direction = float3(0,0,1);\n        float3 velocity = float3(0,0,0);\n
       \       float3 force = float3(0,0,0);\n        float mass = (float)1;\n        float
       size = (float)0.1;\n        uint buckets_0 = (uint)0;\n        uint buckets_1
@@ -3462,13 +3439,12 @@ VisualEffectResource:
   - compute: 0
     name: '[System 1]Quad Output'
     source: "Shader \"Hidden/VFX/System 1/Quad Output\"\n{\n\tSubShader\n\t{\t\n\t\tCull
-      Off\n\t\t\n\t\tTags { \"Queue\"=\"Transparent\" \"IgnoreProjector\"=\"True\"
-      \"RenderType\"=\"Transparent\" }\n\t\t\n\t\t\n\t\t\n\t\t\n\t\t\n\t\t\n\t\t\n\t\t\n\t\t\n\t\t\n\t\t\n\t\t\n\t\tBlend
-      SrcAlpha OneMinusSrcAlpha\n\t\tZTest LEqual\n\t\tZWrite Off\n\t\tCull Off\n\t\t\n\t\n\t\t\t\n\t\tHLSLINCLUDE\n\t\t#if
+      Off\n\t\t\n\t\tTags { \"Queue\"=\"Transparent+0\" \"IgnoreProjector\"=\"True\"
+      \"RenderType\"=\"Transparent\" }\n\t\t\n\t\t\n\t\t\n\t\t\n\t\t\n\t\t\n\t\t\n\t\t\n\t\t\n\t\t\n\t\t\n\t\t\n\t\t\n\t\t\n\t\tBlend
+      SrcAlpha OneMinusSrcAlpha \n\t\tZTest LEqual\n\t\tZWrite Off\n\t\tCull Off\n\t\t\n\t\n\t\t\t\n\t\tHLSLINCLUDE\n\t\t#if
       !defined(VFX_WORLD_SPACE) && !defined(VFX_LOCAL_SPACE)\n\t\t#define VFX_LOCAL_SPACE
-      1\n\t\t#endif\n\t\t\n\t\t#include \"HLSLSupport.cginc\"\n\t\t#define NB_THREADS_PER_GROUP
-      64\n\t\t#define VFX_USE_LIFETIME_CURRENT 1\n\t\t#define VFX_USE_POSITION_CURRENT
-      1\n\t\t#define VFX_USE_SIZE_CURRENT 1\n\t\t#define VFX_USE_DENSITYPRESSURE_CURRENT
+      1\n\t\t#endif\n\t\t\n\t\t#define NB_THREADS_PER_GROUP 64\n\t\t#define VFX_USE_LIFETIME_CURRENT
+      1\n\t\t#define VFX_USE_POSITION_CURRENT 1\n\t\t#define VFX_USE_SIZE_CURRENT
       1\n\t\t#define VFX_USE_COLOR_CURRENT 1\n\t\t#define VFX_USE_ALPHA_CURRENT 1\n\t\t#define
       VFX_USE_ALIVE_CURRENT 1\n\t\t#define VFX_USE_AXISX_CURRENT 1\n\t\t#define VFX_USE_AXISY_CURRENT
       1\n\t\t#define VFX_USE_AXISZ_CURRENT 1\n\t\t#define VFX_USE_ANGLEX_CURRENT 1\n\t\t#define
@@ -3476,32 +3452,37 @@ VisualEffectResource:
       VFX_USE_PIVOTX_CURRENT 1\n\t\t#define VFX_USE_PIVOTY_CURRENT 1\n\t\t#define
       VFX_USE_PIVOTZ_CURRENT 1\n\t\t#define VFX_USE_SCALEX_CURRENT 1\n\t\t#define
       VFX_USE_SCALEY_CURRENT 1\n\t\t#define VFX_USE_SCALEZ_CURRENT 1\n\t\t#define
-      VFX_USE_AGE_CURRENT 1\n\t\t#define VFX_BLENDMODE_ALPHA 1\n\t\t#define VFX_HAS_INDIRECT_DRAW
-      1\n\t\t#define USE_DEAD_LIST_COUNT 1\n\t\t\n\t\t\n\t\t\n\t\t#define VFX_WORLD_SPACE
-      1\n\t\t\n\n\t\tCBUFFER_START(parameters)\n\t\t    float4 Size_a;\n\t\t    float4
-      Alpha_b;\n\t\tCBUFFER_END\n\t\tTexture2D mainTexture;\n\t\tSamplerState samplermainTexture;\n\t\t\n\n\t\t\n\t\t#define
-      VFX_NEEDS_COLOR_INTERPOLATOR (VFX_USE_COLOR_CURRENT || VFX_USE_ALPHA_CURRENT)\n\t\t#define
-      IS_TRANSPARENT_PARTICLE (!IS_OPAQUE_PARTICLE)\n\t\t\n\t\t#include \"Packages/com.unity.visualeffectgraph/Shaders/RenderPipeline/HDRP/VFXGlobalDefines.cginc\"\n\t\t\n\n\t\t\n\t\tByteAddressBuffer
+      VFX_USE_AGE_CURRENT 1\n\t\t#define VFX_COLORMAPPING_DEFAULT 1\n\t\t#define IS_TRANSPARENT_PARTICLE
+      1\n\t\t#define VFX_BLENDMODE_ALPHA 1\n\t\t#define VFX_HAS_INDIRECT_DRAW 1\n\t\t#define
+      USE_DEAD_LIST_COUNT 1\n\t\t#define VFX_PRIMITIVE_QUAD 1\n\t\t\n\t\t\n\t\t\n\t\t#define
+      VFX_WORLD_SPACE 1\n\t\t#include \"Packages/com.unity.visualeffectgraph/Shaders/RenderPipeline/HDRP/VFXDefines.hlsl\"\n\t\t\n\n\t\tCBUFFER_START(parameters)\n\t\t
+      \   float4 Size_a;\n\t\t    float4 Alpha_b;\n\t\tCBUFFER_END\n\t\tTexture2D
+      mainTexture;\n\t\tSamplerState samplermainTexture;\n\t\t\n\n\t\t\n\t\t#define
+      VFX_NEEDS_COLOR_INTERPOLATOR (VFX_USE_COLOR_CURRENT || VFX_USE_ALPHA_CURRENT)\n\t\t\n\t\tByteAddressBuffer
       attributeBuffer;\t\n\t\t\n\t\t#if VFX_HAS_INDIRECT_DRAW\n\t\tStructuredBuffer<uint>
       indirectBuffer;\t\n\t\t#endif\t\n\t\t\n\t\t#if USE_DEAD_LIST_COUNT\n\t\tByteAddressBuffer
       deadListCount;\n\t\t#endif\n\t\t\n\t\tCBUFFER_START(outputParams)\n\t\t\tfloat
       nbMax;\n\t\t\tfloat systemSeed;\n\t\tCBUFFER_END\n\t\t\n\t\tENDHLSL\n\t\t\n\n\t\t\n\t\t//
       Forward pass\n\t\tPass\n\t\t{\t\t\n\t\t\tTags { \"LightMode\"=\"ForwardOnly\"
-      }\n\t\t\t\n\t\t\tHLSLPROGRAM\n\t\t\t#pragma target 4.5\n\t\t\t\t\n\t\t\tstruct
+      }\n\t\t\t\n\t\t\tHLSLPROGRAM\n\t\t\t#pragma target 4.5\n\t\t\t\n\t\t\n\t\t\tstruct
       ps_input\n\t\t\t{\n\t\t\t\tfloat4 pos : SV_POSITION;\n\t\t\t\t#if USE_FLIPBOOK_INTERPOLATION\n\t\t\t\tfloat4
       uv : TEXCOORD0;\n\t\t\t\t#else\n\t\t\t\tfloat2 uv : TEXCOORD0;\t\n\t\t\t\t#endif\n\t\t\t\t#if
       VFX_NEEDS_COLOR_INTERPOLATOR\n\t\t\t\tnointerpolation float4 color : COLOR0;\n\t\t\t\t#endif\n\t\t\t\t#if
-      USE_SOFT_PARTICLE || USE_ALPHA_TEST || USE_FLIPBOOK_INTERPOLATION\n\t\t\t\t//
+      USE_SOFT_PARTICLE || USE_ALPHA_TEST || USE_FLIPBOOK_INTERPOLATION || USE_EXPOSURE_WEIGHT\n\t\t\t\t//
       x: inverse soft particles fade distance\n\t\t\t\t// y: alpha threshold\n\t\t\t\t//
-      z: frame blending factor\n\t\t\t\tnointerpolation float3 builtInInterpolants
-      : TEXCOORD1;\n\t\t\t\t#endif\n\t\t\t\t#if VFX_NEEDS_POSWS_INTERPOLATOR\n\t\t\t\tfloat3
-      posWS : TEXCOORD2;\n\t\t\t\t#endif\n\t\t\t};\n\t\t\t\n\t\t\tstruct ps_output\n\t\t\t{\n\t\t\t\tfloat4
+      z: frame blending factor\n\t\t\t\t// w: exposure weight\n\t\t\t\tnointerpolation
+      float4 builtInInterpolants : TEXCOORD1;\n\t\t\t\t#endif\n\t\t\t\t#if USE_FLIPBOOK_MOTIONVECTORS\n\t\t\t\t//
+      x: motion vectors scale X\n\t\t\t\t// y: motion vectors scale Y\n\t\t\t\tnointerpolation
+      float2 builtInInterpolants2 : TEXCOORD2;\n\t\t\t\t#endif\n\t\t\t\t#if VFX_NEEDS_POSWS_INTERPOLATOR\n\t\t\t\tfloat3
+      posWS : TEXCOORD3;\n\t\t\t\t#endif\n\t\t\t};\n\t\t\t\n\t\t\tstruct ps_output\n\t\t\t{\n\t\t\t\tfloat4
       color : SV_Target0;\n\t\t\t};\n\t\t\n\t\t#define VFX_VARYING_PS_INPUTS ps_input\n\t\t#define
       VFX_VARYING_POSCS pos\n\t\t#define VFX_VARYING_COLOR color.rgb\n\t\t#define
       VFX_VARYING_ALPHA color.a\n\t\t#define VFX_VARYING_INVSOFTPARTICLEFADEDISTANCE
       builtInInterpolants.x\n\t\t#define VFX_VARYING_ALPHATHRESHOLD builtInInterpolants.y\n\t\t#define
-      VFX_VARYING_FRAMEBLEND builtInInterpolants.z\n\t\t#define VFX_VARYING_UV uv\n\t\t#if
-      VFX_NEEDS_POSWS_INTERPOLATOR\n\t\t#define VFX_VARYING_POSWS posWS\n\t\t#endif\n\t\t\t\t\n\t\t\t#if
+      VFX_VARYING_FRAMEBLEND builtInInterpolants.z\n\t\t#define VFX_VARYING_MOTIONVECTORSCALE
+      builtInInterpolants2.xy\n\t\t#define VFX_VARYING_UV uv\n\t\t#if VFX_NEEDS_POSWS_INTERPOLATOR\n\t\t#define
+      VFX_VARYING_POSWS posWS\n\t\t#endif\n\t\t#if USE_EXPOSURE_WEIGHT\n\t\t#define
+      VFX_VARYING_EXPOSUREWEIGHT builtInInterpolants.w\n\t\t#endif\n\t\t\t\t\n\t\t\t#if
       !(defined(VFX_VARYING_PS_INPUTS) && defined(VFX_VARYING_POSCS))\n\t\t\t#error
       VFX_VARYING_PS_INPUTS, VFX_VARYING_POSCS and VFX_VARYING_UV must be defined.\n\t\t\t#endif\n\t\t\t\n\t\t\t#include
       \"Packages/com.unity.visualeffectgraph/Shaders/RenderPipeline/HDRP/VFXCommon.cginc\"\n\t\t\t#include
@@ -3528,16 +3509,19 @@ VisualEffectResource:
       \       axisX = normalize(cross(GetVFXToViewRotMatrix()[1].xyz,axisZ));\n\t\t\t
       \       axisY = cross(axisZ,axisX);\n\t\t\t    }\n\t\t\t    \n\t\t\t}\n\t\t\t\n\n\t\t\t\n\t\t\t#pragma
       vertex vert\n\t\t\tVFX_VARYING_PS_INPUTS vert(uint id : SV_VertexID, uint instanceID
-      : SV_InstanceID)\n\t\t\t{\n\t\t\t\tuint index = (id >> 2) + instanceID * 2048;\n\t\t\t\tVFX_VARYING_PS_INPUTS
-      o = (VFX_VARYING_PS_INPUTS)0;\n\t\t\t\t\n\t\t\t\t\n\t\t\t\t\t\tuint deadCount
+      : SV_InstanceID)\n\t\t\t{\n\t\t\t#if VFX_PRIMITIVE_TRIANGLE\n\t\t\t\tuint index
+      = id / 3;\n\t\t\t#elif VFX_PRIMITIVE_QUAD\n\t\t\t\tuint index = (id >> 2) +
+      instanceID * 2048;\n\t\t\t#elif VFX_PRIMITIVE_OCTAGON\n\t\t\t\tuint index =
+      (id >> 3) + instanceID * 1024;\n\t\t\t#endif\n\t\t\t\n\t\t\t\tVFX_VARYING_PS_INPUTS
+      o = (VFX_VARYING_PS_INPUTS)0;\n\t\t\t\n\t\t\t\t\n\t\t\t\t\t\tuint deadCount
       = 0;\n\t\t\t\t\t\t#if USE_DEAD_LIST_COUNT\n\t\t\t\t\t\tdeadCount = deadListCount.Load(0);\n\t\t\t\t\t\t#endif\t\n\t\t\t\t\t\tif
-      (index >= asuint(nbMax) - deadCount)\n\t\t\t\t\t\t\treturn o; // cull\n\t\t\t\t\t\t\n\t\t\t\t\t\t#if
+      (index >= asuint(nbMax) - deadCount)\n\t\t\t\t\t\t#if USE_GEOMETRY_SHADER\n\t\t\t\t\t\t\treturn;
+      // cull\n\t\t\t\t\t\t#else\n\t\t\t\t\t\t\treturn o; // cull\n\t\t\t\t\t\t#endif\n\t\t\t\t\t\t\n\t\t\t\t\t\t#if
       VFX_HAS_INDIRECT_DRAW\n\t\t\t\t\t\tindex = indirectBuffer[index];\n\t\t\t\t\t\tfloat
       lifetime = asfloat(attributeBuffer.Load((index * 0x1 + 0x0) << 2));\n\t\t\t\t\t\tfloat3
       position = asfloat(attributeBuffer.Load3((index * 0x4 + 0x2740) << 2));\n\t\t\t\t\t\tfloat
-      size = asfloat(attributeBuffer.Load((index * 0x1 + 0x22580) << 2));\n\t\t\t\t\t\tfloat4
-      densityPressure = asfloat(attributeBuffer.Load4((index * 0x4 + 0x8BACC0) <<
-      2));\n\t\t\t\t\t\tfloat3 color = float3(1,1,1);\n\t\t\t\t\t\tfloat alpha = (float)1;\n\t\t\t\t\t\tbool
+      size = asfloat(attributeBuffer.Load((index * 0x1 + 0x22580) << 2));\n\t\t\t\t\t\tfloat3
+      color = float3(1,1,1);\n\t\t\t\t\t\tfloat alpha = (float)1;\n\t\t\t\t\t\tbool
       alive = (attributeBuffer.Load((index * 0x1 + 0x8D83C0) << 2));\n\t\t\t\t\t\tfloat3
       axisX = float3(1,0,0);\n\t\t\t\t\t\tfloat3 axisY = float3(0,1,0);\n\t\t\t\t\t\tfloat3
       axisZ = float3(0,0,1);\n\t\t\t\t\t\tfloat angleX = (float)0;\n\t\t\t\t\t\tfloat
@@ -3550,9 +3534,8 @@ VisualEffectResource:
       (!alive)\n\t\t\t\t\t\t\treturn o;\n\t\t\t\t\t\t\t\n\t\t\t\t\t\tfloat lifetime
       = asfloat(attributeBuffer.Load((index * 0x1 + 0x0) << 2));\n\t\t\t\t\t\tfloat3
       position = asfloat(attributeBuffer.Load3((index * 0x4 + 0x2740) << 2));\n\t\t\t\t\t\tfloat
-      size = asfloat(attributeBuffer.Load((index * 0x1 + 0x22580) << 2));\n\t\t\t\t\t\tfloat4
-      densityPressure = asfloat(attributeBuffer.Load4((index * 0x4 + 0x8BACC0) <<
-      2));\n\t\t\t\t\t\tfloat3 color = float3(1,1,1);\n\t\t\t\t\t\tfloat alpha = (float)1;\n\t\t\t\t\t\tfloat3
+      size = asfloat(attributeBuffer.Load((index * 0x1 + 0x22580) << 2));\n\t\t\t\t\t\tfloat3
+      color = float3(1,1,1);\n\t\t\t\t\t\tfloat alpha = (float)1;\n\t\t\t\t\t\tfloat3
       axisX = float3(1,0,0);\n\t\t\t\t\t\tfloat3 axisY = float3(0,1,0);\n\t\t\t\t\t\tfloat3
       axisZ = float3(0,0,1);\n\t\t\t\t\t\tfloat angleX = (float)0;\n\t\t\t\t\t\tfloat
       angleY = (float)0;\n\t\t\t\t\t\tfloat angleZ = (float)0;\n\t\t\t\t\t\tfloat
@@ -3560,50 +3543,67 @@ VisualEffectResource:
       pivotZ = (float)0;\n\t\t\t\t\t\tfloat scaleX = (float)1;\n\t\t\t\t\t\tfloat
       scaleY = (float)1;\n\t\t\t\t\t\tfloat scaleZ = (float)1;\n\t\t\t\t\t\tfloat
       age = asfloat(attributeBuffer.Load((index * 0x1 + 0x8DAB00) << 2));\n\t\t\t\t\t\t\n\t\t\t\t\n\t\t\t\t\t\t#endif\n\t\t\t\t\t\t\n\t\t\t\t{\n\t\t\t\t
-      \   float tmp_bjq = densityPressure[0];\n\t\t\t\t    float tmp_bjs = tmp_bjq
-      - (float)499.145;\n\t\t\t\t    float tmp_bju = tmp_bjs / (float)9483.756;\n\t\t\t\t
-      \   AttributeFromCurve_6F068247( /*inout */size, Size_a, tmp_bju);\n\t\t\t\t}\n\t\t\t\tAttributeFromCurve_CF7471E0(
+      \   AttributeFromCurve_6F068247( /*inout */size, Size_a, (float)0);\n\t\t\t\t}\n\t\t\t\tAttributeFromCurve_CF7471E0(
       /*inout */alpha, age, lifetime, Alpha_b);\n\t\t\t\tOrient_1( /*inout */axisX,
       \ /*inout */axisY,  /*inout */axisZ, position);\n\t\t\t\t\n\n\t\t\t\t\n\t\t\t\tif
-      (!alive)\n\t\t\t\t\treturn o;\n\t\t\t\t\n\t\t\t\to.VFX_VARYING_UV.x = float(id
-      & 1);\n\t\t\t\to.VFX_VARYING_UV.y = float((id & 2) >> 1);\n\t\t\t\t\n\t\t\t\t\n\t\t\t\t\t\tfloat3
+      (!alive)\n\t\t\t\t\treturn o;\n\t\t\t\t\n\t\t\t#if VFX_PRIMITIVE_QUAD\n\t\t\t\n\t\t\t\to.VFX_VARYING_UV.x
+      = float(id & 1);\n\t\t\t\to.VFX_VARYING_UV.y = float((id & 2) >> 1);\n\t\t\t\tconst
+      float2 vOffsets = o.VFX_VARYING_UV.xy - 0.5f;\n\t\t\t\t\n\t\t\t#elif VFX_PRIMITIVE_TRIANGLE\n\t\t\t\n\t\t\t\tconst
+      float2 kOffsets[] = {\n\t\t\t\t\tfloat2(-0.5f, \t-0.288675129413604736328125f),\n\t\t\t\t\tfloat2(0.0f,
+      \t0.57735025882720947265625f),\n\t\t\t\t\tfloat2(0.5f,\t-0.288675129413604736328125f),\n\t\t\t\t};\n\t\t\t\t\n\t\t\t\tconst
+      float kUVScale = 0.866025388240814208984375f;\n\t\t\t\t\n\t\t\t\tconst float2
+      vOffsets = kOffsets[id % 3];\n\t\t\t\to.VFX_VARYING_UV.xy = (vOffsets * kUVScale)
+      + 0.5f;\n\t\t\t\t\n\t\t\t#elif VFX_PRIMITIVE_OCTAGON\t\n\t\t\t\t\n\t\t\t\tconst
+      float2 kUvs[8] = \n\t\t\t\t{\n\t\t\t\t\tfloat2(-0.5f,\t0.0f),\n\t\t\t\t\tfloat2(-0.5f,\t0.5f),\n\t\t\t\t\tfloat2(0.0f,\t0.5f),\n\t\t\t\t\tfloat2(0.5f,\t0.5f),\n\t\t\t\t\tfloat2(0.5f,\t0.0f),\n\t\t\t\t\tfloat2(0.5f,\t-0.5f),\n\t\t\t\t\tfloat2(0.0f,\t-0.5f),\n\t\t\t\t\tfloat2(-0.5f,\t-0.5f),\n\t\t\t\t};\n\t\t\t\t\n\t\t\t\t\n\t\t\t\tcropFactor
+      = id & 1 ? 1.0f - cropFactor : 1.0f;\n\t\t\t\tconst float2 vOffsets = kUvs[id
+      & 7] * cropFactor;\n\t\t\t\to.VFX_VARYING_UV.xy = vOffsets + 0.5f;\n\t\t\t\t\n\t\t\t#endif\n\t\t\t\t\n\t\t\t\t\n\t\t\t\t\t\tfloat3
       size3 = float3(size,size,size);\n\t\t\t\t\t\t#if VFX_USE_SCALEX_CURRENT\n\t\t\t\t\t\tsize3.x
       *= scaleX;\n\t\t\t\t\t\t#endif\n\t\t\t\t\t\t#if VFX_USE_SCALEY_CURRENT\n\t\t\t\t\t\tsize3.y
       *= scaleY;\n\t\t\t\t\t\t#endif\n\t\t\t\t\t\t#if VFX_USE_SCALEZ_CURRENT\n\t\t\t\t\t\tsize3.z
-      *= scaleZ;\n\t\t\t\t\t\t#endif\n\t\t\t\t\t\t\n\t\t\t\t\n\t\t\t\tconst float2
-      vOffsets = o.VFX_VARYING_UV.xy - 0.5f;\n\t\t\t\tconst float4x4 elementToVFX
-      = GetElementToVFXMatrix(axisX,axisY,axisZ,float3(angleX,angleY,angleZ),float3(pivotX,pivotY,pivotZ),size3,position);\n\t\t\t\tconst
-      float3 vPos = mul(elementToVFX,float4(vOffsets,0.0f,1.0f)).xyz;\n\t\t\t\n\t\t\t\to.VFX_VARYING_POSCS
-      = TransformPositionVFXToClip(vPos);\n\t\t\t\t\n\t\t\t\t#ifdef VFX_VARYING_NORMAL\n\t\t\t\tfloat
-      normalFlip = (size3.x * size3.y * size3.z) < 0 ? -1 : 1;\n\t\t\t\to.VFX_VARYING_NORMAL
-      = normalFlip * normalize(TransformDirectionVFXToWorld(normalize(-transpose(elementToVFX)[2].xyz)));\n\t\t\t\t#endif\n\t\t\t\t#ifdef
+      *= scaleZ;\n\t\t\t\t\t\t#endif\n\t\t\t\t\t\t\n\t\t\t\t\n\t\t\t\tconst float4x4
+      elementToVFX = GetElementToVFXMatrix(axisX,axisY,axisZ,float3(angleX,angleY,angleZ),float3(pivotX,pivotY,pivotZ),size3,position);\n\t\t\t\tfloat3
+      vPos = mul(elementToVFX,float4(vOffsets,0.0f,1.0f)).xyz;\n\t\t\t\n\t\t\t\to.VFX_VARYING_POSCS
+      = TransformPositionVFXToClip(vPos);\n\t\t\t\n\t\t\t\tfloat3 normalWS = normalize(TransformDirectionVFXToWorld(normalize(-transpose(elementToVFX)[2].xyz)));\n\t\t\t\t#ifdef
+      VFX_VARYING_NORMAL\n\t\t\t\tfloat normalFlip = (size3.x * size3.y * size3.z)
+      < 0 ? -1 : 1;\n\t\t\t\to.VFX_VARYING_NORMAL = normalFlip * normalWS;\n\t\t\t\t#endif\n\t\t\t\t#ifdef
       VFX_VARYING_TANGENT\n\t\t\t\to.VFX_VARYING_TANGENT = normalize(TransformDirectionVFXToWorld(normalize(transpose(elementToVFX)[0].xyz)));\n\t\t\t\t#endif\n\t\t\t\t#ifdef
-      VFX_VARYING_BENTFACTORS\n\t\t\t\t\n\t\t\t\to.VFX_VARYING_BENTFACTORS = vOffsets
-      * bentNormalFactor;\n\t\t\t\t#endif\n\t\t\t\n\t\t\t\t\n\t\t\t\t\t\t#if VFX_USE_COLOR_CURRENT
-      && defined(VFX_VARYING_COLOR)\n\t\t\t\t\t\to.VFX_VARYING_COLOR = color;\n\t\t\t\t\t\t#endif\n\t\t\t\t\t\t#if
-      VFX_USE_ALPHA_CURRENT && defined(VFX_VARYING_ALPHA) \n\t\t\t\t\t\to.VFX_VARYING_ALPHA
-      = alpha;\n\t\t\t\t\t\t#endif\n\t\t\t\t\t\t\n\t\t\t\t\t\t\n\t\t\t\t\t\t#if USE_SOFT_PARTICLE
+      VFX_VARYING_BENTFACTORS\n\t\t\t\t\n\t\t\t\t#if HAS_STRIPS\n\t\t\t\t#define BENT_FACTOR_MULTIPLIER
+      2.0f\n\t\t\t\t#else\n\t\t\t\t#define BENT_FACTOR_MULTIPLIER 1.41421353816986083984375f\n\t\t\t\t#endif\n\t\t\t\to.VFX_VARYING_BENTFACTORS
+      = vOffsets * bentNormalFactor * BENT_FACTOR_MULTIPLIER;\n\t\t\t\t#endif\n\t\t\t\n\t\t\t\t\n\t\t\t\t\t\t#if
+      VFX_USE_COLOR_CURRENT && defined(VFX_VARYING_COLOR)\n\t\t\t\t\t\to.VFX_VARYING_COLOR
+      = color;\n\t\t\t\t\t\t#endif\n\t\t\t\t\t\t#if VFX_USE_ALPHA_CURRENT && defined(VFX_VARYING_ALPHA)
+      \n\t\t\t\t\t\to.VFX_VARYING_ALPHA = alpha;\n\t\t\t\t\t\t#endif\n\t\t\t\t\t\t\n\t\t\t\t\t\t#ifdef
+      VFX_VARYING_EXPOSUREWEIGHT\n\t\t\t\t\t\t\n\t\t\t\t\t\to.VFX_VARYING_EXPOSUREWEIGHT
+      = exposureWeight;\n\t\t\t\t\t\t#endif\n\t\t\t\t\t\t\n\t\t\t\t\t\t#if USE_SOFT_PARTICLE
       && defined(VFX_VARYING_INVSOFTPARTICLEFADEDISTANCE)\n\t\t\t\t\t\t\n\t\t\t\t\t\to.VFX_VARYING_INVSOFTPARTICLEFADEDISTANCE
       = invSoftParticlesFadeDistance;\n\t\t\t\t\t\t#endif\n\t\t\t\t\t\t\n\t\t\t\t\t\t#if
       USE_ALPHA_TEST && defined(VFX_VARYING_ALPHATHRESHOLD)\n\t\t\t\t\t\t\n\t\t\t\t\t\to.VFX_VARYING_ALPHATHRESHOLD
       = alphaThreshold;\n\t\t\t\t\t\t#endif\n\t\t\t\t\t\t\n\t\t\t\t\t\t#if USE_UV_SCALE_BIAS\n\t\t\t\t\t\t\n\t\t\t\t\t\t\n\t\t\t\t\t\to.VFX_VARYING_UV.xy
       = o.VFX_VARYING_UV.xy * uvScale + uvBias;\n\t\t\t\t\t\t#endif\n\t\t\t\t\t\t\n\t\t\t\t\t\t#if
-      defined(VFX_VARYING_POSWS)\n\t\t\t\t\t\to.VFX_VARYING_POSWS = TransformPositionVFXToWorld(vPos);\n\t\t\t\t\t\t#endif\n\t\t\t\t\t\t\n\t\t\t\t\t\t\n\t\t\t\t\n\t\t\t\t\n\t\t\t\t\t\t#if
+      defined(VFX_VARYING_POSWS)\n\t\t\t\t\t\to.VFX_VARYING_POSWS = TransformPositionVFXToWorld(vPos);\n\t\t\t\t\t\t#endif\n\t\t\t\t\t\t\n\t\t\t\t\n\t\t\t\t\n\t\t\t\t\t\t#if
       USE_FLIPBOOK\n\t\t\t\t\t\t\n\t\t\t\t\t\t\n\t\t\t\t\t\tVFXUVData uvData = GetUVData(flipBookSize,
       invFlipBookSize, o.VFX_VARYING_UV.xy, texIndex);\n\t\t\t\t\t\to.VFX_VARYING_UV.xy
       = uvData.uvs.xy;\n\t\t\t\t\t\t#if USE_FLIPBOOK_INTERPOLATION\n\t\t\t\t\t\to.VFX_VARYING_UV.zw
-      = uvData.uvs.zw;\n\t\t\t\t\t\to.VFX_VARYING_FRAMEBLEND = uvData.blend;\n\t\t\t\t\t\t#endif\n\t\t\t\t\t\t#endif\n\t\t\t\t\t\t\n\t\t\t\n\t\t\t\t\n\t\t\t\n\t\t\t\treturn
+      = uvData.uvs.zw;\n\t\t\t\t\t\to.VFX_VARYING_FRAMEBLEND = uvData.blend;\n\t\t\t\t\t\t#if
+      USE_FLIPBOOK_MOTIONVECTORS\n\t\t\t\t\t\t\n\t\t\t\t\t\to.VFX_VARYING_MOTIONVECTORSCALE
+      = motionVectorScale * invFlipBookSize;\n\t\t\t\t\t\t#endif\n\t\t\t\t\t\t#endif\n\t\t\t\t\t\t#endif\n\t\t\t\t\t\t\n\t\t\t\n\t\t\t\t\n\t\t\t\n\t\t\t\treturn
       o;\n\t\t\t}\n\t\t\t\n\t\t\t\n\t\t\t\n\t\t\t\n\t\t\t\n\t\t\t\n\t\t\t#include
       \"Packages/com.unity.visualeffectgraph/Shaders/VFXCommonOutput.cginc\"\n\t\t\t\n\t\t\t\n\t\t\t\n\t\t\t\t\n\t\t\t#pragma
       fragment frag\n\t\t\tps_output frag(ps_input i)\n\t\t\t{\n\t\t\t\tps_output
-      o = (ps_output)0;\n\t\t\t\to.color = VFXGetFragmentColor(i);\n\t\t\t\to.color
-      *= VFXGetTextureColor(VFX_SAMPLER(mainTexture),i);\n\t\t\t\to.color = VFXApplyFog(o.color,i);\n\t\t\t\tVFXClipFragmentColor(o.color.a,i);\n\t\t\t\to.color.a
+      o = (ps_output)0;\n\t\t\t\tVFXTransformPSInputs(i);\n\t\t\t\n\t\t\t\t#define
+      VFX_TEXTURE_COLOR VFXGetTextureColor(VFX_SAMPLER(mainTexture),i)\n\t\t\t\t\n\t\t\t\t\t\t\n\t\t\t\t\t\tfloat4
+      color = VFXGetFragmentColor(i);\n\t\t\t\t\t\t\n\t\t\t\t\t\t#ifndef VFX_TEXTURE_COLOR\n\t\t\t\t\t\t\t#define
+      VFX_TEXTURE_COLOR float4(1.0,1.0,1.0,1.0)\n\t\t\t\t\t\t#endif\n\t\t\t\t\t\t\n\t\t\t\t\t\t#if
+      VFX_COLORMAPPING_DEFAULT\n\t\t\t\t\t\t\to.color = color * VFX_TEXTURE_COLOR;\n\t\t\t\t\t\t#endif\n\t\t\t\t\t\t\n\t\t\t\t\t\t#if
+      VFX_COLORMAPPING_GRADIENTMAPPED\n\t\t\t\t\t\t\t\n\t\t\t\t\t\t\to.color = SampleGradient(gradient,
+      VFX_TEXTURE_COLOR.a * color.a) * float4(color.rgb,1.0);\n\t\t\t\t\t\t#endif\n\t\t\t\t\t\t\n\t\t\t\t\t\t\n\t\t\n\t\t\t\to.color
+      = VFXApplyPreExposure(o.color, i);\n\t\t\t\to.color = VFXApplyFog(o.color,i);\n\t\t\t\tVFXClipFragmentColor(o.color.a,i);\n\t\t\t\to.color.a
       = saturate(o.color.a);\n\t\t\t\treturn o;\n\t\t\t}\n\t\t\tENDHLSL\n\t\t}\n\t\t\n\n\t\t\n\t}\n}\n"
   - compute: 1
     name: '[System 1]CameraSort'
-    source: "#pragma kernel CSMain\n#include \"HLSLSupport.cginc\"\n#define NB_THREADS_PER_GROUP
-      64\n#define VFX_USE_POSITION_CURRENT 1\n#define USE_DEAD_LIST_COUNT 1\n#define
-      VFX_WORLD_SPACE 1\n\n\n\n#include \"Packages/com.unity.visualeffectgraph/Shaders/Common/VFXCommonCompute.cginc\"\n#include
+    source: "#pragma kernel CSMain\n#define NB_THREADS_PER_GROUP 64\n#define VFX_USE_POSITION_CURRENT
+      1\n#define USE_DEAD_LIST_COUNT 1\n#define VFX_WORLD_SPACE 1\n#include \"Packages/com.unity.visualeffectgraph/Shaders/RenderPipeline/HDRP/VFXDefines.hlsl\"\n\n\n\n#include
+      \"Packages/com.unity.visualeffectgraph/Shaders/Common/VFXCommonCompute.cginc\"\n#include
       \"Packages/com.unity.visualeffectgraph/Shaders/VFXCommon.cginc\"\n\n\n\nCBUFFER_START(params)\n
       \   uint nbMax;\n    uint dispatchWidth;\nCBUFFER_END\n\nCBUFFER_START(cameraParams)\n
       \   float3 cameraPosition;\nCBUFFER_END\n\nByteAddressBuffer attributeBuffer;\nStructuredBuffer<uint>
@@ -3627,121 +3627,121 @@ VisualEffectResource:
         data[0]: -1
         data[1]: -1
         data[2]: -1
-        data[3]: 1
-      - op: 1
-        valueIndex: 1
-        data[0]: -1
-        data[1]: -1
-        data[2]: -1
         data[3]: 3
       - op: 1
-        valueIndex: 4
-        data[0]: -1
-        data[1]: -1
-        data[2]: -1
-        data[3]: 3
-      - op: 1
-        valueIndex: 7
-        data[0]: -1
-        data[1]: -1
-        data[2]: -1
-        data[3]: 1
-      - op: 1
-        valueIndex: 8
+        valueIndex: 3
         data[0]: -1
         data[1]: -1
         data[2]: -1
         data[3]: 13
       - op: 9
-        valueIndex: 9
+        valueIndex: 4
         data[0]: -1
         data[1]: -1
         data[2]: -1
         data[3]: -1
       - op: 1
-        valueIndex: 25
+        valueIndex: 20
         data[0]: -1
         data[1]: -1
         data[2]: -1
         data[3]: 13
       - op: 1
+        valueIndex: 21
+        data[0]: -1
+        data[1]: -1
+        data[2]: -1
+        data[3]: 1
+      - op: 56
+        valueIndex: 22
+        data[0]: 3
+        data[1]: -1
+        data[2]: -1
+        data[3]: 0
+      - op: 56
         valueIndex: 26
-        data[0]: -1
+        data[0]: 1
         data[1]: -1
         data[2]: -1
         data[3]: 1
       - op: 1
-        valueIndex: 27
+        valueIndex: 30
         data[0]: -1
         data[1]: -1
         data[2]: -1
         data[3]: 1
-      - op: 1
-        valueIndex: 28
-        data[0]: -1
-        data[1]: -1
-        data[2]: -1
-        data[3]: 1
-      - op: 1
-        valueIndex: 29
-        data[0]: -1
-        data[1]: -1
-        data[2]: -1
-        data[3]: 2
       - op: 1
         valueIndex: 31
         data[0]: -1
         data[1]: -1
         data[2]: -1
-        data[3]: 1
+        data[3]: 2
       - op: 1
-        valueIndex: 32
+        valueIndex: 33
         data[0]: -1
         data[1]: -1
         data[2]: -1
         data[3]: 1
-      - op: 44
-        valueIndex: 33
-        data[0]: 4
-        data[1]: -1
-        data[2]: -1
-        data[3]: 0
-      - op: 44
-        valueIndex: 37
-        data[0]: 6
+      - op: 1
+        valueIndex: 34
+        data[0]: -1
         data[1]: -1
         data[2]: -1
         data[3]: 1
+      - op: 1
+        valueIndex: 35
+        data[0]: -1
+        data[1]: -1
+        data[2]: -1
+        data[3]: 1
+      - op: 1
+        valueIndex: 36
+        data[0]: -1
+        data[1]: -1
+        data[2]: -1
+        data[3]: 1
+      - op: 42
+        valueIndex: 37
+        data[0]: 2
+        data[1]: 0
+        data[2]: -1
+        data[3]: -1
+      - op: 6
+        valueIndex: 40
+        data[0]: -1
+        data[1]: -1
+        data[2]: -1
+        data[3]: -1
       - op: 1
         valueIndex: 41
         data[0]: -1
         data[1]: -1
         data[2]: -1
-        data[3]: 1
-      - op: 35
-        valueIndex: 42
-        data[0]: 5
-        data[1]: 1
+        data[3]: 3
+      - op: 1
+        valueIndex: 44
+        data[0]: -1
+        data[1]: -1
         data[2]: -1
-        data[3]: -1
-      - op: 6
+        data[3]: 1
+      - op: 1
         valueIndex: 45
         data[0]: -1
         data[1]: -1
         data[2]: -1
-        data[3]: -1
-      - op: 36
-        valueIndex: 46
-        data[0]: 5
-        data[1]: 2
-        data[2]: -1
-        data[3]: -1
+        data[3]: 1
       - op: 1
-        valueIndex: 49
+        valueIndex: 46
         data[0]: -1
         data[1]: -1
         data[2]: -1
         data[3]: 1
+      - op: 1
+        valueIndex: 47
+        data[0]: -1
+        data[1]: -1
+        data[2]: -1
+        data[3]: 3
       - op: 1
         valueIndex: 50
         data[0]: -1
@@ -3759,19 +3759,13 @@ VisualEffectResource:
         data[0]: -1
         data[1]: -1
         data[2]: -1
-        data[3]: 3
+        data[3]: 1
       - op: 1
-        valueIndex: 55
+        valueIndex: 53
         data[0]: -1
         data[1]: -1
         data[2]: -1
-        data[3]: 1
-      - op: 1
-        valueIndex: 56
-        data[0]: -1
-        data[1]: -1
-        data[2]: -1
-        data[3]: 1
+        data[3]: 4
       - op: 1
         valueIndex: 57
         data[0]: -1
@@ -3783,85 +3777,70 @@ VisualEffectResource:
         data[0]: -1
         data[1]: -1
         data[2]: -1
-        data[3]: 4
-      - op: 1
-        valueIndex: 62
-        data[0]: -1
-        data[1]: -1
-        data[2]: -1
-        data[3]: 1
-      - op: 1
-        valueIndex: 63
-        data[0]: -1
-        data[1]: -1
-        data[2]: -1
         data[3]: 3
       - op: 1
-        valueIndex: 66
+        valueIndex: 61
         data[0]: -1
         data[1]: -1
         data[2]: -1
         data[3]: 1
       - op: 1
-        valueIndex: 67
+        valueIndex: 62
         data[0]: -1
         data[1]: -1
         data[2]: -1
         data[3]: 7
       m_NeedsLocalToWorld: 1
       m_NeedsWorldToLocal: 0
+      m_NeededMainCameraBuffers: 0
     m_PropertySheet:
       m_Float:
         m_Array:
-        - m_ExpressionIndex: 0
-          m_Value: 499.145
-        - m_ExpressionIndex: 3
-          m_Value: 9483.756
-        - m_ExpressionIndex: 7
+        - m_ExpressionIndex: 4
           m_Value: 1000
-        - m_ExpressionIndex: 8
-          m_Value: 0.25
-        - m_ExpressionIndex: 9
-          m_Value: 0.3
-        - m_ExpressionIndex: 11
-          m_Value: 5.999999
-        - m_ExpressionIndex: 12
+        - m_ExpressionIndex: 7
           m_Value: 5
-        - m_ExpressionIndex: 15
+        - m_ExpressionIndex: 9
+          m_Value: 5.999999
+        - m_ExpressionIndex: 10
           m_Value: 6.2831855
-        - m_ExpressionIndex: 19
+        - m_ExpressionIndex: 11
+          m_Value: 0.3
+        - m_ExpressionIndex: 12
+          m_Value: 0.25
+        - m_ExpressionIndex: 16
           m_Value: 0
-        - m_ExpressionIndex: 20
+        - m_ExpressionIndex: 17
           m_Value: 0.728
-        - m_ExpressionIndex: 21
+        - m_ExpressionIndex: 18
           m_Value: 0.03
-        - m_ExpressionIndex: 23
+        - m_ExpressionIndex: 20
           m_Value: 0.01
-        - m_ExpressionIndex: 24
+        - m_ExpressionIndex: 21
           m_Value: 9.9829
-        - m_ExpressionIndex: 25
+        - m_ExpressionIndex: 22
           m_Value: 998.29
-        - m_ExpressionIndex: 27
+        - m_ExpressionIndex: 24
           m_Value: 7.2414393
-        - m_ExpressionIndex: 29
+        - m_ExpressionIndex: 26
           m_Value: 1
       m_Vector2f:
         m_Array:
-        - m_ExpressionIndex: 10
+        - m_ExpressionIndex: 8
           m_Value: {x: 0.04993763, y: 0.99875236}
       m_Vector3f:
         m_Array:
-        - m_ExpressionIndex: 1
+        - m_ExpressionIndex: 0
           m_Value: {x: 0, y: 0, z: 0}
-        - m_ExpressionIndex: 2
+        - m_ExpressionIndex: 15
           m_Value: {x: 0, y: -9.81, z: 0}
-        - m_ExpressionIndex: 22
+        - m_ExpressionIndex: 19
           m_Value: {x: 4713701.5, y: 99508.984, z: 344.64487}
-        - m_ExpressionIndex: 28
+        - m_ExpressionIndex: 25
           m_Value: {x: 8, y: 6, z: 8}
       m_Vector4f:
         m_Array:
-        - m_ExpressionIndex: 26
+        - m_ExpressionIndex: 23
           m_Value: {x: 0.190625, y: 0.03633789, z: 0.00692691, w: 0.0953125}
       m_Uint:
         m_Array: []
@@ -3871,7 +3850,7 @@ VisualEffectResource:
         m_Array: []
       m_AnimationCurve:
         m_Array:
-        - m_ExpressionIndex: 4
+        - m_ExpressionIndex: 1
           m_Value:
             serializedVersion: 2
             m_Curve:
@@ -3905,7 +3884,7 @@ VisualEffectResource:
             m_PreInfinity: 2
             m_PostInfinity: 2
             m_RotationOrder: 4
-        - m_ExpressionIndex: 6
+        - m_ExpressionIndex: 3
           m_Value:
             serializedVersion: 2
             m_Curve:
@@ -3961,7 +3940,7 @@ VisualEffectResource:
         m_Array: []
       m_NamedObject:
         m_Array:
-        - m_ExpressionIndex: 30
+        - m_ExpressionIndex: 27
           m_Value: {fileID: 2800000, guid: 276d9e395ae18fe40a9b4988549f2349, type: 3}
       m_Bool:
         m_Array: []
@@ -14897,6 +14876,7 @@ VisualEffectResource:
       layout: []
       capacity: 0
       stride: 8
+    m_TemporaryBuffers: []
     m_CPUBuffers:
     - capacity: 1
       stride: 1
@@ -14927,7 +14907,7 @@ VisualEffectResource:
     - name: OnStop
       playSystems: 
       stopSystems: 00000000
-    m_RuntimeVersion: 5
+    m_RuntimeVersion: 10
     m_RendererSettings:
       motionVectorGenerationMode: 0
       shadowCastingMode: 0
@@ -14936,6 +14916,8 @@ VisualEffectResource:
       lightProbeUsage: 0
     m_CullingFlags: 3
     m_UpdateMode: 0
+    m_PreWarmDeltaTime: 0.05
+    m_PreWarmStepCount: 0
   m_Systems:
   - type: 0
     flags: 0
@@ -14948,9 +14930,10 @@ VisualEffectResource:
     tasks:
     - type: 268435456
       buffers: []
+      temporaryBuffers: []
       values:
       - nameId: Rate
-        index: 7
+        index: 4
       params: []
       processor: {fileID: 0}
       shaderSourceIndex: -1
@@ -14977,9 +14960,9 @@ VisualEffectResource:
       index: 7
     values:
     - nameId: bounds_center
-      index: 1
+      index: 0
     - nameId: bounds_size
-      index: 28
+      index: 25
     tasks:
     - type: 536870912
       buffers:
@@ -14991,14 +14974,15 @@ VisualEffectResource:
         index: 4
       - nameId: sourceAttributeBuffer
         index: 2
+      temporaryBuffers: []
       values:
       - nameId: Cone_center_b
-        index: 16
+        index: 13
       params:
       - nameId: bounds_center
-        index: 1
+        index: 0
       - nameId: bounds_size
-        index: 28
+        index: 25
       processor: {fileID: 0}
       shaderSourceIndex: 7
     - type: 805306368
@@ -15009,6 +14993,7 @@ VisualEffectResource:
         index: 3
       - nameId: indirectBuffer
         index: 5
+      temporaryBuffers: []
       values: []
       params: []
       processor: {fileID: 0}
@@ -15021,6 +15006,7 @@ VisualEffectResource:
         index: 3
       - nameId: indirectBuffer
         index: 5
+      temporaryBuffers: []
       values: []
       params: []
       processor: {fileID: 0}
@@ -15033,6 +15019,7 @@ VisualEffectResource:
         index: 3
       - nameId: indirectBuffer
         index: 5
+      temporaryBuffers: []
       values: []
       params: []
       processor: {fileID: 0}
@@ -15045,6 +15032,7 @@ VisualEffectResource:
         index: 3
       - nameId: indirectBuffer
         index: 5
+      temporaryBuffers: []
       values: []
       params: []
       processor: {fileID: 0}
@@ -15057,6 +15045,7 @@ VisualEffectResource:
         index: 3
       - nameId: indirectBuffer
         index: 5
+      temporaryBuffers: []
       values: []
       params: []
       processor: {fileID: 0}
@@ -15069,9 +15058,8 @@ VisualEffectResource:
         index: 3
       - nameId: indirectBuffer
         index: 5
-      values:
-      - nameId: solverData_Gravity_a
-        index: 18
+      temporaryBuffers: []
+      values: []
       params: []
       processor: {fileID: 0}
       shaderSourceIndex: 5
@@ -15083,9 +15071,10 @@ VisualEffectResource:
         index: 3
       - nameId: indirectBuffer
         index: 5
+      temporaryBuffers: []
       values:
       - nameId: dt_a
-        index: 17
+        index: 14
       params: []
       processor: {fileID: 0}
       shaderSourceIndex: 6
@@ -15099,6 +15088,7 @@ VisualEffectResource:
         index: 6
       - nameId: deadListCount
         index: 4
+      temporaryBuffers: []
       values: []
       params: []
       processor: {fileID: 0}
@@ -15111,13 +15101,14 @@ VisualEffectResource:
         index: 5
       - nameId: deadListCount
         index: 4
+      temporaryBuffers: []
       values:
       - nameId: Size_a
-        index: 13
+        index: 6
       - nameId: Alpha_b
-        index: 14
+        index: 5
       - nameId: mainTexture
-        index: 30
+        index: 27
       params:
       - nameId: sortPriority
         index: 0
@@ -15139,7 +15130,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Parent: {fileID: 114350483966674976}
   m_Children:
-  - {fileID: 8926484042661618564}
+  - {fileID: 8926484042661618582}
   m_UIPosition: {x: 1352, y: 4}
   m_UICollapsed: 0
   m_UISuperCollapsed: 0
@@ -15173,8 +15164,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Parent: {fileID: 114350483966674976}
   m_Children:
-  - {fileID: 8926484042661618435}
-  m_UIPosition: {x: 1352, y: 234}
+  - {fileID: 8926484042661618642}
+  m_UIPosition: {x: 1352, y: 231}
   m_UICollapsed: 0
   m_UISuperCollapsed: 0
   m_InputSlots: []
@@ -15207,7 +15198,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Parent: {fileID: 114350483966674976}
   m_Children:
-  - {fileID: 8926484042661618436}
+  - {fileID: 8926484042661618643}
   m_UIPosition: {x: 1352, y: 356}
   m_UICollapsed: 0
   m_UISuperCollapsed: 0
@@ -15241,7 +15232,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Parent: {fileID: 114350483966674976}
   m_Children:
-  - {fileID: 8926484042661618437}
+  - {fileID: 8926484042661618644}
   m_UIPosition: {x: 1352, y: 479}
   m_UICollapsed: 0
   m_UISuperCollapsed: 0
@@ -15275,7 +15266,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Parent: {fileID: 114350483966674976}
   m_Children:
-  - {fileID: 8926484042661618438}
+  - {fileID: 8926484042661618645}
   m_UIPosition: {x: 1352, y: 601}
   m_UICollapsed: 0
   m_UISuperCollapsed: 0
@@ -15309,8 +15300,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Parent: {fileID: 114350483966674976}
   m_Children:
-  - {fileID: 8926484042661618179}
-  m_UIPosition: {x: 530, y: 963}
+  - {fileID: 8926484042661618647}
+  m_UIPosition: {x: 530, y: 1047}
   m_UICollapsed: 0
   m_UISuperCollapsed: 0
   m_InputSlots: []
@@ -15329,27 +15320,6 @@ MonoBehaviour:
   angularIntegration: 0
   ageParticles: 1
   reapParticles: 1
---- !u!114 &8926484042661618179
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: af49bc557521a417ab5daee69476f797, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618177}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 2}
-  m_UICollapsed: 0
-  m_UISuperCollapsed: 0
-  m_InputSlots: []
-  m_OutputSlots: []
-  m_Disabled: 0
-  IntegrationMode: 0
 --- !u!114 &8926484042661618182
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -15814,6 +15784,7 @@ MonoBehaviour:
   m_UIPosition: {x: 0, y: 0}
   m_UICollapsed: 1
   m_UISuperCollapsed: 0
+  title: 
   m_Owners:
   - {fileID: 8926484042661618185}
   - {fileID: 8926484042661618129}
@@ -16264,86 +16235,6 @@ MonoBehaviour:
       m_RegexMaxLength: 0
   m_Direction: 0
   m_LinkedSlots: []
---- !u!114 &8926484042661618435
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b24fedd9240514791a200cf1d9ad7673, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618162}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 2}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_InputSlots: []
-  m_OutputSlots: []
-  m_Disabled: 0
---- !u!114 &8926484042661618436
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 47c40ab96b798458780dd052ee1994d6, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618165}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 2}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_InputSlots: []
-  m_OutputSlots: []
-  m_Disabled: 0
---- !u!114 &8926484042661618437
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: bc09ccf3ed7bc4caeabb87acbc42bc10, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618168}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 2}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_InputSlots: []
-  m_OutputSlots: []
-  m_Disabled: 0
---- !u!114 &8926484042661618438
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7f1a69e398cef41a69d4e71a3283432b, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618171}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 2}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_InputSlots: []
-  m_OutputSlots: []
-  m_Disabled: 0
 --- !u!114 &8926484042661618440
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -16358,7 +16249,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Parent: {fileID: 114350483966674976}
   m_Children: []
-  m_UIPosition: {x: 1112, y: 428}
+  m_UIPosition: {x: 1101, y: 426}
   m_UICollapsed: 0
   m_UISuperCollapsed: 0
   m_InputSlots:
@@ -16394,7 +16285,7 @@ MonoBehaviour:
         m_SerializableType: UnityEditor.VFX.Vector, Unity.VisualEffectGraph.Editor,
           Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
       m_SerializableObject: '{"vector":{"x":0.0,"y":-9.8100004196167,"z":0.0}}'
-    m_Space: 0
+    m_Space: 1
   m_Property:
     name: 
     m_serializedType:
@@ -16570,7 +16461,7 @@ MonoBehaviour:
         m_SerializableType: UnityEditor.VFX.Vector, Unity.VisualEffectGraph.Editor,
           Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
       m_SerializableObject: '{"vector":{"x":0.0,"y":0.0,"z":0.0}}'
-    m_Space: 0
+    m_Space: 1
   m_Property:
     name: 
     m_serializedType:
@@ -16579,7 +16470,7 @@ MonoBehaviour:
     attributes: []
   m_Direction: 1
   m_LinkedSlots:
-  - {fileID: 8926484042661618574}
+  - {fileID: 8926484042661618592}
 --- !u!114 &8926484042661618447
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -16735,7 +16626,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Parent: {fileID: 114350483966674976}
   m_Children:
-  - {fileID: 8926484042661618455}
+  - {fileID: 8926484042661618646}
   m_UIPosition: {x: 1352, y: 724}
   m_UICollapsed: 0
   m_UISuperCollapsed: 0
@@ -16755,29 +16646,6 @@ MonoBehaviour:
   angularIntegration: 1
   ageParticles: 0
   reapParticles: 0
---- !u!114 &8926484042661618455
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7cc173ad5f0fb406ba27fcb79ad9ec13, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618453}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 2}
-  m_UICollapsed: 0
-  m_UISuperCollapsed: 0
-  m_InputSlots: []
-  m_OutputSlots: []
-  m_Disabled: 0
-  SurfaceTension: 1
-  Gravity: 1
-  BuoyancyForce: 1
 --- !u!114 &8926484042661618456
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -16841,839 +16709,6 @@ MonoBehaviour:
       m_RegexMaxLength: 0
   m_Direction: 0
   m_LinkedSlots: []
---- !u!114 &8926484042661618458
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 955b0c175a6f3bb4582e92f3de8f0626, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 114350483966674976}
-  m_Children: []
-  m_UIPosition: {x: 1016, y: 19}
-  m_UICollapsed: 0
-  m_UISuperCollapsed: 0
-  m_InputSlots:
-  - {fileID: 8926484042661618459}
-  m_OutputSlots:
-  - {fileID: 8926484042661618468}
-  m_Type:
-    m_SerializableType: Thinksquirrel.FluvioFX.Editor.Fluid, Thinksquirrel.FluvioFX.Editor,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
---- !u!114 &8926484042661618459
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1b605c022ee79394a8a776c0869b3f9a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 0}
-  m_Children:
-  - {fileID: 8926484042661618460}
-  - {fileID: 8926484042661618461}
-  - {fileID: 8926484042661618462}
-  - {fileID: 8926484042661618463}
-  - {fileID: 8926484042661618464}
-  - {fileID: 8926484042661618465}
-  - {fileID: 8926484042661618466}
-  - {fileID: 8926484042661618467}
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 0
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618459}
-  m_MasterData:
-    m_Owner: {fileID: 8926484042661618458}
-    m_Value:
-      m_Type:
-        m_SerializableType: Thinksquirrel.FluvioFX.Editor.Fluid, Thinksquirrel.FluvioFX.Editor,
-          Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-      m_SerializableObject: '{"SmoothingDistance":0.19062499701976777,"ParticleMass":7.241438865661621,"Density":998.2899780273438,"MinimumDensity":9.98289966583252,"GasConstant":0.009999999776482582,"Viscosity":0.029999999329447748,"SurfaceTension":0.7279999852180481,"BuoyancyCoefficient":0.0}'
-    m_Space: 2147483647
-  m_Property:
-    name: 
-    m_serializedType:
-      m_SerializableType: Thinksquirrel.FluvioFX.Editor.Fluid, Thinksquirrel.FluvioFX.Editor,
-        Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661618460
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618459}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618459}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: SmoothingDistance
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 9.9999994e-11
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the smoothing distance of fluid particles. This changes
-        the overall simulation resolution and greatly affects all other properties.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661618461
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618459}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618459}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: ParticleMass
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 9.9999994e-11
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the mass of each fluid particle.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661618462
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618459}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618459}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: Density
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 9.9999994e-11
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the overall density of the fluid.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661618463
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618459}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618459}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: MinimumDensity
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 9.9999994e-11
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the minimum density of any fluid particle. This can be used
-        to help stabilize a low-viscosity fluid.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661618464
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618459}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618459}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: GasConstant
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 9.9999994e-11
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the gas constant of the fluid, which in turn affects the
-        pressure forces applied to particles.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661618465
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618459}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618459}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: Viscosity
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 9.9999994e-11
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the artificial viscosity force of the fluid.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661618466
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618459}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618459}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: SurfaceTension
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 0
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the surface tension of the fluid (intended for liquids only).
-        FluvioFX uses a simplified surface tension model that is ideal for realtime
-        use.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661618467
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618459}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618459}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: BuoyancyCoefficient
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the buoyancy coefficient of a fluid. This controls the buoyancy
-        force, which is a density-dependent force in the opposite direction of gravity.
-        This should be used when simulating gas like smoke or fire, or fluids that
-        are less dense than the surrounding material.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661618468
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1b605c022ee79394a8a776c0869b3f9a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 0}
-  m_Children:
-  - {fileID: 8926484042661618469}
-  - {fileID: 8926484042661618470}
-  - {fileID: 8926484042661618471}
-  - {fileID: 8926484042661618472}
-  - {fileID: 8926484042661618473}
-  - {fileID: 8926484042661618474}
-  - {fileID: 8926484042661618475}
-  - {fileID: 8926484042661618476}
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618468}
-  m_MasterData:
-    m_Owner: {fileID: 8926484042661618458}
-    m_Value:
-      m_Type:
-        m_SerializableType: Thinksquirrel.FluvioFX.Editor.Fluid, Thinksquirrel.FluvioFX.Editor,
-          Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-      m_SerializableObject: '{"SmoothingDistance":0.3812499940395355,"ParticleMass":7.625,"Density":998.2899780273438,"MinimumDensity":9.98289966583252,"GasConstant":0.009999999776482582,"Viscosity":0.30000001192092898,"SurfaceTension":0.7279999852180481,"BuoyancyCoefficient":0.0}'
-    m_Space: 2147483647
-  m_Property:
-    name: 
-    m_serializedType:
-      m_SerializableType: Thinksquirrel.FluvioFX.Editor.Fluid, Thinksquirrel.FluvioFX.Editor,
-        Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-    attributes: []
-  m_Direction: 1
-  m_LinkedSlots:
-  - {fileID: 8926484042661618565}
---- !u!114 &8926484042661618469
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618468}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618468}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: SmoothingDistance
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 9.9999994e-11
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the smoothing distance of fluid particles. This changes
-        the overall simulation resolution and greatly affects all other properties.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 1
-  m_LinkedSlots: []
---- !u!114 &8926484042661618470
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618468}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618468}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: ParticleMass
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 9.9999994e-11
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the mass of each fluid particle.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 1
-  m_LinkedSlots: []
---- !u!114 &8926484042661618471
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618468}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618468}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: Density
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 9.9999994e-11
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the overall density of the fluid.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 1
-  m_LinkedSlots: []
---- !u!114 &8926484042661618472
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618468}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618468}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: MinimumDensity
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 9.9999994e-11
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the minimum density of any fluid particle. This can be used
-        to help stabilize a low-viscosity fluid.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 1
-  m_LinkedSlots: []
---- !u!114 &8926484042661618473
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618468}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618468}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: GasConstant
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 9.9999994e-11
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the gas constant of the fluid, which in turn affects the
-        pressure forces applied to particles.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 1
-  m_LinkedSlots: []
---- !u!114 &8926484042661618474
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618468}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618468}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: Viscosity
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 9.9999994e-11
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the artificial viscosity force of the fluid.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 1
-  m_LinkedSlots: []
---- !u!114 &8926484042661618475
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618468}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618468}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: SurfaceTension
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 1
-      m_Min: 0
-      m_Max: Infinity
-      m_Tooltip: 
-      m_Regex: 
-      m_RegexMaxLength: 0
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the surface tension of the fluid (intended for liquids only).
-        FluvioFX uses a simplified surface tension model that is ideal for realtime
-        use.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 1
-  m_LinkedSlots: []
---- !u!114 &8926484042661618476
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618468}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618468}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: BuoyancyCoefficient
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes:
-    - m_Type: 3
-      m_Min: -Infinity
-      m_Max: Infinity
-      m_Tooltip: Controls the buoyancy coefficient of a fluid. This controls the buoyancy
-        force, which is a density-dependent force in the opposite direction of gravity.
-        This should be used when simulating gas like smoke or fire, or fluids that
-        are less dense than the surrounding material.
-      m_Regex: 
-      m_RegexMaxLength: 0
-  m_Direction: 1
-  m_LinkedSlots: []
 --- !u!114 &8926484042661618543
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -17691,7 +16726,7 @@ MonoBehaviour:
   - {fileID: 8926484042661618557}
   - {fileID: 8926484042661618549}
   - {fileID: 8926484042661618563}
-  m_UIPosition: {x: 530, y: 1219}
+  m_UIPosition: {x: 530, y: 1267}
   m_UICollapsed: 0
   m_UISuperCollapsed: 0
   m_InputSlots:
@@ -17706,16 +16741,20 @@ MonoBehaviour:
   m_OutputFlowSlot:
   - link: []
   blendMode: 1
+  m_SubOutputs:
+  - {fileID: 8926484042661618580}
   cullMode: 0
   zWriteMode: 0
   zTestMode: 0
+  colorMappingMode: 0
   uvMode: 0
   useSoftParticle: 0
   sortPriority: 0
   sort: 2
   indirectDraw: 0
   castShadows: 0
-  preRefraction: 0
+  useExposureWeight: 0
+  primitiveType: 1
   useGeometryShader: 0
 --- !u!114 &8926484042661618544
 MonoBehaviour:
@@ -17813,164 +16852,6 @@ MonoBehaviour:
     attributes: []
   m_Direction: 0
   m_LinkedSlots: []
---- !u!114 &8926484042661618552
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2fddccdf657579a4bbafd40a8a117778, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 114350483966674976}
-  m_Children: []
-  m_UIPosition: {x: 282, y: 1445}
-  m_UICollapsed: 0
-  m_UISuperCollapsed: 0
-  m_InputSlots:
-  - {fileID: 8926484042661618553}
-  m_OutputSlots:
-  - {fileID: 8926484042661618556}
---- !u!114 &8926484042661618553
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1b2b751071c7fc14f9fa503163991826, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 0}
-  m_Children:
-  - {fileID: 8926484042661618554}
-  - {fileID: 8926484042661618555}
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618553}
-  m_MasterData:
-    m_Owner: {fileID: 8926484042661618552}
-    m_Value:
-      m_Type:
-        m_SerializableType: UnityEngine.Vector2, UnityEngine.CoreModule, Version=0.0.0.0,
-          Culture=neutral, PublicKeyToken=null
-      m_SerializableObject: '{"x":499.1449890136719,"y":9982.900390625}'
-    m_Space: 2147483647
-  m_Property:
-    name: Range
-    m_serializedType:
-      m_SerializableType: UnityEngine.Vector2, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661618554
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618553}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618553}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: x
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661618555
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618553}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618553}
-  m_MasterData:
-    m_Owner: {fileID: 0}
-    m_Value:
-      m_Type:
-        m_SerializableType: 
-      m_SerializableObject: 
-    m_Space: 2147483647
-  m_Property:
-    name: y
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 0
-  m_LinkedSlots: []
---- !u!114 &8926484042661618556
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Parent: {fileID: 0}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618556}
-  m_MasterData:
-    m_Owner: {fileID: 8926484042661618552}
-    m_Value:
-      m_Type:
-        m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-          PublicKeyToken=b77a5c561934e089
-      m_SerializableObject: 0
-    m_Space: 2147483647
-  m_Property:
-    name: t
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-    attributes: []
-  m_Direction: 1
-  m_LinkedSlots:
-  - {fileID: 8926484042661618559}
 --- !u!114 &8926484042661618557
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -18067,8 +16948,7 @@ MonoBehaviour:
         PublicKeyToken=b77a5c561934e089
     attributes: []
   m_Direction: 0
-  m_LinkedSlots:
-  - {fileID: 8926484042661618556}
+  m_LinkedSlots: []
 --- !u!114 &8926484042661618563
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -18090,7 +16970,26 @@ MonoBehaviour:
   m_OutputSlots: []
   m_Disabled: 0
   mode: 1
---- !u!114 &8926484042661618564
+--- !u!114 &8926484042661618580
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 081ffb0090424ba4cb05370a42ead6b9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 0}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  opaqueRenderQueue: 0
+  transparentRenderQueue: 1
+--- !u!114 &8926484042661618582
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -18108,13 +17007,13 @@ MonoBehaviour:
   m_UICollapsed: 0
   m_UISuperCollapsed: 0
   m_InputSlots:
-  - {fileID: 8926484042661618565}
-  - {fileID: 8926484042661618574}
+  - {fileID: 8926484042661618583}
+  - {fileID: 8926484042661618592}
   m_OutputSlots: []
   m_Disabled: 0
   AutomaticMass: 1
   AutomaticSize: 1
---- !u!114 &8926484042661618565
+--- !u!114 &8926484042661618583
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -18128,20 +17027,20 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Parent: {fileID: 0}
   m_Children:
-  - {fileID: 8926484042661618566}
-  - {fileID: 8926484042661618567}
-  - {fileID: 8926484042661618568}
-  - {fileID: 8926484042661618569}
-  - {fileID: 8926484042661618570}
-  - {fileID: 8926484042661618571}
-  - {fileID: 8926484042661618572}
-  - {fileID: 8926484042661618573}
+  - {fileID: 8926484042661618584}
+  - {fileID: 8926484042661618585}
+  - {fileID: 8926484042661618586}
+  - {fileID: 8926484042661618587}
+  - {fileID: 8926484042661618588}
+  - {fileID: 8926484042661618589}
+  - {fileID: 8926484042661618590}
+  - {fileID: 8926484042661618591}
   m_UIPosition: {x: 0, y: 0}
   m_UICollapsed: 1
   m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618565}
+  m_MasterSlot: {fileID: 8926484042661618583}
   m_MasterData:
-    m_Owner: {fileID: 8926484042661618564}
+    m_Owner: {fileID: 8926484042661618582}
     m_Value:
       m_Type:
         m_SerializableType: Thinksquirrel.FluvioFX.Editor.Fluid, Thinksquirrel.FluvioFX.Editor,
@@ -18156,8 +17055,8 @@ MonoBehaviour:
     attributes: []
   m_Direction: 0
   m_LinkedSlots:
-  - {fileID: 8926484042661618468}
---- !u!114 &8926484042661618566
+  - {fileID: 8926484042661618607}
+--- !u!114 &8926484042661618584
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -18169,12 +17068,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618565}
+  m_Parent: {fileID: 8926484042661618583}
   m_Children: []
   m_UIPosition: {x: 0, y: 0}
   m_UICollapsed: 1
   m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618565}
+  m_MasterSlot: {fileID: 8926484042661618583}
   m_MasterData:
     m_Owner: {fileID: 0}
     m_Value:
@@ -18203,7 +17102,7 @@ MonoBehaviour:
       m_RegexMaxLength: 0
   m_Direction: 0
   m_LinkedSlots: []
---- !u!114 &8926484042661618567
+--- !u!114 &8926484042661618585
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -18215,12 +17114,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618565}
+  m_Parent: {fileID: 8926484042661618583}
   m_Children: []
   m_UIPosition: {x: 0, y: 0}
   m_UICollapsed: 1
   m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618565}
+  m_MasterSlot: {fileID: 8926484042661618583}
   m_MasterData:
     m_Owner: {fileID: 0}
     m_Value:
@@ -18248,7 +17147,7 @@ MonoBehaviour:
       m_RegexMaxLength: 0
   m_Direction: 0
   m_LinkedSlots: []
---- !u!114 &8926484042661618568
+--- !u!114 &8926484042661618586
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -18260,12 +17159,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618565}
+  m_Parent: {fileID: 8926484042661618583}
   m_Children: []
   m_UIPosition: {x: 0, y: 0}
   m_UICollapsed: 1
   m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618565}
+  m_MasterSlot: {fileID: 8926484042661618583}
   m_MasterData:
     m_Owner: {fileID: 0}
     m_Value:
@@ -18293,7 +17192,7 @@ MonoBehaviour:
       m_RegexMaxLength: 0
   m_Direction: 0
   m_LinkedSlots: []
---- !u!114 &8926484042661618569
+--- !u!114 &8926484042661618587
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -18305,12 +17204,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618565}
+  m_Parent: {fileID: 8926484042661618583}
   m_Children: []
   m_UIPosition: {x: 0, y: 0}
   m_UICollapsed: 1
   m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618565}
+  m_MasterSlot: {fileID: 8926484042661618583}
   m_MasterData:
     m_Owner: {fileID: 0}
     m_Value:
@@ -18339,7 +17238,7 @@ MonoBehaviour:
       m_RegexMaxLength: 0
   m_Direction: 0
   m_LinkedSlots: []
---- !u!114 &8926484042661618570
+--- !u!114 &8926484042661618588
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -18351,12 +17250,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618565}
+  m_Parent: {fileID: 8926484042661618583}
   m_Children: []
   m_UIPosition: {x: 0, y: 0}
   m_UICollapsed: 1
   m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618565}
+  m_MasterSlot: {fileID: 8926484042661618583}
   m_MasterData:
     m_Owner: {fileID: 0}
     m_Value:
@@ -18385,7 +17284,7 @@ MonoBehaviour:
       m_RegexMaxLength: 0
   m_Direction: 0
   m_LinkedSlots: []
---- !u!114 &8926484042661618571
+--- !u!114 &8926484042661618589
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -18397,12 +17296,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618565}
+  m_Parent: {fileID: 8926484042661618583}
   m_Children: []
   m_UIPosition: {x: 0, y: 0}
   m_UICollapsed: 1
   m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618565}
+  m_MasterSlot: {fileID: 8926484042661618583}
   m_MasterData:
     m_Owner: {fileID: 0}
     m_Value:
@@ -18430,7 +17329,7 @@ MonoBehaviour:
       m_RegexMaxLength: 0
   m_Direction: 0
   m_LinkedSlots: []
---- !u!114 &8926484042661618572
+--- !u!114 &8926484042661618590
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -18442,12 +17341,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618565}
+  m_Parent: {fileID: 8926484042661618583}
   m_Children: []
   m_UIPosition: {x: 0, y: 0}
   m_UICollapsed: 1
   m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618565}
+  m_MasterSlot: {fileID: 8926484042661618583}
   m_MasterData:
     m_Owner: {fileID: 0}
     m_Value:
@@ -18477,7 +17376,7 @@ MonoBehaviour:
       m_RegexMaxLength: 0
   m_Direction: 0
   m_LinkedSlots: []
---- !u!114 &8926484042661618573
+--- !u!114 &8926484042661618591
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -18489,12 +17388,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618565}
+  m_Parent: {fileID: 8926484042661618583}
   m_Children: []
   m_UIPosition: {x: 0, y: 0}
   m_UICollapsed: 1
   m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618565}
+  m_MasterSlot: {fileID: 8926484042661618583}
   m_MasterData:
     m_Owner: {fileID: 0}
     m_Value:
@@ -18519,7 +17418,7 @@ MonoBehaviour:
       m_RegexMaxLength: 0
   m_Direction: 0
   m_LinkedSlots: []
---- !u!114 &8926484042661618574
+--- !u!114 &8926484042661618592
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -18533,19 +17432,19 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Parent: {fileID: 0}
   m_Children:
-  - {fileID: 8926484042661618575}
+  - {fileID: 8926484042661618593}
   m_UIPosition: {x: 0, y: 0}
   m_UICollapsed: 1
   m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618574}
+  m_MasterSlot: {fileID: 8926484042661618592}
   m_MasterData:
-    m_Owner: {fileID: 8926484042661618564}
+    m_Owner: {fileID: 8926484042661618582}
     m_Value:
       m_Type:
         m_SerializableType: UnityEditor.VFX.Vector, Unity.VisualEffectGraph.Editor,
           Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
       m_SerializableObject: '{"vector":{"x":0.0,"y":0.0,"z":0.0}}'
-    m_Space: 0
+    m_Space: 1
   m_Property:
     name: Gravity
     m_serializedType:
@@ -18555,7 +17454,7 @@ MonoBehaviour:
   m_Direction: 0
   m_LinkedSlots:
   - {fileID: 8926484042661618446}
---- !u!114 &8926484042661618575
+--- !u!114 &8926484042661618593
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -18567,15 +17466,15 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ac39bd03fca81b849929b9c966f1836a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618574}
+  m_Parent: {fileID: 8926484042661618592}
   m_Children:
-  - {fileID: 8926484042661618576}
-  - {fileID: 8926484042661618577}
-  - {fileID: 8926484042661618578}
+  - {fileID: 8926484042661618594}
+  - {fileID: 8926484042661618595}
+  - {fileID: 8926484042661618596}
   m_UIPosition: {x: 0, y: 0}
   m_UICollapsed: 1
   m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618574}
+  m_MasterSlot: {fileID: 8926484042661618592}
   m_MasterData:
     m_Owner: {fileID: 0}
     m_Value:
@@ -18597,7 +17496,7 @@ MonoBehaviour:
       m_RegexMaxLength: 0
   m_Direction: 0
   m_LinkedSlots: []
---- !u!114 &8926484042661618576
+--- !u!114 &8926484042661618594
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -18609,12 +17508,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618575}
+  m_Parent: {fileID: 8926484042661618593}
   m_Children: []
   m_UIPosition: {x: 0, y: 0}
   m_UICollapsed: 1
   m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618574}
+  m_MasterSlot: {fileID: 8926484042661618592}
   m_MasterData:
     m_Owner: {fileID: 0}
     m_Value:
@@ -18630,7 +17529,7 @@ MonoBehaviour:
     attributes: []
   m_Direction: 0
   m_LinkedSlots: []
---- !u!114 &8926484042661618577
+--- !u!114 &8926484042661618595
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -18642,12 +17541,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618575}
+  m_Parent: {fileID: 8926484042661618593}
   m_Children: []
   m_UIPosition: {x: 0, y: 0}
   m_UICollapsed: 1
   m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618574}
+  m_MasterSlot: {fileID: 8926484042661618592}
   m_MasterData:
     m_Owner: {fileID: 0}
     m_Value:
@@ -18663,7 +17562,7 @@ MonoBehaviour:
     attributes: []
   m_Direction: 0
   m_LinkedSlots: []
---- !u!114 &8926484042661618578
+--- !u!114 &8926484042661618596
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -18675,12 +17574,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Parent: {fileID: 8926484042661618575}
+  m_Parent: {fileID: 8926484042661618593}
   m_Children: []
   m_UIPosition: {x: 0, y: 0}
   m_UICollapsed: 1
   m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661618574}
+  m_MasterSlot: {fileID: 8926484042661618592}
   m_MasterData:
     m_Owner: {fileID: 0}
     m_Value:
@@ -18696,3 +17595,960 @@ MonoBehaviour:
     attributes: []
   m_Direction: 0
   m_LinkedSlots: []
+--- !u!114 &8926484042661618597
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 955b0c175a6f3bb4582e92f3de8f0626, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 114350483966674976}
+  m_Children: []
+  m_UIPosition: {x: 1007, y: 31}
+  m_UICollapsed: 0
+  m_UISuperCollapsed: 0
+  m_InputSlots:
+  - {fileID: 8926484042661618598}
+  m_OutputSlots:
+  - {fileID: 8926484042661618607}
+  m_Type:
+    m_SerializableType: Thinksquirrel.FluvioFX.Editor.Fluid, Thinksquirrel.FluvioFX.Editor,
+      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+--- !u!114 &8926484042661618598
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1b605c022ee79394a8a776c0869b3f9a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 0}
+  m_Children:
+  - {fileID: 8926484042661618599}
+  - {fileID: 8926484042661618600}
+  - {fileID: 8926484042661618601}
+  - {fileID: 8926484042661618602}
+  - {fileID: 8926484042661618603}
+  - {fileID: 8926484042661618604}
+  - {fileID: 8926484042661618605}
+  - {fileID: 8926484042661618606}
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 0
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618598}
+  m_MasterData:
+    m_Owner: {fileID: 8926484042661618597}
+    m_Value:
+      m_Type:
+        m_SerializableType: Thinksquirrel.FluvioFX.Editor.Fluid, Thinksquirrel.FluvioFX.Editor,
+          Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+      m_SerializableObject: '{"SmoothingDistance":0.19062499701976777,"ParticleMass":7.241438865661621,"Density":998.2899780273438,"MinimumDensity":9.98289966583252,"GasConstant":0.009999999776482582,"Viscosity":0.029999999329447748,"SurfaceTension":0.7279999852180481,"BuoyancyCoefficient":0.0}'
+    m_Space: 2147483647
+  m_Property:
+    name: 
+    m_serializedType:
+      m_SerializableType: Thinksquirrel.FluvioFX.Editor.Fluid, Thinksquirrel.FluvioFX.Editor,
+        Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+    attributes: []
+  m_Direction: 0
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618599
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618598}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618598}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: SmoothingDistance
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes:
+    - m_Type: 1
+      m_Min: 9.9999994e-11
+      m_Max: Infinity
+      m_Tooltip: 
+      m_Regex: 
+      m_RegexMaxLength: 0
+    - m_Type: 3
+      m_Min: -Infinity
+      m_Max: Infinity
+      m_Tooltip: Controls the smoothing distance of fluid particles. This changes
+        the overall simulation resolution and greatly affects all other properties.
+      m_Regex: 
+      m_RegexMaxLength: 0
+  m_Direction: 0
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618600
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618598}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618598}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: ParticleMass
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes:
+    - m_Type: 1
+      m_Min: 9.9999994e-11
+      m_Max: Infinity
+      m_Tooltip: 
+      m_Regex: 
+      m_RegexMaxLength: 0
+    - m_Type: 3
+      m_Min: -Infinity
+      m_Max: Infinity
+      m_Tooltip: Controls the mass of each fluid particle.
+      m_Regex: 
+      m_RegexMaxLength: 0
+  m_Direction: 0
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618601
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618598}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618598}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: Density
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes:
+    - m_Type: 1
+      m_Min: 9.9999994e-11
+      m_Max: Infinity
+      m_Tooltip: 
+      m_Regex: 
+      m_RegexMaxLength: 0
+    - m_Type: 3
+      m_Min: -Infinity
+      m_Max: Infinity
+      m_Tooltip: Controls the overall density of the fluid.
+      m_Regex: 
+      m_RegexMaxLength: 0
+  m_Direction: 0
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618602
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618598}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618598}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: MinimumDensity
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes:
+    - m_Type: 1
+      m_Min: 9.9999994e-11
+      m_Max: Infinity
+      m_Tooltip: 
+      m_Regex: 
+      m_RegexMaxLength: 0
+    - m_Type: 3
+      m_Min: -Infinity
+      m_Max: Infinity
+      m_Tooltip: Controls the minimum density of any fluid particle. This can be used
+        to help stabilize a low-viscosity fluid.
+      m_Regex: 
+      m_RegexMaxLength: 0
+  m_Direction: 0
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618603
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618598}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618598}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: GasConstant
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes:
+    - m_Type: 1
+      m_Min: 9.9999994e-11
+      m_Max: Infinity
+      m_Tooltip: 
+      m_Regex: 
+      m_RegexMaxLength: 0
+    - m_Type: 3
+      m_Min: -Infinity
+      m_Max: Infinity
+      m_Tooltip: Controls the gas constant of the fluid, which in turn affects the
+        pressure forces applied to particles.
+      m_Regex: 
+      m_RegexMaxLength: 0
+  m_Direction: 0
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618604
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618598}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618598}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: Viscosity
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes:
+    - m_Type: 1
+      m_Min: 9.9999994e-11
+      m_Max: Infinity
+      m_Tooltip: 
+      m_Regex: 
+      m_RegexMaxLength: 0
+    - m_Type: 3
+      m_Min: -Infinity
+      m_Max: Infinity
+      m_Tooltip: Controls the artificial viscosity force of the fluid.
+      m_Regex: 
+      m_RegexMaxLength: 0
+  m_Direction: 0
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618605
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618598}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618598}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: SurfaceTension
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes:
+    - m_Type: 1
+      m_Min: 0
+      m_Max: Infinity
+      m_Tooltip: 
+      m_Regex: 
+      m_RegexMaxLength: 0
+    - m_Type: 3
+      m_Min: -Infinity
+      m_Max: Infinity
+      m_Tooltip: Controls the surface tension of the fluid (intended for liquids only).
+        FluvioFX uses a simplified surface tension model that is ideal for realtime
+        use.
+      m_Regex: 
+      m_RegexMaxLength: 0
+  m_Direction: 0
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618606
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618598}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618598}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: BuoyancyCoefficient
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes:
+    - m_Type: 3
+      m_Min: -Infinity
+      m_Max: Infinity
+      m_Tooltip: Controls the buoyancy coefficient of a fluid. This controls the buoyancy
+        force, which is a density-dependent force in the opposite direction of gravity.
+        This should be used when simulating gas like smoke or fire, or fluids that
+        are less dense than the surrounding material.
+      m_Regex: 
+      m_RegexMaxLength: 0
+  m_Direction: 0
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618607
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1b605c022ee79394a8a776c0869b3f9a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 0}
+  m_Children:
+  - {fileID: 8926484042661618608}
+  - {fileID: 8926484042661618609}
+  - {fileID: 8926484042661618610}
+  - {fileID: 8926484042661618611}
+  - {fileID: 8926484042661618612}
+  - {fileID: 8926484042661618613}
+  - {fileID: 8926484042661618614}
+  - {fileID: 8926484042661618615}
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618607}
+  m_MasterData:
+    m_Owner: {fileID: 8926484042661618597}
+    m_Value:
+      m_Type:
+        m_SerializableType: Thinksquirrel.FluvioFX.Editor.Fluid, Thinksquirrel.FluvioFX.Editor,
+          Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+      m_SerializableObject: '{"SmoothingDistance":0.19062499701976777,"ParticleMass":7.241438865661621,"Density":998.2899780273438,"MinimumDensity":9.98289966583252,"GasConstant":0.009999999776482582,"Viscosity":0.029999999329447748,"SurfaceTension":0.7279999852180481,"BuoyancyCoefficient":0.0}'
+    m_Space: 2147483647
+  m_Property:
+    name: 
+    m_serializedType:
+      m_SerializableType: Thinksquirrel.FluvioFX.Editor.Fluid, Thinksquirrel.FluvioFX.Editor,
+        Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+    attributes: []
+  m_Direction: 1
+  m_LinkedSlots:
+  - {fileID: 8926484042661618583}
+--- !u!114 &8926484042661618608
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618607}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618607}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: SmoothingDistance
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes:
+    - m_Type: 1
+      m_Min: 9.9999994e-11
+      m_Max: Infinity
+      m_Tooltip: 
+      m_Regex: 
+      m_RegexMaxLength: 0
+    - m_Type: 3
+      m_Min: -Infinity
+      m_Max: Infinity
+      m_Tooltip: Controls the smoothing distance of fluid particles. This changes
+        the overall simulation resolution and greatly affects all other properties.
+      m_Regex: 
+      m_RegexMaxLength: 0
+  m_Direction: 1
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618609
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618607}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618607}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: ParticleMass
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes:
+    - m_Type: 1
+      m_Min: 9.9999994e-11
+      m_Max: Infinity
+      m_Tooltip: 
+      m_Regex: 
+      m_RegexMaxLength: 0
+    - m_Type: 3
+      m_Min: -Infinity
+      m_Max: Infinity
+      m_Tooltip: Controls the mass of each fluid particle.
+      m_Regex: 
+      m_RegexMaxLength: 0
+  m_Direction: 1
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618610
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618607}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618607}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: Density
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes:
+    - m_Type: 1
+      m_Min: 9.9999994e-11
+      m_Max: Infinity
+      m_Tooltip: 
+      m_Regex: 
+      m_RegexMaxLength: 0
+    - m_Type: 3
+      m_Min: -Infinity
+      m_Max: Infinity
+      m_Tooltip: Controls the overall density of the fluid.
+      m_Regex: 
+      m_RegexMaxLength: 0
+  m_Direction: 1
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618611
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618607}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618607}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: MinimumDensity
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes:
+    - m_Type: 1
+      m_Min: 9.9999994e-11
+      m_Max: Infinity
+      m_Tooltip: 
+      m_Regex: 
+      m_RegexMaxLength: 0
+    - m_Type: 3
+      m_Min: -Infinity
+      m_Max: Infinity
+      m_Tooltip: Controls the minimum density of any fluid particle. This can be used
+        to help stabilize a low-viscosity fluid.
+      m_Regex: 
+      m_RegexMaxLength: 0
+  m_Direction: 1
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618612
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618607}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618607}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: GasConstant
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes:
+    - m_Type: 1
+      m_Min: 9.9999994e-11
+      m_Max: Infinity
+      m_Tooltip: 
+      m_Regex: 
+      m_RegexMaxLength: 0
+    - m_Type: 3
+      m_Min: -Infinity
+      m_Max: Infinity
+      m_Tooltip: Controls the gas constant of the fluid, which in turn affects the
+        pressure forces applied to particles.
+      m_Regex: 
+      m_RegexMaxLength: 0
+  m_Direction: 1
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618613
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618607}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618607}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: Viscosity
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes:
+    - m_Type: 1
+      m_Min: 9.9999994e-11
+      m_Max: Infinity
+      m_Tooltip: 
+      m_Regex: 
+      m_RegexMaxLength: 0
+    - m_Type: 3
+      m_Min: -Infinity
+      m_Max: Infinity
+      m_Tooltip: Controls the artificial viscosity force of the fluid.
+      m_Regex: 
+      m_RegexMaxLength: 0
+  m_Direction: 1
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618614
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618607}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618607}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: SurfaceTension
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes:
+    - m_Type: 1
+      m_Min: 0
+      m_Max: Infinity
+      m_Tooltip: 
+      m_Regex: 
+      m_RegexMaxLength: 0
+    - m_Type: 3
+      m_Min: -Infinity
+      m_Max: Infinity
+      m_Tooltip: Controls the surface tension of the fluid (intended for liquids only).
+        FluvioFX uses a simplified surface tension model that is ideal for realtime
+        use.
+      m_Regex: 
+      m_RegexMaxLength: 0
+  m_Direction: 1
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618615
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618607}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 1
+  m_UISuperCollapsed: 0
+  m_MasterSlot: {fileID: 8926484042661618607}
+  m_MasterData:
+    m_Owner: {fileID: 0}
+    m_Value:
+      m_Type:
+        m_SerializableType: 
+      m_SerializableObject: 
+    m_Space: 2147483647
+  m_Property:
+    name: BuoyancyCoefficient
+    m_serializedType:
+      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
+        PublicKeyToken=b77a5c561934e089
+    attributes:
+    - m_Type: 3
+      m_Min: -Infinity
+      m_Max: Infinity
+      m_Tooltip: Controls the buoyancy coefficient of a fluid. This controls the buoyancy
+        force, which is a density-dependent force in the opposite direction of gravity.
+        This should be used when simulating gas like smoke or fire, or fluids that
+        are less dense than the surrounding material.
+      m_Regex: 
+      m_RegexMaxLength: 0
+  m_Direction: 1
+  m_LinkedSlots: []
+--- !u!114 &8926484042661618642
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b24fedd9240514791a200cf1d9ad7673, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618162}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 0
+  m_UISuperCollapsed: 0
+  m_InputSlots: []
+  m_OutputSlots: []
+  m_Disabled: 0
+--- !u!114 &8926484042661618643
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 47c40ab96b798458780dd052ee1994d6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618165}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 0
+  m_UISuperCollapsed: 0
+  m_InputSlots: []
+  m_OutputSlots: []
+  m_Disabled: 0
+--- !u!114 &8926484042661618644
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bc09ccf3ed7bc4caeabb87acbc42bc10, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618168}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 0
+  m_UISuperCollapsed: 0
+  m_InputSlots: []
+  m_OutputSlots: []
+  m_Disabled: 0
+--- !u!114 &8926484042661618645
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7f1a69e398cef41a69d4e71a3283432b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618171}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 0
+  m_UISuperCollapsed: 0
+  m_InputSlots: []
+  m_OutputSlots: []
+  m_Disabled: 0
+--- !u!114 &8926484042661618646
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7cc173ad5f0fb406ba27fcb79ad9ec13, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618453}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 0
+  m_UISuperCollapsed: 0
+  m_InputSlots: []
+  m_OutputSlots: []
+  m_Disabled: 0
+  SurfaceTension: 1
+  Gravity: 1
+  BuoyancyForce: 1
+--- !u!114 &8926484042661618647
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: af49bc557521a417ab5daee69476f797, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Parent: {fileID: 8926484042661618177}
+  m_Children: []
+  m_UIPosition: {x: 0, y: 0}
+  m_UICollapsed: 0
+  m_UISuperCollapsed: 0
+  m_InputSlots: []
+  m_OutputSlots: []
+  m_Disabled: 0
+  IntegrationMode: 0

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # FluvioFX
 
-Copyright 2018 Thinksquirrel Inc.
+Copyright 2019 Lily Montoute
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/README.md
+++ b/README.md
@@ -8,12 +8,8 @@ FluvioFX is currently in early active development. While we will try to maintain
 
 ## Requirements
 
-- Unity 2018.3 or newer
-- HDRP (or LWRP with Unity 2019.1 or newer)
-- Unity 2018.3+ only:
-    - Visual Effect Graph 4.9.0-preview or newer
-- Unity 2019.1+ only:
-    - Visual Effect Graph 5.2.0-preview or newer
+- Unity 2019.2 or newer
+- Visual Effect Graph 6.9.1 or newer
 
 ## Installation
 


### PR DESCRIPTION
This adds support and bumps the minimum Unity version to 2019.2, with a minimum VFX graph version of 6.9.1.

Also includes a copyright assignment change.